### PR TITLE
Window State, Classic GMK & YYP Support, and Recent Files

### DIFF
--- a/Components/RecentFiles.cpp
+++ b/Components/RecentFiles.cpp
@@ -1,0 +1,97 @@
+#include "RecentFiles.h"
+
+#include <QFileInfo>
+#include <QSettings>
+#include <QString>
+
+RecentFiles::RecentFiles(QPointer<MainWindow> mainWindow, QPointer<QMenu> menuRecent,
+                         QPointer<QAction> actionClearRecentMenu)
+    : QObject(mainWindow), mainWindow(mainWindow), menuRecent(menuRecent) {
+  menuRecent->connect(menuRecent, &QMenu::aboutToShow, this, &RecentFiles::updateActions);
+  for (int i = 0; i < MaxRecentFiles; ++i) {
+    recentFileActs[i] = menuRecent->addAction(QString(), this, &RecentFiles::recentFileActionTriggered);
+    recentFileActs[i]->setVisible(false);
+  }
+
+  menuRecent->addSeparator();
+  menuRecent->addAction(actionClearRecentMenu);
+
+  menuRecent->setEnabled(this->empty());
+}
+
+static inline QString recentFilesKey() { return QStringLiteral("recentFileList"); }
+static inline QString fileKey() { return QStringLiteral("file"); }
+
+bool RecentFiles::empty() {
+  QSettings settings;
+
+  const int count = settings.beginReadArray(recentFilesKey());
+  settings.endArray();
+  return count > 0;
+}
+
+static QStringList readRecentFiles(QSettings &settings) {
+  QStringList result;
+  const int count = settings.beginReadArray(recentFilesKey());
+  for (int i = 0; i < count; ++i) {
+    settings.setArrayIndex(i);
+    result.append(settings.value(fileKey()).toString());
+  }
+  settings.endArray();
+  return result;
+}
+
+void RecentFiles::updateActions() {
+  QSettings settings;
+
+  const QStringList recentFiles = readRecentFiles(settings);
+  const int count = qMin(int(MaxRecentFiles), recentFiles.size());
+  int i = 0;
+  for (; i < count; ++i) {
+    const QString fileName = QFileInfo(recentFiles.at(i)).fileName();
+    QString numberString = QString::number(i + 1);
+    recentFileActs[i]->setText(numberString.insert(numberString.length() - 1, '&') + " " + fileName);
+    recentFileActs[i]->setData(recentFiles.at(i));
+    recentFileActs[i]->setVisible(true);
+  }
+  for (; i < MaxRecentFiles; ++i) recentFileActs[i]->setVisible(false);
+}
+
+static void writeRecentFiles(const QStringList &files, QSettings &settings) {
+  const int count = files.size();
+  settings.beginWriteArray(recentFilesKey());
+  for (int i = 0; i < count; ++i) {
+    settings.setArrayIndex(i);
+    settings.setValue(fileKey(), files.at(i));
+  }
+  settings.endArray();
+}
+
+void RecentFiles::prependFile(const QString &fileName) {
+  QSettings settings;
+
+  const QStringList oldRecentFiles = readRecentFiles(settings);
+  QStringList recentFiles = oldRecentFiles;
+  recentFiles.removeAll(fileName);
+  recentFiles.prepend(fileName);
+  if (oldRecentFiles != recentFiles) writeRecentFiles(recentFiles, settings);
+
+  this->menuRecent->setEnabled(!recentFiles.isEmpty());
+}
+
+void RecentFiles::recentFileActionTriggered() {
+  if (const QAction *action = qobject_cast<const QAction *>(sender())) mainWindow->openFile(action->data().toString());
+}
+
+void RecentFiles::clear() {
+  QSettings settings;
+
+  settings.beginWriteArray(recentFilesKey());
+  settings.endArray();
+
+  for (int i = 0; i < MaxRecentFiles; ++i) {
+    recentFileActs[i]->setVisible(false);
+  }
+
+  menuRecent->setEnabled(false);
+}

