### PR TITLE
Plugins, GRPC Integration, and Improvements

### DIFF
--- a/Editors/BackgroundEditor.cpp
+++ b/Editors/BackgroundEditor.cpp
@@ -14,8 +14,8 @@
 
 using buffers::resources::Background;
 
-BackgroundEditor::BackgroundEditor(QWidget* parent, ProtoModel* model)
-    : BaseEditor(parent, model), ui(new Ui::BackgroundEditor) {
+BackgroundEditor::BackgroundEditor(ProtoModel* model, QWidget* parent)
+    : BaseEditor(model, parent), ui(new Ui::BackgroundEditor) {
   ui->setupUi(this);
 
   ui->backgroundRenderer->SetResourceModel(model);

--- a/Editors/BackgroundEditor.h
+++ b/Editors/BackgroundEditor.h
@@ -13,7 +13,7 @@ class BackgroundEditor : public BaseEditor {
   Q_OBJECT
 
  public:
-  explicit BackgroundEditor(QWidget *parent, ProtoModel *model);
+  explicit BackgroundEditor(ProtoModel *model, QWidget *parent);
   ~BackgroundEditor();
 
  private slots:

--- a/Editors/BaseEditor.cpp
+++ b/Editors/BaseEditor.cpp
@@ -25,6 +25,7 @@ void BaseEditor::closeEvent(QCloseEvent* event) {
     }
   }
 
+  model->SetDirty(false);
   event->accept();
 }
 

--- a/Editors/BaseEditor.cpp
+++ b/Editors/BaseEditor.cpp
@@ -3,7 +3,7 @@
 #include <QCloseEvent>
 #include <QMessageBox>
 
-BaseEditor::BaseEditor(QWidget* parent, ProtoModel* model)
+BaseEditor::BaseEditor(ProtoModel* model, QWidget* parent)
     : QWidget(parent), model(model), mapper(new ImmediateDataWidgetMapper(this)) {
   mapper->setOrientation(Qt::Vertical);
   mapper->setModel(model);

--- a/Editors/BaseEditor.cpp
+++ b/Editors/BaseEditor.cpp
@@ -6,8 +6,8 @@
 BaseEditor::BaseEditor(QWidget* parent, ProtoModel* model)
     : QWidget(parent), model(model), mapper(new ImmediateDataWidgetMapper(this)) {
   mapper->setOrientation(Qt::Vertical);
-  connect(model, &ProtoModel::dataChanged, this, &BaseEditor::dataChanged);
   mapper->setModel(model);
+  connect(model, &ProtoModel::dataChanged, this, &BaseEditor::dataChanged);
 }
 
 void BaseEditor::closeEvent(QCloseEvent* event) {
@@ -19,8 +19,10 @@ void BaseEditor::closeEvent(QCloseEvent* event) {
     if (reply == QMessageBox::Cancel) {
       event->ignore();
       return;
-    } else if (reply == QMessageBox::No)
+    } else if (reply == QMessageBox::No) {
+      mapper->clearMapping();
       model->RestoreBuffer();
+    }
   }
 
   event->accept();

--- a/Editors/BaseEditor.h
+++ b/Editors/BaseEditor.h
@@ -12,7 +12,7 @@ class BaseEditor : public QWidget {
   Q_OBJECT
 
  public:
-  explicit BaseEditor(QWidget *parent, ProtoModel *model);
+  explicit BaseEditor(ProtoModel *model, QWidget *parent);
 
   virtual void closeEvent(QCloseEvent *event);
   void ReplaceBuffer(google::protobuf::Message *buffer);

--- a/Editors/FontEditor.cpp
+++ b/Editors/FontEditor.cpp
@@ -2,7 +2,7 @@
 
 #include "ui_FontEditor.h"
 
-FontEditor::FontEditor(QWidget* parent, ProtoModel* model) : BaseEditor(parent, model), ui(new Ui::FontEditor) {
+FontEditor::FontEditor(ProtoModel* model, QWidget* parent) : BaseEditor(model, parent), ui(new Ui::FontEditor) {
   ui->setupUi(this);
 }
 

--- a/Editors/FontEditor.h
+++ b/Editors/FontEditor.h
@@ -11,11 +11,11 @@ class FontEditor : public BaseEditor {
   Q_OBJECT
 
  public:
-  explicit FontEditor(QWidget *parent, ProtoModel *model);
+  explicit FontEditor(ProtoModel* model, QWidget* parent);
   ~FontEditor();
 
  private:
-  Ui::FontEditor *ui;
+  Ui::FontEditor* ui;
 };
 
 #endif  // FONTEDITOR_H

--- a/Editors/ObjectEditor.cpp
+++ b/Editors/ObjectEditor.cpp
@@ -2,8 +2,7 @@
 
 #include "ui_ObjectEditor.h"
 
-ObjectEditor::ObjectEditor(QWidget* parent, ProtoModel* model)
-    : BaseEditor(parent, model), ui(new Ui::ObjectEditor) {
+ObjectEditor::ObjectEditor(ProtoModel* model, QWidget* parent) : BaseEditor(model, parent), ui(new Ui::ObjectEditor) {
   ui->setupUi(this);
 }
 

--- a/Editors/ObjectEditor.h
+++ b/Editors/ObjectEditor.h
@@ -11,11 +11,11 @@ class ObjectEditor : public BaseEditor {
   Q_OBJECT
 
  public:
-  explicit ObjectEditor(QWidget *parent, ProtoModel *model);
+  explicit ObjectEditor(ProtoModel* model, QWidget* parent);
   ~ObjectEditor();
 
  private:
-  Ui::ObjectEditor *ui;
+  Ui::ObjectEditor* ui;
 };
 
 #endif  // OBJECTEDITOR_H

--- a/Editors/PathEditor.cpp
+++ b/Editors/PathEditor.cpp
@@ -2,7 +2,7 @@
 
 #include "ui_PathEditor.h"
 
-PathEditor::PathEditor(QWidget* parent, ProtoModel* model) : BaseEditor(parent, model), ui(new Ui::PathEditor) {
+PathEditor::PathEditor(ProtoModel* model, QWidget* parent) : BaseEditor(model, parent), ui(new Ui::PathEditor) {
   ui->setupUi(this);
 }
 

--- a/Editors/PathEditor.h
+++ b/Editors/PathEditor.h
@@ -11,11 +11,11 @@ class PathEditor : public BaseEditor {
   Q_OBJECT
 
  public:
-  explicit PathEditor(QWidget *parent, ProtoModel *model);
+  explicit PathEditor(ProtoModel* model, QWidget* parent);
   ~PathEditor();
 
  private:
-  Ui::PathEditor *ui;
+  Ui::PathEditor* ui;
 };
 
 #endif  // PATHEDITOR_H

--- a/Editors/RoomEditor.cpp
+++ b/Editors/RoomEditor.cpp
@@ -5,7 +5,7 @@
 #include <Qsci/qsciscintilla.h>
 #include <QFontMetrics>
 
-RoomEditor::RoomEditor(QWidget* parent, ProtoModel* model) : BaseEditor(parent, model), ui(new Ui::RoomEditor) {
+RoomEditor::RoomEditor(ProtoModel* model, QWidget* parent) : BaseEditor(model, parent), ui(new Ui::RoomEditor) {
   ui->setupUi(this);
 
   QsciScintilla* textEdit = new QsciScintilla(this);

--- a/Editors/RoomEditor.cpp
+++ b/Editors/RoomEditor.cpp
@@ -1,27 +1,39 @@
 #include "RoomEditor.h"
 #include "ui_RoomEditor.h"
 
+#include <QFontMetrics>
+
+#ifndef RGM_DISABLE_SYNTAXHIGHLIGHTING
 #include <Qsci/qscilexercpp.h>
 #include <Qsci/qsciscintilla.h>
-#include <QFontMetrics>
+#else
+#include <QPlainTextEdit>
+#endif
 
 RoomEditor::RoomEditor(ProtoModel* model, QWidget* parent) : BaseEditor(model, parent), ui(new Ui::RoomEditor) {
   ui->setupUi(this);
 
+  QFont font("Courier", 10);
+  QFontMetrics fontMetrics(font);
+
+#ifndef RGM_DISABLE_SYNTAXHIGHLIGHTING
   QsciScintilla* textEdit = new QsciScintilla(this);
 
   textEdit->setCaretLineVisible(true);
   textEdit->setCaretLineBackgroundColor(QColor("#ffe4e4"));
 
   textEdit->setMarginLineNumbers(0, true);
-  QFont font("Courier", 10);
-  QFontMetrics fontMetrics(font);
   textEdit->setMarginWidth(0, fontMetrics.width("000"));
   textEdit->setMarginsFont(font);
   QsciLexerCPP* lexer = new QsciLexerCPP();
   lexer->setDefaultFont(font);
   textEdit->setLexer(lexer);
   this->layout()->addWidget(textEdit);
+#else
+  QPlainTextEdit* plainTextEdit = new QPlainTextEdit(this);
+  plainTextEdit->setFont(font);
+  this->layout()->addWidget(plainTextEdit);
+#endif
 }
 
 RoomEditor::~RoomEditor() { delete ui; }

--- a/Editors/RoomEditor.cpp
+++ b/Editors/RoomEditor.cpp
@@ -1,39 +1,8 @@
 #include "RoomEditor.h"
 #include "ui_RoomEditor.h"
 
-#include <QFontMetrics>
-
-#ifndef RGM_DISABLE_SYNTAXHIGHLIGHTING
-#include <Qsci/qscilexercpp.h>
-#include <Qsci/qsciscintilla.h>
-#else
-#include <QPlainTextEdit>
-#endif
-
 RoomEditor::RoomEditor(ProtoModel* model, QWidget* parent) : BaseEditor(model, parent), ui(new Ui::RoomEditor) {
   ui->setupUi(this);
-
-  QFont font("Courier", 10);
-  QFontMetrics fontMetrics(font);
-
-#ifndef RGM_DISABLE_SYNTAXHIGHLIGHTING
-  QsciScintilla* textEdit = new QsciScintilla(this);
-
-  textEdit->setCaretLineVisible(true);
-  textEdit->setCaretLineBackgroundColor(QColor("#ffe4e4"));
-
-  textEdit->setMarginLineNumbers(0, true);
-  textEdit->setMarginWidth(0, fontMetrics.width("000"));
-  textEdit->setMarginsFont(font);
-  QsciLexerCPP* lexer = new QsciLexerCPP();
-  lexer->setDefaultFont(font);
-  textEdit->setLexer(lexer);
-  this->layout()->addWidget(textEdit);
-#else
-  QPlainTextEdit* plainTextEdit = new QPlainTextEdit(this);
-  plainTextEdit->setFont(font);
-  this->layout()->addWidget(plainTextEdit);
-#endif
 }
 
 RoomEditor::~RoomEditor() { delete ui; }

--- a/Editors/RoomEditor.cpp
+++ b/Editors/RoomEditor.cpp
@@ -7,7 +7,8 @@
 
 RoomEditor::RoomEditor(QWidget* parent, ProtoModel* model) : BaseEditor(parent, model), ui(new Ui::RoomEditor) {
   ui->setupUi(this);
-  QsciScintilla* textEdit = new QsciScintilla;
+
+  QsciScintilla* textEdit = new QsciScintilla(this);
 
   textEdit->setCaretLineVisible(true);
   textEdit->setCaretLineBackgroundColor(QColor("#ffe4e4"));

--- a/Editors/RoomEditor.h
+++ b/Editors/RoomEditor.h
@@ -11,11 +11,11 @@ class RoomEditor : public BaseEditor {
   Q_OBJECT
 
  public:
-  explicit RoomEditor(QWidget *parent, ProtoModel *model);
+  explicit RoomEditor(ProtoModel* model, QWidget* parent);
   ~RoomEditor();
 
  private:
-  Ui::RoomEditor *ui;
+  Ui::RoomEditor* ui;
 };
 
 #endif  // ROOMEDITOR_H

--- a/Editors/SpriteEditor.cpp
+++ b/Editors/SpriteEditor.cpp
@@ -2,8 +2,7 @@
 
 #include "ui_SpriteEditor.h"
 
-SpriteEditor::SpriteEditor(QWidget* parent, ProtoModel* model)
-    : BaseEditor(parent, model), ui(new Ui::SpriteEditor) {
+SpriteEditor::SpriteEditor(ProtoModel* model, QWidget* parent) : BaseEditor(model, parent), ui(new Ui::SpriteEditor) {
   ui->setupUi(this);
 }
 

--- a/Editors/SpriteEditor.h
+++ b/Editors/SpriteEditor.h
@@ -11,11 +11,11 @@ class SpriteEditor : public BaseEditor {
   Q_OBJECT
 
  public:
-  explicit SpriteEditor(QWidget *parent, ProtoModel *model);
+  explicit SpriteEditor(ProtoModel* model, QWidget* parent);
   ~SpriteEditor();
 
  private:
-  Ui::SpriteEditor *ui;
+  Ui::SpriteEditor* ui;
 };
 
 #endif  // SPRITEEDITOR_H

--- a/Editors/TimelineEditor.cpp
+++ b/Editors/TimelineEditor.cpp
@@ -2,8 +2,8 @@
 
 #include "ui_TimelineEditor.h"
 
-TimelineEditor::TimelineEditor(QWidget* parent, ProtoModel* model)
-    : BaseEditor(parent, model), ui(new Ui::TimelineEditor) {
+TimelineEditor::TimelineEditor(ProtoModel* model, QWidget* parent)
+    : BaseEditor(model, parent), ui(new Ui::TimelineEditor) {
   ui->setupUi(this);
 }
 

--- a/Editors/TimelineEditor.h
+++ b/Editors/TimelineEditor.h
@@ -11,11 +11,11 @@ class TimelineEditor : public BaseEditor {
   Q_OBJECT
 
  public:
-  explicit TimelineEditor(QWidget *parent, ProtoModel *model);
+  explicit TimelineEditor(ProtoModel* model, QWidget* parent);
   ~TimelineEditor();
 
  private:
-  Ui::TimelineEditor *ui;
+  Ui::TimelineEditor* ui;
 };
 
 #endif  // TIMELINEEDITOR_H

--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -13,6 +13,9 @@
 
 #include "Components/ArtManager.h"
 
+#include "Plugins/PluginServer.h"
+#include "Plugins/RGMPlugin.h"
+
 #include "gmx.h"
 
 #include "resources/Background.pb.h"
@@ -35,11 +38,15 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWi
   ui->setupUi(this);
 
   ui->mdiArea->setBackground(QImage(":/banner.png"));
+
+  RGMPlugin *pluginServer = new PluginServer(*this);
+  auto outputTextBrowser = this->ui->outputTextBrowser;
+  connect(pluginServer, &RGMPlugin::OutputRead, outputTextBrowser, &QTextBrowser::append);
+  connect(pluginServer, &RGMPlugin::ErrorRead, outputTextBrowser, &QTextBrowser::append);
+  connect(ui->actionRun, &QAction::triggered, pluginServer, &RGMPlugin::Run);
+  connect(ui->actionDebug, &QAction::triggered, pluginServer, &RGMPlugin::Debug);
+  connect(ui->actionCreateExecutable, &QAction::triggered, pluginServer, &RGMPlugin::CreateExecutable);
 }
-
-void MainWindow::HandleOutput(QString output) { this->ui->outputTextBrowser->append(output); }
-
-void MainWindow::HandleError(QString error) { this->ui->outputTextBrowser->append(error); }
 
 void MainWindow::closeEvent(QCloseEvent *event) { event->accept(); }
 
@@ -119,8 +126,8 @@ void MainWindow::openFile(QString fName) {
 }
 
 void MainWindow::on_actionOpen_triggered() {
-  const QString fileName = QFileDialog::getOpenFileName(this, tr("Open Project"), "",
-                                                        tr("GameMaker: Studio (*.project.gmx);;All Files (*)"));
+  const QString &fileName = QFileDialog::getOpenFileName(this, tr("Open Project"), "",
+                                                         tr("GameMaker: Studio (*.project.gmx);;All Files (*)"));
   if (!fileName.isEmpty()) openFile(fileName);
 }
 

--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -13,8 +13,8 @@
 
 #include "Components/ArtManager.h"
 
-#include "Plugins/PluginServer.h"
 #include "Plugins/RGMPlugin.h"
+#include "Plugins/ServerPlugin.h"
 
 #include "gmx.h"
 
@@ -39,7 +39,7 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWi
 
   ui->mdiArea->setBackground(QImage(":/banner.png"));
 
-  RGMPlugin *pluginServer = new PluginServer(*this);
+  RGMPlugin *pluginServer = new ServerPlugin(*this);
   auto outputTextBrowser = this->ui->outputTextBrowser;
   connect(pluginServer, &RGMPlugin::OutputRead, outputTextBrowser, &QTextBrowser::append);
   connect(pluginServer, &RGMPlugin::ErrorRead, outputTextBrowser, &QTextBrowser::append);

--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -52,7 +52,7 @@ MainWindow::~MainWindow() { delete ui; }
 void MainWindow::closeEvent(QCloseEvent *event) { event->accept(); }
 
 template <typename T>
-T *EditorFactory(ProtoModel *model, QWidget *parent = nullptr) {
+T *EditorFactory(ProtoModel *model, QWidget *parent) {
   return new T(model, parent);
 }
 
@@ -85,7 +85,7 @@ void MainWindow::openSubWindow(buffers::TreeNode *item) {
     auto factoryFunction = factoryMap.find(item->type_case());
     if (factoryFunction == factoryMap.end()) return;  // no registered editor
 
-    if (!resourceModels.contains(item)) resourceModels[item] = new ProtoModel(typeMessage);
+    if (!resourceModels.contains(item)) resourceModels[item] = new ProtoModel(typeMessage, nullptr);
     auto resourceModel = resourceModels[item];
 
     QWidget *editor = factoryFunction->second(resourceModel, nullptr);

--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -23,23 +23,36 @@
 
 #undef GetMessage
 
+#include <QDebug>
+
 MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWindow) {
   ArtManager::Init();
 
-  QString program = "./Submodules/enigma-dev/emake";
+  process = new QProcess(this);
+  connect(process, SIGNAL(readyReadStandardOutput()), this, SLOT(HandleOutput()));
+  connect(process, SIGNAL(readyReadStandardError()), this, SLOT(HandleOutput()));
+  process->setWorkingDirectory("../RadialGM/Submodules/enigma-dev");
+
+  QString program = "emake";
   QStringList arguments;
   arguments << "--server"
             << "--quiet";
-  QProcess *myProcess = new QProcess(this);
-  myProcess->start(program, arguments);
-
-  ui->setupUi(this);
+  process->start(program, arguments);
 
   setCorner(Qt::TopLeftCorner, Qt::LeftDockWidgetArea);
   setCorner(Qt::TopRightCorner, Qt::RightDockWidgetArea);
   setCorner(Qt::BottomLeftCorner, Qt::LeftDockWidgetArea);
   setCorner(Qt::BottomRightCorner, Qt::RightDockWidgetArea);
+
+  ui->setupUi(this);
+
   ui->mdiArea->setBackground(QImage(":/banner.png"));
+}
+
+void MainWindow::HandleOutput() {
+  if (!process) return;
+  this->ui->outputTextBrowser->append(process->readAllStandardOutput());
+  this->ui->outputTextBrowser->append(process->readAllStandardError());
 }
 
 void MainWindow::closeEvent(QCloseEvent *event) { event->accept(); }

--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -48,7 +48,7 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWi
   connect(ui->actionCreateExecutable, &QAction::triggered, pluginServer, &RGMPlugin::CreateExecutable);
 }
 
-void MainWindow::closeEvent(QCloseEvent *event) { event->accept(); }
+void MainWindow::closeEvent(QCloseEvent *event) { QMainWindow::closeEvent(event); }
 
 template <typename T>
 T *EditorFactory(QWidget *parent, ProtoModel *model) {
@@ -92,8 +92,8 @@ void MainWindow::openSubWindow(buffers::TreeNode *item) {
 
     subWindow = subWindows[item] = ui->mdiArea->addSubWindow(editor);
     subWindow->connect(subWindow, &QObject::destroyed, [=]() {
-      subWindows.remove(item);
       resourceModels.remove(item);
+      subWindows.remove(item);
     });
     subWindow->setWindowIcon(subWindow->widget()->windowIcon());
     subWindow->setWindowTitle(QString::fromStdString(item->name()));

--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -25,7 +25,20 @@
 
 MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWindow) {
   ArtManager::Init();
+
+  QString program = "./Submodules/enigma-dev/emake";
+  QStringList arguments;
+  arguments << "--server"
+            << "--quiet";
+  QProcess *myProcess = new QProcess(this);
+  myProcess->start(program, arguments);
+
   ui->setupUi(this);
+
+  setCorner(Qt::TopLeftCorner, Qt::LeftDockWidgetArea);
+  setCorner(Qt::TopRightCorner, Qt::RightDockWidgetArea);
+  setCorner(Qt::BottomLeftCorner, Qt::LeftDockWidgetArea);
+  setCorner(Qt::BottomRightCorner, Qt::RightDockWidgetArea);
   ui->mdiArea->setBackground(QImage(":/banner.png"));
 }
 
@@ -87,6 +100,8 @@ void MainWindow::openSubWindow(buffers::TreeNode *item) {
 MainWindow::~MainWindow() { delete ui; }
 
 void MainWindow::openFile(QString fName) {
+  QFileInfo fileInfo(fName);
+  this->setWindowTitle(fileInfo.fileName() + " - ENIGMA");
   game = gmx::LoadGMX(fName.toStdString());
   treeModel = new TreeModel(game->mutable_game()->mutable_root(), this);
   ui->treeView->setModel(treeModel);
@@ -107,7 +122,6 @@ void MainWindow::openFile(QString fName) {
 void MainWindow::on_actionOpen_triggered() {
   const QString fileName = QFileDialog::getOpenFileName(this, tr("Open Project"), "",
                                                         tr("GameMaker: Studio (*.project.gmx);;All Files (*)"));
-
   if (!fileName.isEmpty()) openFile(fileName);
 }
 
@@ -156,7 +170,8 @@ void MainWindow::on_actionExploreENIGMA_triggered() { QDesktopServices::openUrl(
 
 void MainWindow::on_actionAbout_triggered() {
   QMessageBox aboutBox(QMessageBox::Information, tr("About"),
-                       tr("ENIGMA is a free, open-source, and cross-platform game engine."), QMessageBox::Ok, this, 0);
+                       tr("ENIGMA is a free, open-source, and cross-platform game engine."), QMessageBox::Ok, this,
+                       nullptr);
   QAbstractButton *aboutQtButton = aboutBox.addButton(tr("About Qt"), QMessageBox::HelpRole);
   aboutBox.exec();
 

--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -108,8 +108,8 @@ MainWindow::~MainWindow() { delete ui; }
 void MainWindow::openFile(QString fName) {
   QFileInfo fileInfo(fName);
   this->setWindowTitle(fileInfo.fileName() + " - ENIGMA");
-  game = gmx::LoadGMX(fName.toStdString());
-  treeModel = new TreeModel(game->mutable_game()->mutable_root(), this);
+  project = gmx::LoadGMX(fName.toStdString());
+  treeModel = new TreeModel(project->mutable_game()->mutable_root(), this);
   ui->treeView->setModel(treeModel);
   treeModel->connect(treeModel, &QAbstractItemModel::dataChanged,
                      [=](const QModelIndex &topLeft, const QModelIndex &bottomRight) {

--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -27,18 +27,6 @@
 
 MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWindow) {
   ArtManager::Init();
-
-  process = new QProcess(this);
-  connect(process, SIGNAL(readyReadStandardOutput()), this, SLOT(HandleOutput()));
-  connect(process, SIGNAL(readyReadStandardError()), this, SLOT(HandleOutput()));
-  process->setWorkingDirectory("../RadialGM/Submodules/enigma-dev");
-
-  QString program = "emake";
-  QStringList arguments;
-  arguments << "--server"
-            << "--quiet";
-  process->start(program, arguments);
-
   setCorner(Qt::TopLeftCorner, Qt::LeftDockWidgetArea);
   setCorner(Qt::TopRightCorner, Qt::RightDockWidgetArea);
   setCorner(Qt::BottomLeftCorner, Qt::LeftDockWidgetArea);
@@ -49,11 +37,9 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWi
   ui->mdiArea->setBackground(QImage(":/banner.png"));
 }
 
-void MainWindow::HandleOutput() {
-  if (!process) return;
-  this->ui->outputTextBrowser->append(process->readAllStandardOutput());
-  this->ui->outputTextBrowser->append(process->readAllStandardError());
-}
+void MainWindow::HandleOutput(QString output) { this->ui->outputTextBrowser->append(output); }
+
+void MainWindow::HandleError(QString error) { this->ui->outputTextBrowser->append(error); }
 
 void MainWindow::closeEvent(QCloseEvent *event) { event->accept(); }
 

--- a/MainWindow.h
+++ b/MainWindow.h
@@ -18,7 +18,7 @@ class MainWindow : public QMainWindow {
   Q_OBJECT
 
  public:
-  explicit MainWindow(QWidget *parent = nullptr);
+  explicit MainWindow(QWidget *parent);
   ~MainWindow();
   void closeEvent(QCloseEvent *event);
   void openFile(QString fName);

--- a/MainWindow.h
+++ b/MainWindow.h
@@ -8,6 +8,7 @@
 
 #include <QMainWindow>
 #include <QMdiSubWindow>
+#include <QProcess>
 
 namespace Ui {
 class MainWindow;
@@ -23,6 +24,8 @@ class MainWindow : public QMainWindow {
   void openFile(QString fName);
 
  private slots:
+  void HandleOutput();
+
   // file menu
   void on_actionOpen_triggered();
   void on_actionPreferences_triggered();
@@ -48,10 +51,13 @@ class MainWindow : public QMainWindow {
 
  private:
   Ui::MainWindow *ui;
-  buffers::Project *game;
   TreeModel *treeModel;
+
   QHash<buffers::TreeNode *, ProtoModel *> resourceModels;
   QHash<buffers::TreeNode *, QMdiSubWindow *> subWindows;
+
+  buffers::Project *game;
+  QProcess *process;
 
   void openSubWindow(buffers::TreeNode *item);
 };

--- a/MainWindow.h
+++ b/MainWindow.h
@@ -23,6 +23,8 @@ class MainWindow : public QMainWindow {
   void closeEvent(QCloseEvent *event);
   void openFile(QString fName);
 
+  const buffers::Game &Game() { return this->project->game(); }
+
  private slots:
   // file menu
   void on_actionOpen_triggered();
@@ -54,7 +56,7 @@ class MainWindow : public QMainWindow {
   QHash<buffers::TreeNode *, ProtoModel *> resourceModels;
   QHash<buffers::TreeNode *, QMdiSubWindow *> subWindows;
 
-  buffers::Project *game;
+  buffers::Project *project;
 
   void openSubWindow(buffers::TreeNode *item);
 };

--- a/MainWindow.h
+++ b/MainWindow.h
@@ -17,7 +17,7 @@ class MainWindow : public QMainWindow {
   Q_OBJECT
 
  public:
-  explicit MainWindow(QWidget *parent = 0);
+  explicit MainWindow(QWidget *parent = nullptr);
   ~MainWindow();
   void closeEvent(QCloseEvent *event);
   void openFile(QString fName);

--- a/MainWindow.h
+++ b/MainWindow.h
@@ -23,7 +23,7 @@ class MainWindow : public QMainWindow {
   void closeEvent(QCloseEvent *event);
   void openFile(QString fName);
 
-  const buffers::Game &Game() { return this->project->game(); }
+  buffers::Game *Game() const { return this->project->mutable_game(); }
 
  private slots:
   // file menu

--- a/MainWindow.h
+++ b/MainWindow.h
@@ -23,10 +23,6 @@ class MainWindow : public QMainWindow {
   void closeEvent(QCloseEvent *event);
   void openFile(QString fName);
 
- public slots:
-  void HandleOutput(QString output);
-  void HandleError(QString error);
-
  private slots:
   // file menu
   void on_actionOpen_triggered();

--- a/MainWindow.h
+++ b/MainWindow.h
@@ -23,9 +23,11 @@ class MainWindow : public QMainWindow {
   void closeEvent(QCloseEvent *event);
   void openFile(QString fName);
 
- private slots:
-  void HandleOutput();
+ public slots:
+  void HandleOutput(QString output);
+  void HandleError(QString error);
 
+ private slots:
   // file menu
   void on_actionOpen_triggered();
   void on_actionPreferences_triggered();
@@ -57,7 +59,6 @@ class MainWindow : public QMainWindow {
   QHash<buffers::TreeNode *, QMdiSubWindow *> subWindows;
 
   buffers::Project *game;
-  QProcess *process;
 
   void openSubWindow(buffers::TreeNode *item);
 };

--- a/MainWindow.h
+++ b/MainWindow.h
@@ -50,11 +50,11 @@ class MainWindow : public QMainWindow {
   void on_treeView_doubleClicked(const QModelIndex &index);
 
  private:
-  Ui::MainWindow *ui;
-  TreeModel *treeModel;
-
   QHash<buffers::TreeNode *, ProtoModel *> resourceModels;
   QHash<buffers::TreeNode *, QMdiSubWindow *> subWindows;
+
+  TreeModel *treeModel;
+  Ui::MainWindow *ui;
 
   buffers::Project *project;
 

--- a/MainWindow.ui
+++ b/MainWindow.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>&lt;platform.gmx&gt; - ENIGMA</string>
+   <string>&lt;new game&gt; - ENIGMA</string>
   </property>
   <property name="windowIcon">
    <iconset resource="images.qrc">
@@ -19,6 +19,12 @@
   </property>
   <property name="autoFillBackground">
    <bool>false</bool>
+  </property>
+  <property name="dockNestingEnabled">
+   <bool>true</bool>
+  </property>
+  <property name="dockOptions">
+   <set>QMainWindow::AllowNestedDocks|QMainWindow::AllowTabbedDocks|QMainWindow::AnimatedDocks</set>
   </property>
   <widget class="QWidget" name="centralWidget">
    <layout class="QVBoxLayout" name="verticalLayout">
@@ -187,6 +193,45 @@
    <addaction name="actionPreferences"/>
    <addaction name="actionDocumentation"/>
   </widget>
+  <widget class="QDockWidget" name="outputDockWidget">
+   <property name="floating">
+    <bool>false</bool>
+   </property>
+   <property name="features">
+    <set>QDockWidget::AllDockWidgetFeatures</set>
+   </property>
+   <property name="allowedAreas">
+    <set>Qt::AllDockWidgetAreas</set>
+   </property>
+   <property name="windowTitle">
+    <string>Output</string>
+   </property>
+   <attribute name="dockWidgetArea">
+    <number>8</number>
+   </attribute>
+   <widget class="QWidget" name="outputDockWidgetContents">
+    <layout class="QVBoxLayout" name="verticalLayout_3">
+     <property name="spacing">
+      <number>2</number>
+     </property>
+     <property name="leftMargin">
+      <number>2</number>
+     </property>
+     <property name="topMargin">
+      <number>2</number>
+     </property>
+     <property name="rightMargin">
+      <number>2</number>
+     </property>
+     <property name="bottomMargin">
+      <number>2</number>
+     </property>
+     <item>
+      <widget class="QTextBrowser" name="outputTextBrowser"/>
+     </item>
+    </layout>
+   </widget>
+  </widget>
   <widget class="QDockWidget" name="treeDockWidget">
    <property name="autoFillBackground">
     <bool>false</bool>
@@ -195,7 +240,7 @@
     <set>Qt::AllDockWidgetAreas</set>
    </property>
    <property name="windowTitle">
-    <string>&amp;Project</string>
+    <string>Project</string>
    </property>
    <attribute name="dockWidgetArea">
     <number>1</number>

--- a/MainWindow.ui
+++ b/MainWindow.ui
@@ -72,6 +72,9 @@
         </color>
        </brush>
       </property>
+      <property name="activationOrder">
+       <enum>QMdiArea::ActivationHistoryOrder</enum>
+      </property>
       <property name="documentMode">
        <bool>false</bool>
       </property>

--- a/Models/ImmediateMapper.cpp
+++ b/Models/ImmediateMapper.cpp
@@ -6,16 +6,28 @@
 #include <QMetaObject>
 #include <QMetaProperty>
 
-ImmediateDataWidgetMapper::ImmediateDataWidgetMapper(QObject *parent) : QDataWidgetMapper(parent) {}
+ImmediateDataWidgetMapper::ImmediateDataWidgetMapper(QObject *parent) : QDataWidgetMapper(parent) {
+  this->setSubmitPolicy(QDataWidgetMapper::ManualSubmit);
+}
+
+QModelIndex ImmediateDataWidgetMapper::indexAt(int section) {
+  auto currentIndex = this->currentIndex();
+  auto model = this->model();
+  auto rootIndex = this->rootIndex();
+  return (this->orientation() == Qt::Horizontal) ? model->index(currentIndex, section, rootIndex)
+                                                 : model->index(section, currentIndex, rootIndex);
+}
 
 void ImmediateDataWidgetMapper::widgetChanged() {
   auto delegate = this->itemDelegate();
   auto editor = static_cast<QWidget *>(this->sender());
-  delegate->commitData(editor);
-  delegate->closeEditor(editor, QAbstractItemDelegate::SubmitModelCache);
+  auto model = this->model();
+  delegate->setModelData(editor, model, this->indexAt(this->mappedSection(editor)));
 }
 
 void ImmediateDataWidgetMapper::addMapping(QWidget *widget, int section, QByteArray propertyName) {
+  if (widgetList.contains(widget)) return;
+  widgetList.append(widget);
   QDataWidgetMapper::addMapping(widget, section, propertyName);
   propertyName = this->mappedPropertyName(widget);
   auto widgetMetaObject = widget->metaObject();
@@ -24,8 +36,18 @@ void ImmediateDataWidgetMapper::addMapping(QWidget *widget, int section, QByteAr
   QMetaObject::connect(widget, property.notifySignalIndex(), this, metaObject->indexOfSlot("widgetChanged()"));
 }
 
+void ImmediateDataWidgetMapper::clearMapping() {
+  widgetList.clear();
+  QDataWidgetMapper::clearMapping();
+}
+
 void ImmediateDataWidgetMapper::setCurrentIndex(int index) {
-  this->itemDelegate()->blockSignals(true);
+  QList<QWidget *> wasBlocked;
+  for (QWidget *widget : widgetList) {
+    if (!widget->blockSignals(true)) {
+      wasBlocked.append(widget);
+    }
+  }
   QDataWidgetMapper::setCurrentIndex(index);
-  this->itemDelegate()->blockSignals(false);
+  for (QWidget *widget : wasBlocked) widget->blockSignals(false);
 }

--- a/Models/ImmediateMapper.cpp
+++ b/Models/ImmediateMapper.cpp
@@ -7,6 +7,8 @@
 #include <QMetaProperty>
 
 ImmediateDataWidgetMapper::ImmediateDataWidgetMapper(QObject *parent) : QDataWidgetMapper(parent) {
+  // we do manual submission because auto submission will commit even on left click
+  // and give false-positives about the dirty state of our model
   this->setSubmitPolicy(QDataWidgetMapper::ManualSubmit);
 }
 
@@ -26,10 +28,18 @@ void ImmediateDataWidgetMapper::widgetChanged() {
 }
 
 void ImmediateDataWidgetMapper::addMapping(QWidget *widget, int section, QByteArray propertyName) {
+  // since QDataWidgetMapper makes its widget map private we have no way of
+  // getting all of the widgets registered with this mapper
+  // we also do not want to hook up a widget that's already mapped
   if (widgetList.contains(widget)) return;
   widgetList.append(widget);
   QDataWidgetMapper::addMapping(widget, section, propertyName);
+  // we use the QDataWidgetMapper to tell us what property we should listen to for changes
+  // all widgets have several properties, but most have a "primary" property with which
+  // the user interacts, i.e. "checked" for QCheckBox
   propertyName = this->mappedPropertyName(widget);
+  // we use the widget's meta object in order to get us a signal that we can listen to
+  // so we know when this property changes
   auto widgetMetaObject = widget->metaObject();
   auto property = widgetMetaObject->property(widgetMetaObject->indexOfProperty(propertyName));
   auto metaObject = this->metaObject();
@@ -37,11 +47,19 @@ void ImmediateDataWidgetMapper::addMapping(QWidget *widget, int section, QByteAr
 }
 
 void ImmediateDataWidgetMapper::clearMapping() {
+  // since we are keeping our own list to know what widgets were mapped with this mapper
+  // we have to clear it at the same time the QDataWidgetMapper clears its widget map
   widgetList.clear();
   QDataWidgetMapper::clearMapping();
 }
 
 void ImmediateDataWidgetMapper::setCurrentIndex(int index) {
+  // when the current index changes all the widgets have to be reloaded from the model
+  // we do not want them to signal property changes to us while they are reloading
+  // so we have to block their signals until the current index is changed and then
+  // unblock them afterwards if there were not blocked when this method entered
+  // NOTE: this probably is not threadsafe or reentrant, just like the rest of Qt
+  // and any other GUI framework, so take care when synchronizing it with other threads
   QList<QWidget *> wasBlocked;
   for (QWidget *widget : widgetList) {
     if (!widget->blockSignals(true)) {

--- a/Models/ImmediateMapper.cpp
+++ b/Models/ImmediateMapper.cpp
@@ -24,8 +24,8 @@ void ImmediateDataWidgetMapper::addMapping(QWidget *widget, int section, QByteAr
   QMetaObject::connect(widget, property.notifySignalIndex(), this, metaObject->indexOfSlot("widgetChanged()"));
 }
 
-void ImmediateDataWidgetMapper::toFirst() {
-  QDataWidgetMapper::toFirst();
-  // Mapper::toFirst triggers SetData and marks our model as dirty when it's really a virgin
-  static_cast<ProtoModel *>(model())->SetDirty(false);
+void ImmediateDataWidgetMapper::setCurrentIndex(int index) {
+  this->itemDelegate()->blockSignals(true);
+  QDataWidgetMapper::setCurrentIndex(index);
+  this->itemDelegate()->blockSignals(false);
 }

--- a/Models/ImmediateMapper.cpp
+++ b/Models/ImmediateMapper.cpp
@@ -57,7 +57,7 @@ void ImmediateDataWidgetMapper::setCurrentIndex(int index) {
   // when the current index changes all the widgets have to be reloaded from the model
   // we do not want them to signal property changes to us while they are reloading
   // so we have to block their signals until the current index is changed and then
-  // unblock them afterwards if there were not blocked when this method entered
+  // unblock them afterwards if they were not blocked when this method entered
   // NOTE: this probably is not threadsafe or reentrant, just like the rest of Qt
   // and any other GUI framework, so take care when synchronizing it with other threads
   QList<QWidget *> wasBlocked;

--- a/Models/ImmediateMapper.h
+++ b/Models/ImmediateMapper.h
@@ -12,7 +12,7 @@ class ImmediateDataWidgetMapper : public QDataWidgetMapper {
   void addMapping(QWidget *widget, int section, QByteArray propertyName = "");
 
  public slots:
-  void toFirst();
+  void setCurrentIndex(int index) override;  // toFirst(), toLast(), etc.
 
  private slots:
   void widgetChanged();

--- a/Models/ImmediateMapper.h
+++ b/Models/ImmediateMapper.h
@@ -2,6 +2,7 @@
 #define IMEDIATEDATAWIDGETWRAPPER_H
 
 #include <QDataWidgetMapper>
+#include <QList>
 
 class ImmediateDataWidgetMapper : public QDataWidgetMapper {
   Q_OBJECT
@@ -10,12 +11,17 @@ class ImmediateDataWidgetMapper : public QDataWidgetMapper {
   explicit ImmediateDataWidgetMapper(QObject *parent);
 
   void addMapping(QWidget *widget, int section, QByteArray propertyName = "");
+  void clearMapping();
+  QModelIndex indexAt(int section);
 
  public slots:
   void setCurrentIndex(int index) override;  // toFirst(), toLast(), etc.
 
  private slots:
   void widgetChanged();
+
+ private:
+  QList<QWidget *> widgetList;
 };
 
 #endif  // IMEDIATEDATAWIDGETWRAPPER_H

--- a/Models/ProtoModel.cpp
+++ b/Models/ProtoModel.cpp
@@ -9,6 +9,8 @@ ProtoModel::ProtoModel(Message *protobuf, QObject *parent)
   protobufBackup->CopyFrom(*protobuf);
 }
 
+ProtoModel::~ProtoModel() { delete protobufBackup; }
+
 void ProtoModel::ReplaceBuffer(Message *buffer) {
   SetDirty(true);
   protobuf->CopyFrom(*buffer);
@@ -16,8 +18,9 @@ void ProtoModel::ReplaceBuffer(Message *buffer) {
 }
 
 void ProtoModel::RestoreBuffer() {
-  std::swap(protobuf, protobufBackup);
-  protobufBackup->CopyFrom(*protobuf);
+  SetDirty(false);
+  protobuf->CopyFrom(*protobufBackup);
+  emit dataChanged(index(0), index(rowCount()));
 }
 
 int ProtoModel::rowCount(const QModelIndex & /*parent*/) const {

--- a/Models/ProtoModel.h
+++ b/Models/ProtoModel.h
@@ -9,7 +9,7 @@ class ProtoModel : public QAbstractItemModel {
   Q_OBJECT
 
  public:
-  explicit ProtoModel(google::protobuf::Message *protobuf, QObject *parent = nullptr);
+  explicit ProtoModel(google::protobuf::Message *protobuf, QObject *parent);
   ~ProtoModel();
 
   void ReplaceBuffer(google::protobuf::Message *buffer);

--- a/Models/ProtoModel.h
+++ b/Models/ProtoModel.h
@@ -10,6 +10,7 @@ class ProtoModel : public QAbstractItemModel {
 
  public:
   explicit ProtoModel(google::protobuf::Message *protobuf, QObject *parent = nullptr);
+  ~ProtoModel();
 
   void ReplaceBuffer(google::protobuf::Message *buffer);
   void RestoreBuffer();

--- a/Models/TreeModel.cpp
+++ b/Models/TreeModel.cpp
@@ -2,6 +2,8 @@
 
 #include "Components/ArtManager.h"
 
+#include <QFont>
+
 TreeModel::TreeModel(buffers::TreeNode *root, QObject *parent) : QAbstractItemModel(parent), root(root) {
   SetupParents(root);
 }
@@ -24,7 +26,6 @@ bool TreeModel::setData(const QModelIndex &index, const QVariant &value, int rol
   return true;
 }
 
-#include <QFont>
 QVariant TreeModel::data(const QModelIndex &index, int role) const {
   using TypeCase = buffers::TreeNode::TypeCase;
   using IconMap = std::unordered_map<TypeCase, QIcon>;

--- a/Models/TreeModel.cpp
+++ b/Models/TreeModel.cpp
@@ -53,7 +53,7 @@ QVariant TreeModel::data(const QModelIndex &index, int role) const {
     return QString::fromStdString(item->name());
   } else if (role == Qt::FontRole) {
     QFont font;
-    if (item->type_case() == TypeCase::kFolder && item->child_size()) font.setBold(true);
+    if (item->type_case() == TypeCase::kFolder && item->child_size()) font.setWeight(QFont::DemiBold);
     return font;
   }
 

--- a/Models/TreeModel.cpp
+++ b/Models/TreeModel.cpp
@@ -2,7 +2,17 @@
 
 #include "Components/ArtManager.h"
 
-TreeModel::TreeModel(buffers::TreeNode *root, QObject *parent) : QAbstractItemModel(parent), root(root) {}
+TreeModel::TreeModel(buffers::TreeNode *root, QObject *parent) : QAbstractItemModel(parent), root(root) {
+  SetupParents(root);
+}
+
+void TreeModel::SetupParents(buffers::TreeNode *root) {
+  for (int i = 0; i < root->child_size(); ++i) {
+    auto child = root->mutable_child(i);
+    parents[child] = root;
+    SetupParents(child);
+  }
+}
 
 int TreeModel::columnCount(const QModelIndex & /*parent*/) const { return 1; }
 
@@ -77,7 +87,7 @@ QModelIndex TreeModel::parent(const QModelIndex &index) const {
   if (!index.isValid()) return QModelIndex();
 
   buffers::TreeNode *childItem = static_cast<buffers::TreeNode *>(index.internalPointer());
-  buffers::TreeNode *parentItem = childItem->mutable_parent();
+  buffers::TreeNode *parentItem = parents[childItem];
 
   if (parentItem == root) return QModelIndex();
 

--- a/Models/TreeModel.cpp
+++ b/Models/TreeModel.cpp
@@ -24,6 +24,7 @@ bool TreeModel::setData(const QModelIndex &index, const QVariant &value, int rol
   return true;
 }
 
+#include <QFont>
 QVariant TreeModel::data(const QModelIndex &index, int role) const {
   using TypeCase = buffers::TreeNode::TypeCase;
   using IconMap = std::unordered_map<TypeCase, QIcon>;
@@ -31,7 +32,6 @@ QVariant TreeModel::data(const QModelIndex &index, int role) const {
   if (!index.isValid()) return QVariant();
 
   buffers::TreeNode *item = static_cast<buffers::TreeNode *>(index.internalPointer());
-
   if (role == Qt::DecorationRole) {
     static IconMap iconMap({{TypeCase::kFolder, ArtManager::GetIcon("group")},
                             {TypeCase::kSprite, ArtManager::GetIcon("sprite")},
@@ -48,11 +48,15 @@ QVariant TreeModel::data(const QModelIndex &index, int role) const {
     auto it = iconMap.find(item->type_case());
     if (it == iconMap.end()) return ArtManager::GetIcon("info");
     return it->second;
+  } else if (role == Qt::EditRole || role == Qt::DisplayRole) {
+    return QString::fromStdString(item->name());
+  } else if (role == Qt::FontRole) {
+    QFont font;
+    if (item->type_case() == TypeCase::kFolder && item->child_size()) font.setBold(true);
+    return font;
   }
 
-  if (role != Qt::DisplayRole && role != Qt::EditRole) return QVariant();
-
-  return QString::fromStdString(item->name());
+  return QVariant();
 }
 
 Qt::ItemFlags TreeModel::flags(const QModelIndex &index) const {

--- a/Models/TreeModel.h
+++ b/Models/TreeModel.h
@@ -4,6 +4,7 @@
 #include "treenode.pb.h"
 
 #include <QAbstractItemModel>
+#include <QHash>
 
 class TreeModel : public QAbstractItemModel {
   Q_OBJECT
@@ -21,9 +22,10 @@ class TreeModel : public QAbstractItemModel {
   int columnCount(const QModelIndex &parent = QModelIndex()) const override;
 
  private:
-  //void setupModelData(const QStringList &lines, TreeItem *parent);
-
   buffers::TreeNode *root;
+  QHash<buffers::TreeNode *, buffers::TreeNode *> parents;
+
+  void SetupParents(buffers::TreeNode *root);
 };
 
 #endif  // TREEMODEL_H

--- a/Plugins/PluginServer.cpp
+++ b/Plugins/PluginServer.cpp
@@ -1,0 +1,24 @@
+#include "PluginServer.h"
+
+PluginServer::PluginServer(const QApplication &app, MainWindow &mainWindow) : RGMPlugin(app, mainWindow) {
+  process = new QProcess(const_cast<QApplication *>(&app));
+
+  connect(process, &QProcess::readyReadStandardOutput, this, &PluginServer::HandleOutput);
+  connect(process, &QProcess::readyReadStandardError, this, &PluginServer::HandleError);
+  process->setWorkingDirectory("../RadialGM/Submodules/enigma-dev");
+
+  QString program = "emake";
+  QStringList arguments;
+  arguments << "--server"
+            << "--quiet";
+  process->start(program, arguments);
+}
+
+PluginServer::~PluginServer() {
+  process->terminate();
+  process->waitForFinished();
+}
+
+void PluginServer::HandleOutput() { mainWindow.HandleOutput(process->readAllStandardOutput()); }
+
+void PluginServer::HandleError() { mainWindow.HandleError(process->readAllStandardError()); }

--- a/Plugins/PluginServer.cpp
+++ b/Plugins/PluginServer.cpp
@@ -1,7 +1,9 @@
 #include "PluginServer.h"
 
-PluginServer::PluginServer(const QApplication &app, MainWindow &mainWindow) : RGMPlugin(app, mainWindow) {
-  process = new QProcess(const_cast<QApplication *>(&app));
+#include <QFileDialog>
+
+PluginServer::PluginServer(MainWindow& mainWindow) : RGMPlugin(mainWindow) {
+  process = new QProcess(this);
 
   connect(process, &QProcess::readyReadStandardOutput, this, &PluginServer::HandleOutput);
   connect(process, &QProcess::readyReadStandardError, this, &PluginServer::HandleError);
@@ -19,6 +21,20 @@ PluginServer::~PluginServer() {
   process->waitForFinished();
 }
 
-void PluginServer::HandleOutput() { mainWindow.HandleOutput(process->readAllStandardOutput()); }
+void PluginServer::Run(){
 
-void PluginServer::HandleError() { mainWindow.HandleError(process->readAllStandardError()); }
+};
+
+void PluginServer::Debug(){
+
+};
+
+void PluginServer::CreateExecutable() {
+  const QString& fileName =
+      QFileDialog::getSaveFileName(&mainWindow, tr("Create Executable"), "", tr("Executable (*.exe);;All Files (*)"));
+  //if (!fileName.isEmpty()) pluginServer->CreateExecutable(fileName);
+};
+
+void PluginServer::HandleOutput() { emit OutputRead(process->readAllStandardOutput()); }
+
+void PluginServer::HandleError() { emit ErrorRead(process->readAllStandardError()); }

--- a/Plugins/PluginServer.h
+++ b/Plugins/PluginServer.h
@@ -1,0 +1,21 @@
+#ifndef PLUGINSERVER_H
+#define PLUGINSERVER_H
+
+#include "RGMPlugin.h"
+
+#include <QProcess>
+
+class PluginServer : public RGMPlugin {
+ public:
+  PluginServer(const QApplication &app, MainWindow &mainWindow);
+  ~PluginServer();
+
+ private slots:
+  void HandleOutput();
+  void HandleError();
+
+ private:
+  QProcess *process;
+};
+
+#endif  // PLUGINSERVER_H

--- a/Plugins/PluginServer.h
+++ b/Plugins/PluginServer.h
@@ -7,8 +7,13 @@
 
 class PluginServer : public RGMPlugin {
  public:
-  PluginServer(const QApplication &app, MainWindow &mainWindow);
+  PluginServer(MainWindow &mainWindow);
   ~PluginServer();
+
+ public slots:
+  void Run() override;
+  void Debug() override;
+  void CreateExecutable() override;
 
  private slots:
   void HandleOutput();

--- a/Plugins/RGMPlugin.cpp
+++ b/Plugins/RGMPlugin.cpp
@@ -1,0 +1,4 @@
+#include "RGMPlugin.h"
+
+RGMPlugin::RGMPlugin(const QApplication& app, MainWindow& mainWindow) : QObject(), app(app), mainWindow(mainWindow) {}
+RGMPlugin::~RGMPlugin() {}

--- a/Plugins/RGMPlugin.cpp
+++ b/Plugins/RGMPlugin.cpp
@@ -1,4 +1,4 @@
 #include "RGMPlugin.h"
 
-RGMPlugin::RGMPlugin(const QApplication& app, MainWindow& mainWindow) : QObject(), app(app), mainWindow(mainWindow) {}
+RGMPlugin::RGMPlugin(MainWindow& mainWindow) : QObject(&mainWindow), mainWindow(mainWindow) {}
 RGMPlugin::~RGMPlugin() {}

--- a/Plugins/RGMPlugin.h
+++ b/Plugins/RGMPlugin.h
@@ -11,12 +11,20 @@ class RGMPlugin : public QObject {
  public:
   ~RGMPlugin();
 
+ signals:
+  void OutputRead(const QString &output);
+  void ErrorRead(const QString &error);
+
+ public slots:
+  virtual void Run() {}
+  virtual void Debug() {}
+  virtual void CreateExecutable() {}
+
  protected:
-  const QApplication &app;
   MainWindow &mainWindow;
 
  protected:
-  explicit RGMPlugin(const QApplication &app, MainWindow &mainWindow);
+  explicit RGMPlugin(MainWindow &mainWindow);
 };
 
 #endif  // RGMPLUGIN_H

--- a/Plugins/RGMPlugin.h
+++ b/Plugins/RGMPlugin.h
@@ -1,0 +1,22 @@
+#ifndef RGMPLUGIN_H
+#define RGMPLUGIN_H
+
+#include "MainWindow.h"
+
+#include <QApplication>
+
+class RGMPlugin : public QObject {
+  Q_OBJECT
+
+ public:
+  ~RGMPlugin();
+
+ protected:
+  const QApplication &app;
+  MainWindow &mainWindow;
+
+ protected:
+  explicit RGMPlugin(const QApplication &app, MainWindow &mainWindow);
+};
+
+#endif  // RGMPLUGIN_H

--- a/Plugins/ServerPlugin.cpp
+++ b/Plugins/ServerPlugin.cpp
@@ -43,6 +43,19 @@ class CompilerClient {
     CompileBuffer(game, mode, t.fileName().toStdString());
   }
 
+  void GetResources() {
+    qDebug() << "GetResources()";
+    ClientContext context;
+    Empty emptyRequest;
+
+    std::unique_ptr<ClientReader<Resource> > reader(stub->GetResources(&context, emptyRequest));
+    Resource resource;
+    while (reader->Read(&resource)) {
+      qDebug() << resource.name().c_str();
+    }
+    Status status = reader->Finish();
+  }
+
  private:
   std::unique_ptr<Compiler::Stub> stub;
 };
@@ -65,6 +78,7 @@ ServerPlugin::ServerPlugin(MainWindow& mainWindow) : RGMPlugin(mainWindow) {
   channelArguments.SetMaxReceiveMessageSize(-1);
   auto channel = CreateCustomChannel("localhost:37818", InsecureChannelCredentials(), channelArguments);
   compilerClient = new CompilerClient(channel);
+  compilerClient->GetResources();
 }
 
 ServerPlugin::~ServerPlugin() {

--- a/Plugins/ServerPlugin.cpp
+++ b/Plugins/ServerPlugin.cpp
@@ -1,12 +1,12 @@
-#include "PluginServer.h"
+#include "ServerPlugin.h"
 
 #include <QFileDialog>
 
-PluginServer::PluginServer(MainWindow& mainWindow) : RGMPlugin(mainWindow) {
+ServerPlugin::ServerPlugin(MainWindow& mainWindow) : RGMPlugin(mainWindow) {
   process = new QProcess(this);
 
-  connect(process, &QProcess::readyReadStandardOutput, this, &PluginServer::HandleOutput);
-  connect(process, &QProcess::readyReadStandardError, this, &PluginServer::HandleError);
+  connect(process, &QProcess::readyReadStandardOutput, this, &ServerPlugin::HandleOutput);
+  connect(process, &QProcess::readyReadStandardError, this, &ServerPlugin::HandleError);
   process->setWorkingDirectory("../RadialGM/Submodules/enigma-dev");
 
   QString program = "emake";
@@ -16,25 +16,25 @@ PluginServer::PluginServer(MainWindow& mainWindow) : RGMPlugin(mainWindow) {
   process->start(program, arguments);
 }
 
-PluginServer::~PluginServer() {
+ServerPlugin::~ServerPlugin() {
   process->terminate();
   process->waitForFinished();
 }
 
-void PluginServer::Run(){
+void ServerPlugin::Run(){
 
 };
 
-void PluginServer::Debug(){
+void ServerPlugin::Debug(){
 
 };
 
-void PluginServer::CreateExecutable() {
+void ServerPlugin::CreateExecutable() {
   const QString& fileName =
       QFileDialog::getSaveFileName(&mainWindow, tr("Create Executable"), "", tr("Executable (*.exe);;All Files (*)"));
   //if (!fileName.isEmpty()) pluginServer->CreateExecutable(fileName);
 };
 
-void PluginServer::HandleOutput() { emit OutputRead(process->readAllStandardOutput()); }
+void ServerPlugin::HandleOutput() { emit OutputRead(process->readAllStandardOutput()); }
 
-void PluginServer::HandleError() { emit ErrorRead(process->readAllStandardError()); }
+void ServerPlugin::HandleError() { emit ErrorRead(process->readAllStandardError()); }

--- a/Plugins/ServerPlugin.cpp
+++ b/Plugins/ServerPlugin.cpp
@@ -56,6 +56,27 @@ class CompilerClient {
     Status status = reader->Finish();
   }
 
+  void SetDefinitions(std::string code, std::string yaml) {
+    qDebug() << "SetDefinitions()";
+    ClientContext context;
+    SetDefinitionsRequest definitionsRequest;
+
+    definitionsRequest.set_code(code);
+    definitionsRequest.set_yaml(yaml);
+
+    SyntaxError reply;
+    Status status = stub->SetDefinitions(&context, definitionsRequest, &reply);
+  }
+
+  void SyntaxCheck() {
+    qDebug() << "SyntaxCheck()";
+    ClientContext context;
+    SyntaxCheckRequest syntaxCheckRequest;
+
+    SyntaxError reply;
+    Status status = stub->SyntaxCheck(&context, syntaxCheckRequest, &reply);
+  }
+
  private:
   std::unique_ptr<Compiler::Stub> stub;
 };

--- a/Plugins/ServerPlugin.cpp
+++ b/Plugins/ServerPlugin.cpp
@@ -1,6 +1,41 @@
 #include "ServerPlugin.h"
 
+#define _WIN32_WINNT 0x0600
+#include "server.grpc.pb.h"
+
 #include <QFileDialog>
+#include <QTemporaryFile>
+
+#include <grpc++/channel.h>
+#include <grpc++/client_context.h>
+#include <grpc++/create_channel.h>
+#include <grpc/grpc.h>
+
+using namespace grpc;
+using namespace buffers;
+
+class CompilerClient {
+ public:
+  explicit CompilerClient(std::shared_ptr<Channel> channel) : stub(Compiler::NewStub(channel)) {}
+
+  void CompileBuffer(const Game& game, std::string name, CompileMode mode) {
+    CompileRequest request;
+    request.set_name(name);
+    request.set_allocated_game(const_cast<Game*>(&game));
+    request.set_mode(mode);
+    ClientContext context;
+    stub->CompileBuffer(&context, request);
+  }
+
+  void CompileBuffer(const Game& game, CompileMode mode) {
+    QTemporaryFile t(".exe");
+    if (!t.open()) return;
+    CompileBuffer(game, t.fileName().toStdString(), mode);
+  }
+
+ private:
+  std::unique_ptr<Compiler::Stub> stub;
+};
 
 ServerPlugin::ServerPlugin(MainWindow& mainWindow) : RGMPlugin(mainWindow) {
   process = new QProcess(this);
@@ -14,6 +49,9 @@ ServerPlugin::ServerPlugin(MainWindow& mainWindow) : RGMPlugin(mainWindow) {
   arguments << "--server"
             << "--quiet";
   process->start(program, arguments);
+
+  auto channel = grpc::CreateChannel("localhost:37818", grpc::InsecureChannelCredentials());
+  compilerClient = new CompilerClient(channel);
 }
 
 ServerPlugin::~ServerPlugin() {
@@ -21,18 +59,15 @@ ServerPlugin::~ServerPlugin() {
   process->waitForFinished();
 }
 
-void ServerPlugin::Run(){
+void ServerPlugin::Run() { compilerClient->CompileBuffer(mainWindow.Game(), CompileMode::RUN); };
 
-};
-
-void ServerPlugin::Debug(){
-
-};
+void ServerPlugin::Debug() { compilerClient->CompileBuffer(mainWindow.Game(), CompileMode::DEBUG); };
 
 void ServerPlugin::CreateExecutable() {
   const QString& fileName =
       QFileDialog::getSaveFileName(&mainWindow, tr("Create Executable"), "", tr("Executable (*.exe);;All Files (*)"));
-  //if (!fileName.isEmpty()) pluginServer->CreateExecutable(fileName);
+  if (!fileName.isEmpty())
+    compilerClient->CompileBuffer(mainWindow.Game(), fileName.toStdString(), CompileMode::COMPILE);
 };
 
 void ServerPlugin::HandleOutput() { emit OutputRead(process->readAllStandardOutput()); }

--- a/Plugins/ServerPlugin.h
+++ b/Plugins/ServerPlugin.h
@@ -5,10 +5,10 @@
 
 #include <QProcess>
 
-class PluginServer : public RGMPlugin {
+class ServerPlugin : public RGMPlugin {
  public:
-  PluginServer(MainWindow &mainWindow);
-  ~PluginServer();
+  ServerPlugin(MainWindow &mainWindow);
+  ~ServerPlugin() override;
 
  public slots:
   void Run() override;

--- a/Plugins/ServerPlugin.h
+++ b/Plugins/ServerPlugin.h
@@ -5,6 +5,8 @@
 
 #include <QProcess>
 
+class CompilerClient;
+
 class ServerPlugin : public RGMPlugin {
  public:
   ServerPlugin(MainWindow &mainWindow);
@@ -21,6 +23,7 @@ class ServerPlugin : public RGMPlugin {
 
  private:
   QProcess *process;
+  CompilerClient *compilerClient;
 };
 
 #endif  // PLUGINSERVER_H

--- a/RadialGM.pro
+++ b/RadialGM.pro
@@ -10,7 +10,12 @@ CONFIG   += c++11
 # Uncomment if you want QPlainTextEdit used in place of QScintilla
 #DEFINES += RGM_DISABLE_SYNTAXHIGHLIGHTING
 
-!contains(DEFINES, RGM_DISABLE_SYNTAXHIGHLIGHTING):CONFIG += qscintilla2
+contains(DEFINES, RGM_DISABLE_SYNTAXHIGHLIGHTING) {
+  SOURCES += Widgets/CodeWidgetPlain.cpp
+} else {
+  SOURCES += Widgets/CodeWidgetScintilla.cpp
+  CONFIG += qscintilla2
+}
 
 win32:RC_ICONS += images/icon.ico
 
@@ -82,7 +87,8 @@ HEADERS += \
     Components/Utility.h \
     Editors/BaseEditor.h \
     Plugins/RGMPlugin.h \
-    Plugins/ServerPlugin.h
+    Plugins/ServerPlugin.h \
+    Widgets/CodeWidget.h
 
 FORMS += \
     MainWindow.ui \

--- a/RadialGM.pro
+++ b/RadialGM.pro
@@ -46,8 +46,8 @@ SOURCES += \
     Models/ProtoModel.cpp \
     Models/ImmediateMapper.cpp \
     Components/Utility.cpp \
-    Plugins/PluginServer.cpp \
-    Plugins/RGMPlugin.cpp
+    Plugins/RGMPlugin.cpp \
+    Plugins/ServerPlugin.cpp
 
 HEADERS += \
     MainWindow.h \
@@ -66,8 +66,8 @@ HEADERS += \
     Models/ImmediateMapper.h \
     Components/Utility.h \
     Editors/BaseEditor.h \
-    Plugins/PluginServer.h \
-    Plugins/RGMPlugin.h
+    Plugins/RGMPlugin.h \
+    Plugins/ServerPlugin.h
 
 FORMS += \
     MainWindow.ui \

--- a/RadialGM.pro
+++ b/RadialGM.pro
@@ -26,7 +26,7 @@ DEFINES += QT_DEPRECATED_WARNINGS
 #DEFINES += QT_DISABLE_DEPRECATED_BEFORE=0x060000    # disables all the APIs deprecated before Qt 6.0.0
 
 INCLUDEPATH += /usr/include/qt/ $$PWD/Submodules/enigma-dev/CommandLine/libGMX/ $$PWD/Submodules/enigma-dev/CommandLine/protos $$PWD/Submodules/enigma-dev/CommandLine/protos/codegen
-LIBS += -L$$PWD/Submodules/enigma-dev/CommandLine/libGMX/ -lGMX -lprotobuf -Wl,--rpath=$$PWD/Submodules/enigma-dev/ -L$$PWD/Submodules/enigma-dev/ -lProtocols -lpugixml
+LIBS += -L$$PWD/Submodules/enigma-dev/CommandLine/libGMX/ -lGMX -lprotobuf -Wl,--rpath=$$PWD/Submodules/enigma-dev/ -L$$PWD/Submodules/enigma-dev/ -lProtocols -lpugixml -lgrpc++
 
 SOURCES += \
         main.cpp \

--- a/RadialGM.pro
+++ b/RadialGM.pro
@@ -45,7 +45,9 @@ SOURCES += \
     Editors/BaseEditor.cpp \
     Models/ProtoModel.cpp \
     Models/ImmediateMapper.cpp \
-    Components/Utility.cpp
+    Components/Utility.cpp \
+    Plugins/PluginServer.cpp \
+    Plugins/RGMPlugin.cpp
 
 HEADERS += \
     MainWindow.h \
@@ -63,7 +65,9 @@ HEADERS += \
     Models/ProtoModel.h \
     Models/ImmediateMapper.h \
     Components/Utility.h \
-    Editors/BaseEditor.h
+    Editors/BaseEditor.h \
+    Plugins/PluginServer.h \
+    Plugins/RGMPlugin.h
 
 FORMS += \
     MainWindow.ui \

--- a/RadialGM.pro
+++ b/RadialGM.pro
@@ -36,11 +36,11 @@ DEFINES += QT_DEPRECATED_WARNINGS
 #DEFINES += QT_DISABLE_DEPRECATED_BEFORE=0x060000    # disables all the APIs deprecated before Qt 6.0.0
 
 INCLUDEPATH += /usr/include/qt/ \
-               $$PWD/Submodules/enigma-dev/CommandLine/libGMX/ \
+               $$PWD/Submodules/enigma-dev/CommandLine/libEGM/ \
                $$PWD/Submodules/enigma-dev/CommandLine/protos \
                $$PWD/Submodules/enigma-dev/CommandLine/protos/codegen
-LIBS += -L$$PWD/Submodules/enigma-dev/CommandLine/libGMX/ \
-        -lGMX \
+LIBS += -L$$PWD/Submodules/enigma-dev/CommandLine/libEGM/ \
+        -lEGM \
         -lprotobuf \
         -Wl,--rpath=$$PWD/Submodules/enigma-dev/ \
         -L$$PWD/Submodules/enigma-dev/ \

--- a/RadialGM.pro
+++ b/RadialGM.pro
@@ -5,7 +5,12 @@
 #-------------------------------------------------
 
 QT       += core gui
-CONFIG   += c++11 qscintilla2
+CONFIG   += c++11
+
+# Uncomment if you want QPlainTextEdit used in place of QScintilla
+#DEFINES += RGM_DISABLE_SYNTAXHIGHLIGHTING
+
+!contains(DEFINES, RGM_DISABLE_SYNTAXHIGHLIGHTING):CONFIG += qscintilla2
 
 win32:RC_ICONS += images/icon.ico
 
@@ -25,8 +30,18 @@ DEFINES += QT_DEPRECATED_WARNINGS
 # You can also select to disable deprecated APIs only up to a certain version of Qt.
 #DEFINES += QT_DISABLE_DEPRECATED_BEFORE=0x060000    # disables all the APIs deprecated before Qt 6.0.0
 
-INCLUDEPATH += /usr/include/qt/ $$PWD/Submodules/enigma-dev/CommandLine/libGMX/ $$PWD/Submodules/enigma-dev/CommandLine/protos $$PWD/Submodules/enigma-dev/CommandLine/protos/codegen
-LIBS += -L$$PWD/Submodules/enigma-dev/CommandLine/libGMX/ -lGMX -lprotobuf -Wl,--rpath=$$PWD/Submodules/enigma-dev/ -L$$PWD/Submodules/enigma-dev/ -lProtocols -lpugixml -lgrpc++
+INCLUDEPATH += /usr/include/qt/ \
+               $$PWD/Submodules/enigma-dev/CommandLine/libGMX/ \
+               $$PWD/Submodules/enigma-dev/CommandLine/protos \
+               $$PWD/Submodules/enigma-dev/CommandLine/protos/codegen
+LIBS += -L$$PWD/Submodules/enigma-dev/CommandLine/libGMX/ \
+        -lGMX \
+        -lprotobuf \
+        -Wl,--rpath=$$PWD/Submodules/enigma-dev/ \
+        -L$$PWD/Submodules/enigma-dev/ \
+        -lProtocols \
+        -lpugixml \
+        -lgrpc++
 
 SOURCES += \
         main.cpp \

--- a/Widgets/CodeWidget.h
+++ b/Widgets/CodeWidget.h
@@ -1,0 +1,14 @@
+#ifndef CODEWIDGET_H
+#define CODEWIDGET_H
+
+#include <QFont>
+
+class CodeWidget {
+ public:
+  CodeWidget();
+
+ protected:
+  QFont font;
+};
+
+#endif  // CODEWIDGET_H

--- a/Widgets/CodeWidget.h
+++ b/Widgets/CodeWidget.h
@@ -2,10 +2,12 @@
 #define CODEWIDGET_H
 
 #include <QFont>
+#include <QWidget>
 
-class CodeWidget {
+class CodeWidget : public QWidget {
  public:
-  CodeWidget();
+  explicit CodeWidget(QWidget* parent);
+  ~CodeWidget();
 
  protected:
   QFont font;

--- a/Widgets/CodeWidgetPlain.cpp
+++ b/Widgets/CodeWidgetPlain.cpp
@@ -1,9 +1,12 @@
 #include "CodeWidget.h"
 
+#include <QLayout>
 #include <QPlainTextEdit>
 
-CodeWidget::CodeWidget() : font(QFont("Courier", 10)) {
+CodeWidget::CodeWidget(QWidget* parent) : QWidget(parent), font(QFont("Courier", 10)) {
   QPlainTextEdit* plainTextEdit = new QPlainTextEdit(this);
   plainTextEdit->setFont(font);
   this->layout()->addWidget(plainTextEdit);
 }
+
+CodeWidget::~CodeWidget() {}

--- a/Widgets/CodeWidgetPlain.cpp
+++ b/Widgets/CodeWidgetPlain.cpp
@@ -1,0 +1,9 @@
+#include "CodeWidget.h"
+
+#include <QPlainTextEdit>
+
+CodeWidget::CodeWidget() : font(QFont("Courier", 10)) {
+  QPlainTextEdit* plainTextEdit = new QPlainTextEdit(this);
+  plainTextEdit->setFont(font);
+  this->layout()->addWidget(plainTextEdit);
+}

--- a/Widgets/CodeWidgetScintilla.cpp
+++ b/Widgets/CodeWidgetScintilla.cpp
@@ -1,11 +1,12 @@
 #include "CodeWidget.h"
 
 #include <QFontMetrics>
+#include <QLayout>
 
 #include <Qsci/qscilexercpp.h>
 #include <Qsci/qsciscintilla.h>
 
-CodeWidget::CodeWidget() : font(QFont("Courier", 10)) {
+CodeWidget::CodeWidget(QWidget* parent) : QWidget(parent), font(QFont("Courier", 10)) {
   QFontMetrics fontMetrics(font);
   QsciScintilla* textEdit = new QsciScintilla(this);
 
@@ -20,3 +21,5 @@ CodeWidget::CodeWidget() : font(QFont("Courier", 10)) {
   textEdit->setLexer(lexer);
   this->layout()->addWidget(textEdit);
 }
+
+CodeWidget::~CodeWidget() {}

--- a/Widgets/CodeWidgetScintilla.cpp
+++ b/Widgets/CodeWidgetScintilla.cpp
@@ -1,0 +1,22 @@
+#include "CodeWidget.h"
+
+#include <QFontMetrics>
+
+#include <Qsci/qscilexercpp.h>
+#include <Qsci/qsciscintilla.h>
+
+CodeWidget::CodeWidget() : font(QFont("Courier", 10)) {
+  QFontMetrics fontMetrics(font);
+  QsciScintilla* textEdit = new QsciScintilla(this);
+
+  textEdit->setCaretLineVisible(true);
+  textEdit->setCaretLineBackgroundColor(QColor("#ffe4e4"));
+
+  textEdit->setMarginLineNumbers(0, true);
+  textEdit->setMarginWidth(0, fontMetrics.width("000"));
+  textEdit->setMarginsFont(font);
+  QsciLexerCPP* lexer = new QsciLexerCPP();
+  lexer->setDefaultFont(font);
+  textEdit->setLexer(lexer);
+  this->layout()->addWidget(textEdit);
+}

--- a/main.cpp
+++ b/main.cpp
@@ -5,7 +5,7 @@
 int main(int argc, char *argv[]) {
   QApplication a(argc, argv);
   a.setWindowIcon(QIcon(":/icon.ico"));
-  MainWindow w;
+  MainWindow w(nullptr);
   if (argc > 1) {
     w.openFile(QString(argv[1]));
   }

--- a/main.cpp
+++ b/main.cpp
@@ -1,5 +1,7 @@
-#include <QApplication>
 #include "MainWindow.h"
+#include "Plugins/PluginServer.h"
+
+#include <QApplication>
 
 int main(int argc, char *argv[]) {
   QApplication a(argc, argv);
@@ -9,6 +11,8 @@ int main(int argc, char *argv[]) {
     w.openFile(QString(argv[1]));
   }
   w.show();
+
+  PluginServer pluginServer(a, w);
 
   return a.exec();
 }

--- a/main.cpp
+++ b/main.cpp
@@ -1,5 +1,4 @@
 #include "MainWindow.h"
-#include "Plugins/PluginServer.h"
 
 #include <QApplication>
 
@@ -11,8 +10,6 @@ int main(int argc, char *argv[]) {
     w.openFile(QString(argv[1]));
   }
   w.show();
-
-  PluginServer pluginServer(a, w);
 
   return a.exec();
 }


### PR DESCRIPTION
- Swaps constructor initialization order for editors. The parent should always be last in case it is made optional. However, we're still following the principle of not defaulting the parent parameter to `nullptr` to protect against memory leaks from unparented widgets not being destroyed. This is not to say that `nullptr` parent is disallowed, just that it must be explicit, should be rare (i.e. MainWindow), and you must really be careful when doing it.
- Fixes some issues with the "No" option on the unsaved changes dialog for editors. The widget map should be cleared first of all so it doesn't force the widgets to write their unreverted data into the model. The model should also be firing a data change event just like `ReplaceBuffer` does.
- Adds an output window to the main window layout and fixes the corners so that it is does not stretch horizontally, and instead allows the tree to stretch vertically. I'm really impressed with how easy Qt makes it to hook this thing up to a `QProcess`, however it lacks ANSI escape code support I believe (so forget about GCC color output right away).
- Created an `RGMPlugin` abstract interface for implementing plugins that are decoupled from the UI and main source. The base class inherits QObject in order to enable use of signals and virtual slots to add supported plugin interfacing. The slots are virtual with a default implementation because obviously not every plugin wants to implement "Run/Debug/Compile" behavior. However, since I haven't come up with a way for plugins to "subscribe" to certain slots, I just have the main window always connect the slots for now. Perhaps later I will change it to a QMetaObject and the IDE will only connect the slots on a plugin that match a supported plugin slot in its plugin API.
- Created the `ServerPlugin` inheriting `RGMPlugin` to implement "Run/Debug/Compile" using GRPC and emake's server mode. It has some issues with blocking the main UI thread right now which should be solved by switching to asynchronous GRPC server mode. It also needs a keepalive mode, which should be enabled by default, but I haven't figured out how to configure that yet from the server end (in the enigma-dev/CLI code) to shutdown if the IDE crashes.
- Fixes the window title to show the file name when a game is opened.
- Changes the MDI subwindow ordering to `ActivationHistoryOrder` which behaves as GM5 did from my testing. It's also the more preferable behavior in most situations.
- Adds the ability to compile without QScintilla by defining `RGM_DISABLE_SYNTAXHIGHLIGHTING` which will replace its usage with QPlainTextEdit. Not only is that just a good modular idea, I am actually using it for debugging because [MSYS2's pacman package for QScintilla has a bug](https://github.com/Alexpux/MINGW-packages/pull/3507) that doesn't install the debug build for the designer. I also cleaned up the `.pro` file while I was in there, breaking up the libs and include paths over several lines.
- Made tree nodes that have children `DemiBold` for style and to let the user know which folders actually have resources in them. I did this in the model, which may later need moved to a style delegate if we want to display it in another view without the bold font.
- Added some documentation to the source of `ImmediateMapper` so it's clear why manual submission is used and what problems exist in Qt's built-in `QDataWidgetMapper`. I am confident that it performs much better and will also serve us well.
- Stores a map of parent tree nodes in the tree model because protobuf actually doesn't support reference/pointer types in its schemas, so having the parents in the proto was actually causing stack overflows.