### PR TITLE
Tree View/Empty Folder Presentation

### DIFF
--- a/Models/TreeModel.cpp
+++ b/Models/TreeModel.cpp
@@ -2,8 +2,6 @@
 
 #include "Components/ArtManager.h"
 
-#include <QFont>
-
 TreeModel::TreeModel(buffers::TreeNode *root, QObject *parent) : QAbstractItemModel(parent), root(root) {
   SetupParents(root);
 }
@@ -50,7 +48,7 @@ QVariant TreeModel::data(const QModelIndex &index, int role) const {
     if (it == iconMap.end()) return ArtManager::GetIcon("info");
     const QIcon &icon = it->second;
     if (item->type_case() == TypeCase::kFolder && item->child_size() <= 0) {
-      return icon.pixmap(QSize(18, 18), QIcon::Disabled);
+      return icon.pixmap(icon.availableSizes().first(), QIcon::Disabled);
     }
     return icon;
   } else if (role == Qt::EditRole || role == Qt::DisplayRole) {

--- a/Models/TreeModel.cpp
+++ b/Models/TreeModel.cpp
@@ -48,13 +48,13 @@ QVariant TreeModel::data(const QModelIndex &index, int role) const {
 
     auto it = iconMap.find(item->type_case());
     if (it == iconMap.end()) return ArtManager::GetIcon("info");
-    return it->second;
+    const QIcon &icon = it->second;
+    if (item->type_case() == TypeCase::kFolder && item->child_size() <= 0) {
+      return icon.pixmap(QSize(18, 18), QIcon::Disabled);
+    }
+    return icon;
   } else if (role == Qt::EditRole || role == Qt::DisplayRole) {
     return QString::fromStdString(item->name());
-  } else if (role == Qt::FontRole) {
-    QFont font;
-    if (item->type_case() == TypeCase::kFolder && item->child_size()) font.setWeight(QFont::DemiBold);
-    return font;
   }
 
   return QVariant();


### PR DESCRIPTION
Ok, so I experimented with a couple of different styles for the tree. The top-left one is what the current master branch has, use a demibold font with groups that actually have child nodes. I preferred this over the old always-bold primary nodes in old GM. This pull request actually changes it to the top-right screen for a number of reasons.

* First, the bottom-right one was achieved by turning off the `Qt::ItemIsEnabled` flag, which makes the item unselectable. I tested and ensured that I can still show a context menu for the item this way, but it feels weird because you can't use F2 to select and rename the empty folder like the other folders.
* I feel the bottom-left one, using a folder icon with files for groups with child nodes, looks really trashy. Makes the whole tree look too cluttered.
* I really don't care about showing a different icon for when the folder is expanded because it's not only unnecessarily complicated to achieve that, nobody else really does it. Even the Windows 10 Explorer doesn't show a different icon for expanded folders, it does what the bottom-left screen does.

So, as you can see, the top-right one, which is the solution actually implemented in this PR, not allows me to still select the empty folders, but also makes them visually more appealing. The argument here is that you can mentally ignore resource types you don't use (i.e. Timelines) much easier with this visual aesthetic.

![before](https://user-images.githubusercontent.com/3212801/39548850-d740eee2-4e29-11e8-92c1-0b324cacc070.png)![disbled-folder](https://user-images.githubusercontent.com/3212801/39548852-d75a664c-4e29-11e8-8987-f330a58dfd2a.png)![filled](https://user-images.githubusercontent.com/3212801/39548855-d766ae16-4e29-11e8-963a-21751459a483.png)![disabled-flag](https://user-images.githubusercontent.com/3212801/39548851-d74dddd2-4e29-11e8-9a69-0090ffbedff8.png)