--- a/Components/RecentFiles.h
+++ b/Components/RecentFiles.h
@@ -1,0 +1,34 @@
+#ifndef RECENTFILES_H
+#define RECENTFILES_H
+
+class RecentFiles;
+#include "MainWindow.h"
+
+#include <QAction>
+#include <QMenu>
+#include <QObject>
+#include <QPointer>
+#include <QString>
+
+class RecentFiles : public QObject {
+  Q_OBJECT
+
+ public:
+  explicit RecentFiles(QPointer<MainWindow> mainWindow, QPointer<QMenu> menuRecent,
+                       QPointer<QAction> actionClearRecentMenu);
+
+  bool empty();
+  void prependFile(const QString &fileName);
+  void updateActions();
+  void clear();
+
+ private:
+  QPointer<MainWindow> mainWindow;
+  QPointer<QMenu> menuRecent;
+  static const int MaxRecentFiles = 10;
+  QPointer<QAction> recentFileActs[MaxRecentFiles];
+
+  void recentFileActionTriggered();
+};
+
+#endif  // RECENTFILES_H

--- a/Editors/BackgroundEditor.ui
+++ b/Editors/BackgroundEditor.ui
@@ -166,7 +166,7 @@
            <number>4</number>
           </property>
           <property name="leftMargin">
-           <number>0</number>
+           <number>4</number>
           </property>
           <property name="topMargin">
            <number>4</number>
@@ -377,8 +377,8 @@
          <rect>
           <x>0</x>
           <y>0</y>
-          <width>470</width>
-          <height>339</height>
+          <width>459</width>
+          <height>336</height>
          </rect>
         </property>
         <property name="autoFillBackground">

--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -64,7 +64,7 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWi
 MainWindow::~MainWindow() { delete ui; }
 
 void MainWindow::readSettings() {
-  QSettings settings("ENIGMA Dev Team", "RadialGM");
+  QSettings settings;
 
   settings.beginGroup("MainWindow");
   restoreGeometry(settings.value("geometry").toByteArray());
@@ -76,7 +76,7 @@ static inline QString recentFilesKey() { return QStringLiteral("recentFileList")
 static inline QString fileKey() { return QStringLiteral("file"); }
 
 bool MainWindow::hasRecentFiles() {
-  QSettings settings("ENIGMA Dev Team", "RadialGM");
+  QSettings settings;
 
   const int count = settings.beginReadArray(recentFilesKey());
   settings.endArray();
@@ -95,7 +95,7 @@ static QStringList readRecentFiles(QSettings &settings) {
 }
 
 void MainWindow::updateRecentFileActions() {
-  QSettings settings("ENIGMA Dev Team", "RadialGM");
+  QSettings settings;
 
   const QStringList recentFiles = readRecentFiles(settings);
   const int count = qMin(int(MaxRecentFiles), recentFiles.size());
@@ -121,7 +121,7 @@ static void writeRecentFiles(const QStringList &files, QSettings &settings) {
 }
 
 void MainWindow::prependToRecentFiles(const QString &fileName) {
-  QSettings settings("ENIGMA Dev Team", "RadialGM");
+  QSettings settings;
 
   const QStringList oldRecentFiles = readRecentFiles(settings);
   QStringList recentFiles = oldRecentFiles;
@@ -133,7 +133,7 @@ void MainWindow::prependToRecentFiles(const QString &fileName) {
 }
 
 void MainWindow::writeSettings() {
-  QSettings settings("ENIGMA Dev Team", "RadialGM");
+  QSettings settings;
 
   settings.beginGroup("MainWindow");
   settings.setValue("geometry", saveGeometry());
@@ -318,7 +318,7 @@ void MainWindow::on_treeView_doubleClicked(const QModelIndex &index) {
 }
 
 void MainWindow::on_actionClearRecentMenu_triggered() {
-  QSettings settings("ENIGMA Dev Team", "RadialGM");
+  QSettings settings;
 
   settings.beginWriteArray(recentFilesKey());
   settings.endArray();

--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -37,6 +37,7 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWi
   setCorner(Qt::BottomRightCorner, Qt::RightDockWidgetArea);
 
   ui->setupUi(this);
+  this->readSettings();
 
   ui->mdiArea->setBackground(QImage(":/banner.png"));
 
@@ -51,7 +52,28 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWi
 
 MainWindow::~MainWindow() { delete ui; }
 
-void MainWindow::closeEvent(QCloseEvent *event) { event->accept(); }
+void MainWindow::readSettings() {
+  QSettings settings("ENIGMA Dev Team", "RadialGM");
+
+  settings.beginGroup("MainWindow");
+  restoreGeometry(settings.value("mainWindowGeometry").toByteArray());
+  restoreState(settings.value("mainWindowState").toByteArray());
+  settings.endGroup();
+}
+
+void MainWindow::writeSettings() {
+  QSettings settings("ENIGMA Dev Team", "RadialGM");
+
+  settings.beginGroup("MainWindow");
+  settings.setValue("mainWindowGeometry", saveGeometry());
+  settings.setValue("mainWindowState", saveState());
+  settings.endGroup();
+}
+
+void MainWindow::closeEvent(QCloseEvent *event) {
+  this->writeSettings();
+  event->accept();
+}
 
 template <typename T>
 T *EditorFactory(ProtoModel *model, QWidget *parent) {

--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -18,6 +18,7 @@
 
 #include "gmk.h"
 #include "gmx.h"
+#include "yyp.h"
 
 #include "resources/Background.pb.h"
 
@@ -115,6 +116,8 @@ void MainWindow::openFile(QString fName) {
     project = gmk::LoadGMK(fName.toStdString());
   } else if (suffix == "gmx") {
     project = gmx::LoadGMX(fName.toStdString());
+  } else if (suffix == "yyp") {
+    project = yyp::LoadYYP(fName.toStdString());
   }
   treeModel = new TreeModel(project->mutable_game()->mutable_root(), this);
   ui->treeView->setModel(treeModel);
@@ -135,7 +138,8 @@ void MainWindow::openFile(QString fName) {
 void MainWindow::on_actionOpen_triggered() {
   const QString &fileName = QFileDialog::getOpenFileName(
       this, tr("Open Project"), "",
-      tr("GameMaker: Studio (*.project.gmx);;Classic GameMaker Files (*.gm81 *.gmk *.gm6 *.gmd);;All Files (*)"));
+      tr("GameMaker: Studio 2 Projects (*.yyp);;GameMaker: Studio Projects (*.project.gmx);;Classic "
+         "GameMaker Files (*.gm81 *.gmk *.gm6 *.gmd);;All Files (*)"));
   if (!fileName.isEmpty()) openFile(fileName);
 }
 

--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -56,6 +56,7 @@ MainWindow::~MainWindow() { delete ui; }
 void MainWindow::readSettings() {
   QSettings settings;
 
+  // Restore previous window and dock widget location / state
   settings.beginGroup("MainWindow");
   restoreGeometry(settings.value("geometry").toByteArray());
   restoreState(settings.value("state").toByteArray());
@@ -65,6 +66,7 @@ void MainWindow::readSettings() {
 void MainWindow::writeSettings() {
   QSettings settings;
 
+  // Save window and dock widget location / state for next session
   settings.beginGroup("MainWindow");
   settings.setValue("geometry", saveGeometry());
   settings.setValue("state", saveState());

--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -203,7 +203,6 @@ void MainWindow::openSubWindow(buffers::TreeNode *item) {
 
 void MainWindow::openFile(QString fName) {
   QFileInfo fileInfo(fName);
-  this->setWindowTitle(fileInfo.fileName() + " - ENIGMA");
   const QString suffix = fileInfo.suffix();
   if (suffix == "gm81" || suffix == "gmk" || suffix == "gm6" || suffix == "gmd") {
     project = gmk::LoadGMK(fName.toStdString());
@@ -218,6 +217,7 @@ void MainWindow::openFile(QString fName) {
     return;
   }
 
+  MainWindow::setWindowTitle(fileInfo.fileName() + " - ENIGMA");
   MainWindow::prependToRecentFiles(fName);
 
   treeModel = new TreeModel(project->mutable_game()->mutable_root(), this);

--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -204,6 +204,7 @@ void MainWindow::openSubWindow(buffers::TreeNode *item) {
 void MainWindow::openFile(QString fName) {
   QFileInfo fileInfo(fName);
   const QString suffix = fileInfo.suffix();
+
   if (suffix == "gm81" || suffix == "gmk" || suffix == "gm6" || suffix == "gmd") {
     project = gmk::LoadGMK(fName.toStdString());
   } else if (suffix == "gmx") {
@@ -211,6 +212,7 @@ void MainWindow::openFile(QString fName) {
   } else if (suffix == "yyp") {
     project = yyp::LoadYYP(fName.toStdString());
   }
+
   if (!project) {
     QMessageBox::critical(this, tr("Failed To Open Project"), tr("There was a problem loading the project: ") + fName,
                           QMessageBox::Ok);

--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -160,7 +160,8 @@ void MainWindow::openFile(QString fName) {
 void MainWindow::on_actionOpen_triggered() {
   const QString &fileName = QFileDialog::getOpenFileName(
       this, tr("Open Project"), "",
-      tr("GameMaker: Studio 2 Projects (*.yyp);;GameMaker: Studio Projects (*.project.gmx);;Classic "
+      tr("All supported formats (*.yyp *.project.gmx *.gm81 *.gmk *.gm6 *.gmd);;GameMaker: Studio 2 Projects "
+         "(*.yyp);;GameMaker: Studio Projects (*.project.gmx);;Classic "
          "GameMaker Files (*.gm81 *.gmk *.gm6 *.gmd);;All Files (*)"));
   if (!fileName.isEmpty()) openFile(fileName);
 }

--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -39,6 +39,17 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWi
   ui->setupUi(this);
   this->readSettings();
 
+  connect(ui->menuRecent, &QMenu::aboutToShow, this, &MainWindow::updateRecentFileActions);
+  for (int i = 0; i < MaxRecentFiles; ++i) {
+    recentFileActs[i] = ui->menuRecent->addAction(QString(), this, &MainWindow::openRecentFile);
+    recentFileActs[i]->setVisible(false);
+  }
+
+  ui->menuRecent->addSeparator();
+  ui->menuRecent->addAction(ui->actionClearRecentMenu);
+
+  ui->menuRecent->setEnabled(this->hasRecentFiles());
+
   ui->mdiArea->setBackground(QImage(":/banner.png"));
 
   RGMPlugin *pluginServer = new ServerPlugin(*this);
@@ -59,6 +70,65 @@ void MainWindow::readSettings() {
   restoreGeometry(settings.value("geometry").toByteArray());
   restoreState(settings.value("state").toByteArray());
   settings.endGroup();
+}
+
+static inline QString recentFilesKey() { return QStringLiteral("recentFileList"); }
+static inline QString fileKey() { return QStringLiteral("file"); }
+
+bool MainWindow::hasRecentFiles() {
+  QSettings settings("ENIGMA Dev Team", "RadialGM");
+
+  const int count = settings.beginReadArray(recentFilesKey());
+  settings.endArray();
+  return count > 0;
+}
+
+static QStringList readRecentFiles(QSettings &settings) {
+  QStringList result;
+  const int count = settings.beginReadArray(recentFilesKey());
+  for (int i = 0; i < count; ++i) {
+    settings.setArrayIndex(i);
+    result.append(settings.value(fileKey()).toString());
+  }
+  settings.endArray();
+  return result;
+}
+
+void MainWindow::updateRecentFileActions() {
+  QSettings settings("ENIGMA Dev Team", "RadialGM");
+
+  const QStringList recentFiles = readRecentFiles(settings);
+  const int count = qMin(int(MaxRecentFiles), recentFiles.size());
+  int i = 0;
+  for (; i < count; ++i) {
+    const QString fileName = QFileInfo(recentFiles.at(i)).fileName();
+    recentFileActs[i]->setText(tr("&%1 %2").arg(i + 1).arg(fileName));
+    recentFileActs[i]->setData(recentFiles.at(i));
+    recentFileActs[i]->setVisible(true);
+  }
+  for (; i < MaxRecentFiles; ++i) recentFileActs[i]->setVisible(false);
+}
+
+static void writeRecentFiles(const QStringList &files, QSettings &settings) {
+  const int count = files.size();
+  settings.beginWriteArray(recentFilesKey());
+  for (int i = 0; i < count; ++i) {
+    settings.setArrayIndex(i);
+    settings.setValue(fileKey(), files.at(i));
+  }
+  settings.endArray();
+}
+
+void MainWindow::prependToRecentFiles(const QString &fileName) {
+  QSettings settings("ENIGMA Dev Team", "RadialGM");
+
+  const QStringList oldRecentFiles = readRecentFiles(settings);
+  QStringList recentFiles = oldRecentFiles;
+  recentFiles.removeAll(fileName);
+  recentFiles.prepend(fileName);
+  if (oldRecentFiles != recentFiles) writeRecentFiles(recentFiles, settings);
+
+  this->ui->menuRecent->setEnabled(!recentFiles.isEmpty());
 }
 
 void MainWindow::writeSettings() {
@@ -141,6 +211,14 @@ void MainWindow::openFile(QString fName) {
   } else if (suffix == "yyp") {
     project = yyp::LoadYYP(fName.toStdString());
   }
+  if (!project) {
+    QMessageBox::critical(this, tr("Failed To Open Project"), tr("There was a problem loading the project: ") + fName,
+                          QMessageBox::Ok);
+    return;
+  }
+
+  MainWindow::prependToRecentFiles(fName);
+
   treeModel = new TreeModel(project->mutable_game()->mutable_root(), this);
   ui->treeView->setModel(treeModel);
   treeModel->connect(treeModel, &QAbstractItemModel::dataChanged,
@@ -155,6 +233,10 @@ void MainWindow::openFile(QString fName) {
                          }
                        }
                      });
+}
+
+void MainWindow::openRecentFile() {
+  if (const QAction *action = qobject_cast<const QAction *>(sender())) openFile(action->data().toString());
 }
 
 void MainWindow::on_actionOpen_triggered() {
@@ -230,4 +312,17 @@ void MainWindow::on_treeView_doubleClicked(const QModelIndex &index) {
   }
 
   openSubWindow(item);
+}
+
+void MainWindow::on_actionClearRecentMenu_triggered() {
+  QSettings settings("ENIGMA Dev Team", "RadialGM");
+
+  settings.beginWriteArray(recentFilesKey());
+  settings.endArray();
+
+  for (int i = 0; i < MaxRecentFiles; ++i) {
+    recentFileActs[i]->setVisible(false);
+  }
+
+  ui->menuRecent->setEnabled(false);
 }

--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -56,8 +56,8 @@ void MainWindow::readSettings() {
   QSettings settings("ENIGMA Dev Team", "RadialGM");
 
   settings.beginGroup("MainWindow");
-  restoreGeometry(settings.value("mainWindowGeometry").toByteArray());
-  restoreState(settings.value("mainWindowState").toByteArray());
+  restoreGeometry(settings.value("geometry").toByteArray());
+  restoreState(settings.value("state").toByteArray());
   settings.endGroup();
 }
 
@@ -65,8 +65,8 @@ void MainWindow::writeSettings() {
   QSettings settings("ENIGMA Dev Team", "RadialGM");
 
   settings.beginGroup("MainWindow");
-  settings.setValue("mainWindowGeometry", saveGeometry());
-  settings.setValue("mainWindowState", saveState());
+  settings.setValue("geometry", saveGeometry());
+  settings.setValue("state", saveState());
   settings.endGroup();
 }
 

--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -16,6 +16,7 @@
 #include "Plugins/RGMPlugin.h"
 #include "Plugins/ServerPlugin.h"
 
+#include "gmk.h"
 #include "gmx.h"
 
 #include "resources/Background.pb.h"
@@ -109,7 +110,12 @@ void MainWindow::openSubWindow(buffers::TreeNode *item) {
 void MainWindow::openFile(QString fName) {
   QFileInfo fileInfo(fName);
   this->setWindowTitle(fileInfo.fileName() + " - ENIGMA");
-  project = gmx::LoadGMX(fName.toStdString());
+  if (fileInfo.suffix() == "gm81" || fileInfo.suffix() == "gmk" || fileInfo.suffix() == "gm6" ||
+      fileInfo.suffix() == "gmd") {
+    project = gmk::LoadGMK(fName.toStdString());
+  } else if (fileInfo.suffix() == "gmx") {
+    project = gmx::LoadGMX(fName.toStdString());
+  }
   treeModel = new TreeModel(project->mutable_game()->mutable_root(), this);
   ui->treeView->setModel(treeModel);
   treeModel->connect(treeModel, &QAbstractItemModel::dataChanged,
@@ -127,8 +133,9 @@ void MainWindow::openFile(QString fName) {
 }
 
 void MainWindow::on_actionOpen_triggered() {
-  const QString &fileName = QFileDialog::getOpenFileName(this, tr("Open Project"), "",
-                                                         tr("GameMaker: Studio (*.project.gmx);;All Files (*)"));
+  const QString &fileName = QFileDialog::getOpenFileName(
+      this, tr("Open Project"), "",
+      tr("GameMaker: Studio (*.project.gmx);;Classic GameMaker Files (*.gm81 *.gmk *.gm6 *.gmd);;All Files (*)"));
   if (!fileName.isEmpty()) openFile(fileName);
 }
 

--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -110,10 +110,10 @@ void MainWindow::openSubWindow(buffers::TreeNode *item) {
 void MainWindow::openFile(QString fName) {
   QFileInfo fileInfo(fName);
   this->setWindowTitle(fileInfo.fileName() + " - ENIGMA");
-  if (fileInfo.suffix() == "gm81" || fileInfo.suffix() == "gmk" || fileInfo.suffix() == "gm6" ||
-      fileInfo.suffix() == "gmd") {
+  const QString suffix = fileInfo.suffix();
+  if (suffix == "gm81" || suffix == "gmk" || suffix == "gm6" || suffix == "gmd") {
     project = gmk::LoadGMK(fName.toStdString());
-  } else if (fileInfo.suffix() == "gmx") {
+  } else if (suffix == "gmx") {
     project = gmx::LoadGMX(fName.toStdString());
   }
   treeModel = new TreeModel(project->mutable_game()->mutable_root(), this);

--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -102,7 +102,8 @@ void MainWindow::updateRecentFileActions() {
   int i = 0;
   for (; i < count; ++i) {
     const QString fileName = QFileInfo(recentFiles.at(i)).fileName();
-    recentFileActs[i]->setText(tr("&%1 %2").arg(i + 1).arg(fileName));
+    QString numberString = QString::number(i + 1);
+    recentFileActs[i]->setText(numberString.insert(numberString.length() - 1, '&') + " " + fileName);
     recentFileActs[i]->setData(recentFiles.at(i));
     recentFileActs[i]->setVisible(true);
   }

--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -72,6 +72,15 @@ void MainWindow::readSettings() {
   settings.endGroup();
 }
 
+void MainWindow::writeSettings() {
+  QSettings settings;
+
+  settings.beginGroup("MainWindow");
+  settings.setValue("geometry", saveGeometry());
+  settings.setValue("state", saveState());
+  settings.endGroup();
+}
+
 static inline QString recentFilesKey() { return QStringLiteral("recentFileList"); }
 static inline QString fileKey() { return QStringLiteral("file"); }
 
@@ -130,15 +139,6 @@ void MainWindow::prependToRecentFiles(const QString &fileName) {
   if (oldRecentFiles != recentFiles) writeRecentFiles(recentFiles, settings);
 
   this->ui->menuRecent->setEnabled(!recentFiles.isEmpty());
-}
-
-void MainWindow::writeSettings() {
-  QSettings settings;
-
-  settings.beginGroup("MainWindow");
-  settings.setValue("geometry", saveGeometry());
-  settings.setValue("state", saveState());
-  settings.endGroup();
 }
 
 void MainWindow::closeEvent(QCloseEvent *event) {
@@ -214,8 +214,8 @@ void MainWindow::openFile(QString fName) {
   }
 
   if (!project) {
-    QMessageBox::critical(this, tr("Failed To Open Project"), tr("There was a problem loading the project: ") + fName,
-                          QMessageBox::Ok);
+    QMessageBox::warning(this, tr("Failed To Open Project"), tr("There was a problem loading the project: ") + fName,
+                         QMessageBox::Ok);
     return;
   }
 

--- a/MainWindow.h
+++ b/MainWindow.h
@@ -49,6 +49,8 @@ class MainWindow : public QMainWindow {
 
   void on_treeView_doubleClicked(const QModelIndex &index);
 
+  void on_actionClearRecentMenu_triggered();
+
  private:
   QHash<buffers::TreeNode *, ProtoModel *> resourceModels;
   QHash<buffers::TreeNode *, QMdiSubWindow *> subWindows;
@@ -58,9 +60,16 @@ class MainWindow : public QMainWindow {
 
   buffers::Project *project;
 
+  static const int MaxRecentFiles = 10;
+  QAction *recentFileActs[MaxRecentFiles];
+
   void openSubWindow(buffers::TreeNode *item);
   void readSettings();
   void writeSettings();
+  bool hasRecentFiles();
+  void prependToRecentFiles(const QString &fileName);
+  void updateRecentFileActions();
+  void openRecentFile();
 };
 
 #endif  // MAINWINDOW_H

--- a/MainWindow.h
+++ b/MainWindow.h
@@ -59,6 +59,8 @@ class MainWindow : public QMainWindow {
   buffers::Project *project;
 
   void openSubWindow(buffers::TreeNode *item);
+  void readSettings();
+  void writeSettings();
 };
 
 #endif  // MAINWINDOW_H

--- a/MainWindow.h
+++ b/MainWindow.h
@@ -4,10 +4,14 @@
 #include "Models/ProtoModel.h"
 #include "Models/TreeModel.h"
 
+class MainWindow;
+#include "Components/RecentFiles.h"
+
 #include "codegen/project.pb.h"
 
 #include <QMainWindow>
 #include <QMdiSubWindow>
+#include <QPointer>
 #include <QProcess>
 
 namespace Ui {
@@ -21,9 +25,11 @@ class MainWindow : public QMainWindow {
   explicit MainWindow(QWidget *parent);
   ~MainWindow();
   void closeEvent(QCloseEvent *event);
-  void openFile(QString fName);
 
   buffers::Game *Game() const { return this->project->mutable_game(); }
+
+ public slots:
+  void openFile(QString fName);
 
  private slots:
   // file menu
@@ -59,17 +65,11 @@ class MainWindow : public QMainWindow {
   Ui::MainWindow *ui;
 
   buffers::Project *project;
-
-  static const int MaxRecentFiles = 10;
-  QAction *recentFileActs[MaxRecentFiles];
+  QPointer<RecentFiles> recentFiles;
 
   void openSubWindow(buffers::TreeNode *item);
   void readSettings();
   void writeSettings();
-  bool hasRecentFiles();
-  void prependToRecentFiles(const QString &fileName);
-  void updateRecentFileActions();
-  void openRecentFile();
 };
 
 #endif  // MAINWINDOW_H

--- a/MainWindow.ui
+++ b/MainWindow.ui
@@ -104,8 +104,17 @@
     <property name="title">
      <string>&amp;File</string>
     </property>
+    <widget class="QMenu" name="menuRecent">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="title">
+      <string>&amp;Recent</string>
+     </property>
+    </widget>
     <addaction name="actionNew"/>
     <addaction name="actionOpen"/>
+    <addaction name="menuRecent"/>
     <addaction name="separator"/>
     <addaction name="actionSave"/>
     <addaction name="actionSaveAll"/>
@@ -539,7 +548,7 @@
   </action>
   <action name="actionCloseAll">
    <property name="text">
-    <string>C&amp;lose All</string>
+    <string>Close &amp;All</string>
    </property>
   </action>
   <action name="actionCloseOthers">
@@ -577,6 +586,14 @@
    </property>
    <property name="text">
     <string>Toggle Tabbed &amp;View</string>
+   </property>
+  </action>
+  <action name="actionClearRecentMenu">
+   <property name="text">
+    <string>&amp;Clear Menu</string>
+   </property>
+   <property name="toolTip">
+    <string>Clear Menu</string>
    </property>
   </action>
  </widget>

--- a/Plugins/ServerPlugin.cpp
+++ b/Plugins/ServerPlugin.cpp
@@ -1,8 +1,9 @@
+#ifndef _WIN32_WINNT
+#define _WIN32_WINNT 0x0600  // at least windows vista required for grpc
+#endif
+
 #include "ServerPlugin.h"
 
-#if _WIN32_WINNT < 0x0600
-#define _WIN32_WINNT 0x0600
-#endif
 #include "server.grpc.pb.h"
 
 #include <QDebug>

--- a/RadialGM.pro
+++ b/RadialGM.pro
@@ -5,7 +5,7 @@
 #-------------------------------------------------
 
 QT       += core gui
-CONFIG   += c++14
+CONFIG   += c++11
 
 greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
 

--- a/RadialGM.pro
+++ b/RadialGM.pro
@@ -28,7 +28,7 @@ VERSION = 0.0.1
 QMAKE_TARGET_COMPANY = ENIGMA Dev Team
 QMAKE_TARGET_PRODUCT = ENIGMA Development Environment
 QMAKE_TARGET_DESCRIPTION = ENIGMA Development Environment
-QMAKE_TARGET_COPYRIGHT = Copyright (C) 2007-2018
+QMAKE_TARGET_COPYRIGHT = Copyright © 2007-2018
 
 # The following define makes your compiler emit warnings if you use
 # any feature of Qt which has been marked as deprecated (the exact warnings

--- a/RadialGM.pro
+++ b/RadialGM.pro
@@ -5,7 +5,7 @@
 #-------------------------------------------------
 
 QT       += core gui
-CONFIG   += c++11
+CONFIG   += c++14
 
 greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
 
@@ -73,7 +73,8 @@ SOURCES += \
     Models/ImmediateMapper.cpp \
     Components/Utility.cpp \
     Plugins/RGMPlugin.cpp \
-    Plugins/ServerPlugin.cpp
+    Plugins/ServerPlugin.cpp \
+    Components/RecentFiles.cpp
 
 HEADERS += \
     MainWindow.h \
@@ -94,7 +95,8 @@ HEADERS += \
     Editors/BaseEditor.h \
     Plugins/RGMPlugin.h \
     Plugins/ServerPlugin.h \
-    Widgets/CodeWidget.h
+    Widgets/CodeWidget.h \
+    Components/RecentFiles.h
 
 FORMS += \
     MainWindow.ui \

--- a/RadialGM.pro
+++ b/RadialGM.pro
@@ -7,6 +7,19 @@
 QT       += core gui
 CONFIG   += c++11
 
+greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
+
+win32:RC_ICONS += images/icon.ico
+
+TARGET = ENIGMA
+TEMPLATE = app
+VERSION = 0.0.0.0
+
+QMAKE_TARGET_COMPANY = ENIGMA Dev Team
+QMAKE_TARGET_PRODUCT = ENIGMA Development Environment
+QMAKE_TARGET_DESCRIPTION = ENIGMA Development Environment
+QMAKE_TARGET_COPYRIGHT = "Copyright \\251 2007-2018 ENIGMA Dev Team"
+
 # Uncomment if you want QPlainTextEdit used in place of QScintilla
 #DEFINES += RGM_DISABLE_SYNTAXHIGHLIGHTING
 
@@ -16,19 +29,6 @@ contains(DEFINES, RGM_DISABLE_SYNTAXHIGHLIGHTING) {
   SOURCES += Widgets/CodeWidgetScintilla.cpp
   CONFIG += qscintilla2
 }
-
-win32:RC_ICONS += images/icon.ico
-
-greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
-
-TARGET = ENIGMA
-TEMPLATE = app
-VERSION = 0.0.1
-
-QMAKE_TARGET_COMPANY = ENIGMA Dev Team
-QMAKE_TARGET_PRODUCT = ENIGMA Development Environment
-QMAKE_TARGET_DESCRIPTION = ENIGMA Development Environment
-QMAKE_TARGET_COPYRIGHT = Copyright © 2007-2018
 
 # The following define makes your compiler emit warnings if you use
 # any feature of Qt which has been marked as deprecated (the exact warnings

--- a/RadialGM.pro
+++ b/RadialGM.pro
@@ -21,8 +21,14 @@ win32:RC_ICONS += images/icon.ico
 
 greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
 
-TARGET = RadialGM
+TARGET = ENIGMA
 TEMPLATE = app
+VERSION = 0.0.1
+
+QMAKE_TARGET_COMPANY = ENIGMA Dev Team
+QMAKE_TARGET_PRODUCT = ENIGMA Development Environment
+QMAKE_TARGET_DESCRIPTION = ENIGMA Development Environment
+QMAKE_TARGET_COPYRIGHT = Copyright (C) 2007-2018
 
 # The following define makes your compiler emit warnings if you use
 # any feature of Qt which has been marked as deprecated (the exact warnings

--- a/main.cpp
+++ b/main.cpp
@@ -4,7 +4,10 @@
 
 int main(int argc, char *argv[]) {
   QApplication a(argc, argv);
+  a.setOrganizationName("ENIGMA Dev Team");
+  a.setApplicationName("RadialGM");
   a.setWindowIcon(QIcon(":/icon.ico"));
+
   MainWindow w(nullptr);
   if (argc > 1) {
     w.openFile(QString(argv[1]));

--- a/main.cpp
+++ b/main.cpp
@@ -5,6 +5,7 @@
 int main(int argc, char *argv[]) {
   QApplication a(argc, argv);
   a.setOrganizationName("ENIGMA Dev Team");
+  a.setOrganizationDomain("enigma-dev.org");
   a.setApplicationName("RadialGM");
   a.setWindowIcon(QIcon(":/icon.ico"));
 


### PR DESCRIPTION
This adds the ability to load Classic GameMaker Files and GameMaker: Studio 2's YYP project format from the open dialog.

This follows from the work on https://github.com/enigma-dev/enigma-dev/pull/1179 to get GMK & YYP support in the CLI.

While I was doing this I used QSettings to remember the window state and add a recent files menu.

![GMK FPS Example](https://user-images.githubusercontent.com/3212801/38387307-56f8a760-38e5-11e8-8584-e30da9ff7b62.png)
![GM6 Game of Life](https://user-images.githubusercontent.com/3212801/38420353-689263e4-3971-11e8-9a26-6d7340c5c81c.png)
![GM81 God of Man](https://user-images.githubusercontent.com/3212801/38420383-8c2cb534-3971-11e8-95c2-e5c79f18680e.png)
![GMS2 Arena Shooter](https://user-images.githubusercontent.com/3212801/38612970-5cc089fe-3d56-11e8-8da2-6042ae22608c.png)



