### PR TITLE
Setup AppVeyor Build Using MSVC 2017 & Releases

### DIFF
--- a/CmakeLists.txt
+++ b/CmakeLists.txt
@@ -170,7 +170,6 @@ find_library(LIB_QT_EVENT_D NAMES Qt5EventDispatcherSupportd)
 find_library(LIB_QT_THEME_D NAMES Qt5ThemeSupportd)
 find_library(LIB_QT_ICO_D NAMES qicod PATHS "${QT_DIR}/plugins/imageformats")
 find_library(LIB_QT_GIF_D NAMES qgifd PATHS "${QT_DIR}/plugins/imageformats")
-find_library(LIB_QT_JPEG_D NAMES qjpegd PATHS "${QT_DIR}/plugins/imageformats")
 # Windows 10 SDK doesn't include a debug version of Uxtheme
 find_library(LIB_WIN_UXTHEME_D NAMES Uxtheme)
 find_library(LIB_QT_WINVISTASTYLE_D NAMES qwindowsvistastyled PATHS "${QT_DIR}/plugins/styles")
@@ -182,11 +181,9 @@ find_library(LIB_QT_UI NAMES Qt5WindowsUIAutomationSupport)
 find_library(LIB_QT_EVENT NAMES Qt5EventDispatcherSupport)
 find_library(LIB_QT_THEME NAMES Qt5ThemeSupport)
 # ICO is needed to set Win32 icon on the Window
-# also all 3 of these image plugins are very small
-# even combined they are only 300kb~
+# also all of these image plugins are very small about 100kb~ each
 find_library(LIB_QT_ICO NAMES qico PATHS "${QT_DIR}/plugins/imageformats")
 find_library(LIB_QT_GIF NAMES qgif PATHS "${QT_DIR}/plugins/imageformats")
-find_library(LIB_QT_JPEG NAMES qjpeg PATHS "${QT_DIR}/plugins/imageformats")
 find_library(LIB_WIN_UXTHEME NAMES Uxtheme)
 find_library(LIB_QT_WINVISTASTYLE NAMES qwindowsvistastyle PATHS "${QT_DIR}/plugins/styles")
 find_library(LIB_QT_WIN NAMES qwindows PATHS "${QT_DIR}/plugins/platforms")
@@ -198,7 +195,6 @@ target_link_libraries(${EXE} PRIVATE "$<IF:$<CONFIG:Debug>,${LIB_QT_PLATFORM_D},
                       "$<IF:$<CONFIG:Debug>,${LIB_QT_THEME_D},${LIB_QT_THEME}>"
                       "$<IF:$<CONFIG:Debug>,${LIB_QT_ICO_D},${LIB_QT_ICO}>"
                       "$<IF:$<CONFIG:Debug>,${LIB_QT_GIF_D},${LIB_QT_GIF}>"
-                      "$<IF:$<CONFIG:Debug>,${LIB_QT_JPEG_D},${LIB_QT_JPEG}>"
                       "$<IF:$<CONFIG:Debug>,${LIB_WIN_UXTHEME_D},${LIB_WIN_UXTHEME}>"
                       "$<IF:$<CONFIG:Debug>,${LIB_QT_WINVISTASTYLE_D},${LIB_QT_WINVISTASTYLE}>"
                       "$<IF:$<CONFIG:Debug>,${LIB_QT_WIN_D},${LIB_QT_WIN}>"

--- a/CmakeLists.txt
+++ b/CmakeLists.txt
@@ -149,10 +149,9 @@ find_library(LIB_GPR NAMES gpr)
 target_link_libraries(${EXE} PRIVATE ${LIB_GRPC_UNSECURE} ${LIB_GRPC} ${LIB_GPR})
 
 # Find Protobuf
-find_library(LIB_PROTOBUF NAMES libprotobufd)
-find_library(LIB_PROTOC NAMES libprotocd)
-find_library(LIB_PROTOLITE NAMES libprotobuf-lited)
-target_link_libraries(${EXE} PRIVATE ${LIB_PROTOC} ${LIB_PROTOBUF} ${LIB_PROTOLITE})
+include(FindProtobuf)
+include_directories(${Protobuf_INCLUDE_DIRS})
+target_link_libraries(${EXE} PRIVATE ${Protobuf_LIBRARIES})
 
 # Find OpenSSL
 find_package(OpenSSL REQUIRED)

--- a/CmakeLists.txt
+++ b/CmakeLists.txt
@@ -170,6 +170,7 @@ find_library(LIB_QT_EVENT_D NAMES Qt5EventDispatcherSupportd)
 find_library(LIB_QT_THEME_D NAMES Qt5ThemeSupportd)
 find_library(LIB_QT_ICO_D NAMES qicod PATHS "${QT_DIR}/plugins/imageformats")
 find_library(LIB_QT_GIF_D NAMES qgifd PATHS "${QT_DIR}/plugins/imageformats")
+find_library(LIB_QT_JPEG_D NAMES qjpegd PATHS "${QT_DIR}/plugins/imageformats")
 # Windows 10 SDK doesn't include a debug version of Uxtheme
 find_library(LIB_WIN_UXTHEME_D NAMES Uxtheme)
 find_library(LIB_QT_WINVISTASTYLE_D NAMES qwindowsvistastyled PATHS "${QT_DIR}/plugins/styles")
@@ -184,6 +185,7 @@ find_library(LIB_QT_THEME NAMES Qt5ThemeSupport)
 # also all of these image plugins are very small about 100kb~ each
 find_library(LIB_QT_ICO NAMES qico PATHS "${QT_DIR}/plugins/imageformats")
 find_library(LIB_QT_GIF NAMES qgif PATHS "${QT_DIR}/plugins/imageformats")
+find_library(LIB_QT_JPEG NAMES qjpeg PATHS "${QT_DIR}/plugins/imageformats")
 find_library(LIB_WIN_UXTHEME NAMES Uxtheme)
 find_library(LIB_QT_WINVISTASTYLE NAMES qwindowsvistastyle PATHS "${QT_DIR}/plugins/styles")
 find_library(LIB_QT_WIN NAMES qwindows PATHS "${QT_DIR}/plugins/platforms")
@@ -195,6 +197,7 @@ target_link_libraries(${EXE} PRIVATE "$<IF:$<CONFIG:Debug>,${LIB_QT_PLATFORM_D},
                       "$<IF:$<CONFIG:Debug>,${LIB_QT_THEME_D},${LIB_QT_THEME}>"
                       "$<IF:$<CONFIG:Debug>,${LIB_QT_ICO_D},${LIB_QT_ICO}>"
                       "$<IF:$<CONFIG:Debug>,${LIB_QT_GIF_D},${LIB_QT_GIF}>"
+                      "$<IF:$<CONFIG:Debug>,${LIB_QT_JPEG_D},${LIB_QT_JPEG}>"
                       "$<IF:$<CONFIG:Debug>,${LIB_WIN_UXTHEME_D},${LIB_WIN_UXTHEME}>"
                       "$<IF:$<CONFIG:Debug>,${LIB_QT_WINVISTASTYLE_D},${LIB_QT_WINVISTASTYLE}>"
                       "$<IF:$<CONFIG:Debug>,${LIB_QT_WIN_D},${LIB_QT_WIN}>"
@@ -204,6 +207,10 @@ target_link_libraries(${EXE} PRIVATE "$<IF:$<CONFIG:Debug>,${LIB_QT_PLATFORM_D},
 find_package(Freetype REQUIRED)
 include_directories(${FREETYPE_INCLUDE_DIRS})
 target_link_libraries(${EXE} PRIVATE ${FREETYPE_LIBRARIES})
+
+# Find JPEG
+find_library(LIB_JPEG NAMES jpeg)
+target_link_libraries(${EXE} PRIVATE ${LIB_JPEG})
 
 # Find HarfBuzz
 find_library(LIB_HARFBUZZ NAMES harfbuzz)

--- a/CmakeLists.txt
+++ b/CmakeLists.txt
@@ -4,10 +4,6 @@ set(EXE "RadialGM")
 set(EXE_VERSION "0.1")
 set(EXE_DESCRIPTION "ENIGMA IDE")
 
-set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
-set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
-
 project(RadialGM)
 
 # Find includes in corresponding build directories

--- a/CmakeLists.txt
+++ b/CmakeLists.txt
@@ -168,6 +168,9 @@ find_library(LIB_QT_FONT_D NAMES Qt5FontDatabaseSupportd)
 find_library(LIB_QT_UI_D NAMES Qt5WindowsUIAutomationSupportd)
 find_library(LIB_QT_EVENT_D NAMES Qt5EventDispatcherSupportd)
 find_library(LIB_QT_THEME_D NAMES Qt5ThemeSupportd)
+# Windows 10 SDK doesn't include a debug version of Uxtheme
+find_library(LIB_WIN_UXTHEME_D NAMES Uxtheme)
+find_library(LIB_QT_WINVISTASTYLE_D NAMES qwindowsvistastyled PATHS "${QT_DIR}/plugins/styles")
 find_library(LIB_QT_WIN_D NAMES qwindowsd PATHS "${QT_DIR}/plugins/platforms")
 # Release
 find_library(LIB_QT_PLATFORM NAMES Qt5PlatformCompositorSupport)
@@ -175,6 +178,8 @@ find_library(LIB_QT_FONT NAMES Qt5FontDatabaseSupport)
 find_library(LIB_QT_UI NAMES Qt5WindowsUIAutomationSupport)
 find_library(LIB_QT_EVENT NAMES Qt5EventDispatcherSupport)
 find_library(LIB_QT_THEME NAMES Qt5ThemeSupport)
+find_library(LIB_WIN_UXTHEME NAMES Uxtheme)
+find_library(LIB_QT_WINVISTASTYLE NAMES qwindowsvistastyle PATHS "${QT_DIR}/plugins/styles")
 find_library(LIB_QT_WIN NAMES qwindows PATHS "${QT_DIR}/plugins/platforms")
 
 target_link_libraries(${EXE} PRIVATE "$<IF:$<CONFIG:Debug>,${LIB_QT_PLATFORM_D},${LIB_QT_PLATFORM}>"
@@ -182,6 +187,8 @@ target_link_libraries(${EXE} PRIVATE "$<IF:$<CONFIG:Debug>,${LIB_QT_PLATFORM_D},
                       "$<IF:$<CONFIG:Debug>,${LIB_QT_UI_D},${LIB_QT_UI}>"
                       "$<IF:$<CONFIG:Debug>,${LIB_QT_EVENT_D},${LIB_QT_EVENT}>"
                       "$<IF:$<CONFIG:Debug>,${LIB_QT_THEME_D},${LIB_QT_THEME}>"
+                      "$<IF:$<CONFIG:Debug>,${LIB_WIN_UXTHEME_D},${LIB_WIN_UXTHEME}>"
+                      "$<IF:$<CONFIG:Debug>,${LIB_QT_WINVISTASTYLE_D},${LIB_QT_WINVISTASTYLE}>"
                       "$<IF:$<CONFIG:Debug>,${LIB_QT_WIN_D},${LIB_QT_WIN}>"
 					  )
 

--- a/CmakeLists.txt
+++ b/CmakeLists.txt
@@ -83,7 +83,8 @@ set(RGM_UI
 )
 
 set(RGM_RC
-	images.qrc
+    images.qrc
+    resources.rc
 )
 
 # Check for QScintilla
@@ -159,7 +160,7 @@ target_link_libraries(${EXE} PRIVATE OpenSSL::SSL OpenSSL::Crypto)
 
 # Find Qt
 find_package(Qt5 COMPONENTS Core Widgets Gui REQUIRED)
-target_link_libraries(${EXE} PRIVATE Qt5::Core Qt5::WinMain Qt5::Core Qt5::Widgets Qt5::Gui Qt5::Gui Qt5::QGifPlugin Qt5::QICOPlugin)
+target_link_libraries(${EXE} PRIVATE Qt5::Core Qt5::WinMain Qt5::Core Qt5::Widgets Qt5::Gui Qt5::Gui)
 
 # Debug
 find_library(LIB_QT_PLATFORM_D NAMES Qt5PlatformCompositorSupportd)
@@ -167,6 +168,9 @@ find_library(LIB_QT_FONT_D NAMES Qt5FontDatabaseSupportd)
 find_library(LIB_QT_UI_D NAMES Qt5WindowsUIAutomationSupportd)
 find_library(LIB_QT_EVENT_D NAMES Qt5EventDispatcherSupportd)
 find_library(LIB_QT_THEME_D NAMES Qt5ThemeSupportd)
+find_library(LIB_QT_ICO_D NAMES qicod PATHS "${QT_DIR}/plugins/imageformats")
+find_library(LIB_QT_GIF_D NAMES qgifd PATHS "${QT_DIR}/plugins/imageformats")
+find_library(LIB_QT_JPEG_D NAMES qjpegd PATHS "${QT_DIR}/plugins/imageformats")
 # Windows 10 SDK doesn't include a debug version of Uxtheme
 find_library(LIB_WIN_UXTHEME_D NAMES Uxtheme)
 find_library(LIB_QT_WINVISTASTYLE_D NAMES qwindowsvistastyled PATHS "${QT_DIR}/plugins/styles")
@@ -177,6 +181,12 @@ find_library(LIB_QT_FONT NAMES Qt5FontDatabaseSupport)
 find_library(LIB_QT_UI NAMES Qt5WindowsUIAutomationSupport)
 find_library(LIB_QT_EVENT NAMES Qt5EventDispatcherSupport)
 find_library(LIB_QT_THEME NAMES Qt5ThemeSupport)
+# ICO is needed to set Win32 icon on the Window
+# also all 3 of these image plugins are very small
+# even combined they are only 300kb~
+find_library(LIB_QT_ICO NAMES qico PATHS "${QT_DIR}/plugins/imageformats")
+find_library(LIB_QT_GIF NAMES qgif PATHS "${QT_DIR}/plugins/imageformats")
+find_library(LIB_QT_JPEG NAMES qjpeg PATHS "${QT_DIR}/plugins/imageformats")
 find_library(LIB_WIN_UXTHEME NAMES Uxtheme)
 find_library(LIB_QT_WINVISTASTYLE NAMES qwindowsvistastyle PATHS "${QT_DIR}/plugins/styles")
 find_library(LIB_QT_WIN NAMES qwindows PATHS "${QT_DIR}/plugins/platforms")
@@ -186,6 +196,9 @@ target_link_libraries(${EXE} PRIVATE "$<IF:$<CONFIG:Debug>,${LIB_QT_PLATFORM_D},
                       "$<IF:$<CONFIG:Debug>,${LIB_QT_UI_D},${LIB_QT_UI}>"
                       "$<IF:$<CONFIG:Debug>,${LIB_QT_EVENT_D},${LIB_QT_EVENT}>"
                       "$<IF:$<CONFIG:Debug>,${LIB_QT_THEME_D},${LIB_QT_THEME}>"
+                      "$<IF:$<CONFIG:Debug>,${LIB_QT_ICO_D},${LIB_QT_ICO}>"
+                      "$<IF:$<CONFIG:Debug>,${LIB_QT_GIF_D},${LIB_QT_GIF}>"
+                      "$<IF:$<CONFIG:Debug>,${LIB_QT_JPEG_D},${LIB_QT_JPEG}>"
                       "$<IF:$<CONFIG:Debug>,${LIB_WIN_UXTHEME_D},${LIB_WIN_UXTHEME}>"
                       "$<IF:$<CONFIG:Debug>,${LIB_QT_WINVISTASTYLE_D},${LIB_QT_WINVISTASTYLE}>"
                       "$<IF:$<CONFIG:Debug>,${LIB_QT_WIN_D},${LIB_QT_WIN}>"

--- a/CmakeLists.txt
+++ b/CmakeLists.txt
@@ -210,4 +210,4 @@ find_library(LIB_DOUBLE_CONVERSION NAMES double-conversion)
 target_link_libraries(${EXE} PRIVATE ${LIB_DOUBLE_CONVERSION})
 
 # Windows is a turd
-target_link_libraries(${EXE} PRIVATE Ws2_32 Wldap32 Crypt32 Winmm Userenv Netapi32 Mincore Dwmapi Imm32)
+target_link_libraries(${EXE} PRIVATE Ws2_32 Wldap32 Crypt32 Winmm Userenv Netapi32 version Dwmapi Imm32)

--- a/CmakeLists.txt
+++ b/CmakeLists.txt
@@ -4,6 +4,10 @@ set(EXE "RadialGM")
 set(EXE_VERSION "0.1")
 set(EXE_DESCRIPTION "ENIGMA IDE")
 
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+
 project(RadialGM)
 
 # Find includes in corresponding build directories

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-RadialGM
+RadialGM [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/2cbx3fso760stn7s?svg=true)](https://ci.appveyor.com/project/enigma-dev/RadialGM)
 ==================
 This project is an experimental C++ IDE for ENIGMA written in the [Qt Framework](https://www.qt.io/). The design of the program is a multilayer architecture using the [Google protocol buffer](https://developers.google.com/protocol-buffers/) format from ENIGMA's compiler backend for the data model layer in the resource editors. The resource editors are designed using Qt Creator or Qt Designer and saved in UI layout files. Their corresponding C++ classes bind the widgets in the layout files to the data model using QDataWidgetMapper and a custom resource model that hooks into arbitrary protobuf messages.

--- a/RadialGM.pro
+++ b/RadialGM.pro
@@ -11,12 +11,12 @@ greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
 
 win32:RC_ICONS += images/icon.ico
 
-TARGET = ENIGMA
+TARGET = RadialGM
 TEMPLATE = app
 VERSION = 0.0.0.0
 
 QMAKE_TARGET_COMPANY = ENIGMA Dev Team
-QMAKE_TARGET_PRODUCT = ENIGMA Development Environment
+QMAKE_TARGET_PRODUCT = RadialGM IDE
 QMAKE_TARGET_DESCRIPTION = ENIGMA Development Environment
 QMAKE_TARGET_COPYRIGHT = "Copyright \\251 2007-2018 ENIGMA Dev Team"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,23 +27,16 @@ environment:
   GENERATOR: "Visual Studio 15 2017"
 
 init:
-  - call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars32.bat"
-
-for:
-  # override build type for release
-  - matrix:
-      only:
-        - configuration: Release
-    environment:
-      BUILD_TYPE: MinSizeRel
-  - matrix:
-      only:
-        - platform: x64
-    # override init and generator name for x64
-    init:
-      - call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
-    environment:
-      GENERATOR: "Visual Studio 15 2017 Win64"
+  - ps: |
+      if ($env:configuration -eq "Release") {
+        $env:BUILD_TYPE = "MinSizeRel"
+      }
+      if ($env:platform -eq "x64") {
+        cmd.exe /C "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
+        $env:GENERATOR = "Visual Studio 15 2017 Win64"
+      } else {
+        cmd.exe /C "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars32.bat"
+      }
 
 install:
   - echo %BUILD_TYPE%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -49,21 +49,22 @@ install:
       $apiURL = "https://api.github.com/repos/enigma-dev/radialgm-deps/releases/latest"
       $latest = Invoke-RestMethod -Method Get -Uri $apiURL
       # find the asset whose name matches the architecture of this build
+      $depsName = "rgmdeps-$env:platform.zip"
       foreach ($asset in $latest.assets) {
         Write-Host $asset.name
-        if ($asset.name -eq "rgmdeps-$env:platform.zip") {
-          $assetURL = $asset.browser_download_url
+        if ($asset.name -eq $depsName) {
+          $depsURL = $asset.browser_download_url
           break
         }
       }
-      Write-Host $assetURL
+      Write-Host $depsURL
 
-      # download and extract the previous deps so we can amend them
-      #appveyor DownloadFile ($artifactsURL + $env:ARTIFACT_NAME) -FileName $env:ARTIFACT_NAME
-      #7z e -mmt $env:ARTIFACT_NAME C:\tools\vcpkg\installed\$env:TRIPLET
+      # download and extract the deps matching this job's architecture
+      appveyor DownloadFile $depsURL -FileName $depsName
+      7z e -mmt $depsName C:\tools\vcpkg\installed\$env:TRIPLET
   - exit 1
-  - appveyor DownloadFile %DEPSURL% -FileName vcpkgdeps.zip
-  - 7z e -mmt vcpkgdeps.zip -y -o%VCPKG_DIR%\installed\%TRIPLET_NAME%
+  #- appveyor DownloadFile %DEPSURL% -FileName vcpkgdeps.zip
+  #- 7z e -mmt vcpkgdeps.zip -y -o%VCPKG_DIR%\installed\%TRIPLET_NAME%
 
 build_script:
   - cd %APPVEYOR_BUILD_FOLDER%\Submodules\enigma-dev\CommandLine\protos

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -76,7 +76,7 @@ build_script:
   - mkdir build && cd build
   - cmake -G "Visual Studio 15 2017 Win64" -DCMAKE_BUILD_TYPE=%BUILD_TYPE% -DVCPKG_TARGET_TRIPLET=%TRIPLET_NAME% -DCMAKE_TOOLCHAIN_FILE="%VCPKG_DIR%\scripts\buildsystems\vcpkg.cmake" ..
   - cmake --build . --target ALL_BUILD --config %BUILD_TYPE%
-  - appveyor PushArtifact bin\%BUILD_TYPE%\RadialGM.exe -FileName RadialGM-Win32-$(CONFIGURATION)-$(PLATFORM).exe -DeploymentName RadialGM
+  - appveyor PushArtifact %BUILD_TYPE%\RadialGM.exe -FileName RadialGM-Win32-$(CONFIGURATION)-$(PLATFORM).exe -DeploymentName RadialGM
 
 deploy:
   release: RadialGM-v$(appveyor_build_version)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ branches:
     - master
 
 # Build worker image (VM template)
-image: Visual Studio 2017
+image: Previous Visual Studio 2017
 
 # since we're pushing releases we don't want infinite recursion
 # because the release pushes a tag, hence we aren't building on tags

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -50,7 +50,7 @@ for:
 install:
   - echo %DEPSURL%
   - appveyor DownloadFile %DEPSURL% -FileName vcpkgdeps.zip
-  - 7z e -mmt vcpkgdeps.zip -oC:\tools\vcpkg\installed\%TRIPLET_NAME%
+  - 7z e -mmt vcpkgdeps.zip -y -oC:\tools\vcpkg\installed\%TRIPLET_NAME%
 
 build_script:
   - mkdir enigma-dev/CommandLine/protos/build

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -48,7 +48,8 @@ for:
     BUILD_TYPE: MinSizeRel
 
 install:
-  - appveyor DownloadFile $DEPSURL -FileName vcpkgdeps.zip
+  - echo $(DEPSURL)
+  - appveyor DownloadFile $(DEPSURL) -FileName vcpkgdeps.zip
   - 7z e -mmt vcpkgdeps.zip -oC:\tools\vcpkg\installed\$(TRIPLET_NAME)
 
 build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -61,7 +61,7 @@ install:
 
       # download and extract the deps matching this job's architecture
       appveyor DownloadFile $depsURL -FileName $depsName
-      7z e -mmt $depsName C:\tools\vcpkg\installed\$env:TRIPLET
+      7z x -mmt $depsName -oC:\tools\vcpkg
 
 build_script:
   - cd %APPVEYOR_BUILD_FOLDER%\Submodules\enigma-dev\CommandLine\protos

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,13 +27,9 @@ environment:
   GENERATOR: "Visual Studio 15 2017"
 
 init:
-  - if %PLATFORM% == x64 call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
+  - call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" %PLATFORM%
   - if %PLATFORM% == x64 set GENERATOR="Visual Studio 15 2017 Win64"
-  - if %PLATFORM% == x86 call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars32.bat"
-  - ps: |
-      if ($env:configuration -eq "Release") {
-        $env:BUILD_TYPE = "MinSizeRel"
-      }
+  - if %CONFIGURATION% == Release set BUILD_TYPE="MinSizeRel"
 
 install:
   - git submodule update --init --recursive

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,8 +28,8 @@ environment:
 
 init:
   - call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" %PLATFORM%
-  - if %PLATFORM% == x64 set GENERATOR="Visual Studio 15 2017 Win64"
-  - if %CONFIGURATION% == Release set BUILD_TYPE="MinSizeRel"
+  - if %PLATFORM% == x64 set GENERATOR=Visual Studio 15 2017 Win64
+  - if %CONFIGURATION% == Release set BUILD_TYPE=MinSizeRel
 
 install:
   - git submodule update --init --recursive

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -66,17 +66,17 @@ install:
 build_script:
   - cd %APPVEYOR_BUILD_FOLDER%\Submodules\enigma-dev\CommandLine\protos
   - mkdir build && cd build
-  - cmake -G "Visual Studio 15 2017" -DCMAKE_BUILD_TYPE=%BUILD_TYPE% -Dprotobuf_generate_IMPORT_DIRS="%VCPKG_DIR%\installed\%TRIPLET_NAME%\include" -DVCPKG_TARGET_TRIPLET=%TRIPLET_NAME% -DCMAKE_TOOLCHAIN_FILE="%VCPKG_DIR%\scripts\buildsystems\vcpkg.cmake" ..
+  - cmake -G "Visual Studio 15 2017" -A %PLATFORM% -DCMAKE_BUILD_TYPE=%BUILD_TYPE% -Dprotobuf_generate_IMPORT_DIRS="%VCPKG_DIR%\installed\%TRIPLET_NAME%\include" -DVCPKG_TARGET_TRIPLET=%TRIPLET_NAME% -DCMAKE_TOOLCHAIN_FILE="%VCPKG_DIR%\scripts\buildsystems\vcpkg.cmake" ..
   - cmake --build . --target install --config %BUILD_TYPE%
   - cd %APPVEYOR_BUILD_FOLDER%\Submodules\enigma-dev\CommandLine\libEGM
   - mkdir build && cd build
-  - cmake -G "Visual Studio 15 2017" -DCMAKE_BUILD_TYPE=%BUILD_TYPE% -DVCPKG_TARGET_TRIPLET=%TRIPLET_NAME% -DCMAKE_TOOLCHAIN_FILE="%VCPKG_DIR%\scripts\buildsystems\vcpkg.cmake" ..
+  - cmake -G "Visual Studio 15 2017" -A %PLATFORM% -DCMAKE_BUILD_TYPE=%BUILD_TYPE% -DVCPKG_TARGET_TRIPLET=%TRIPLET_NAME% -DCMAKE_TOOLCHAIN_FILE="%VCPKG_DIR%\scripts\buildsystems\vcpkg.cmake" ..
   - cmake --build . --target install --config %BUILD_TYPE%
   - cd %APPVEYOR_BUILD_FOLDER%
   - mkdir build && cd build
-  - cmake -G "Visual Studio 15 2017" -DCMAKE_BUILD_TYPE=%BUILD_TYPE% -DVCPKG_TARGET_TRIPLET=%TRIPLET_NAME% -DCMAKE_TOOLCHAIN_FILE="%VCPKG_DIR%\scripts\buildsystems\vcpkg.cmake" ..
+  - cmake -G "Visual Studio 15 2017" -A %PLATFORM% -DCMAKE_BUILD_TYPE=%BUILD_TYPE% -DVCPKG_TARGET_TRIPLET=%TRIPLET_NAME% -DCMAKE_TOOLCHAIN_FILE="%VCPKG_DIR%\scripts\buildsystems\vcpkg.cmake" ..
   - cmake --build . --target ALL_BUILD --config %BUILD_TYPE%
-  - appveyor PushArtifact %BUILD_TYPE%\RadialGM.exe -FileName RadialGM-Win32-$(CONFIGURATION)-$(PLATFORM).exe -DeploymentName RadialGM
+  - appveyor PushArtifact %BUILD_TYPE%\RadialGM.exe -FileName RadialGM-Win32-%CONFIGURATION%-%PLATFORM%.exe -DeploymentName RadialGM
 
 deploy:
   release: RadialGM-v$(appveyor_build_version)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -48,24 +48,23 @@ for:
     BUILD_TYPE: MinSizeRel
 
 install:
-  - cd %APPVEYOR_BUILD_FOLDER%
   - appveyor DownloadFile %DEPSURL% -FileName vcpkgdeps.zip
   - 7z e -mmt vcpkgdeps.zip -y -oC:\tools\vcpkg\installed\%TRIPLET_NAME%
 
 build_script:
-  - mkdir enigma-dev/CommandLine/protos/build
-  - cd enigma-dev/CommandLine/protos/build
+  - mkdir enigma-dev\CommandLine\protos\build
+  - cd enigma-dev\CommandLine\protos\build
   - cmake -G "Visual Studio 15 2017 Win64" -DCMAKE_BUILD_TYPE=%BUILD_TYPE% -Dprotobuf_generate_IMPORT_DIRS="C:\vcpkg\installed\%TRIPLET_NAME%\include" -DVCPKG_TARGET_TRIPLET=%TRIPLET_NAME% -DCMAKE_TOOLCHAIN_FILE="C:\vcpkg\scripts\buildsystems\vcpkg.cmake" ..
   - cmake --build . --target install --config %BUILD_TYPE%
-  - mkdir enigma-dev/CommandLine/libEGM/build
-  - cd enigma-dev/CommandLine/libEGM/build
+  - mkdir enigma-dev\CommandLine\libEGM\build
+  - cd enigma-dev\CommandLine\libEGM\build
   - cmake -G "Visual Studio 15 2017 Win64" -DCMAKE_BUILD_TYPE=%BUILD_TYPE% -DVCPKG_TARGET_TRIPLET=%TRIPLET_NAME% -DCMAKE_TOOLCHAIN_FILE="C:\vcpkg\scripts\buildsystems\vcpkg.cmake" ..
   - cmake --build . --target install --config %BUILD_TYPE%
-  - mkdir RadialGM/build
-  - cd RadialGM/build
+  - mkdir RadialGM\build
+  - cd RadialGM\build
   - cmake -G "Visual Studio 15 2017 Win64" -DCMAKE_BUILD_TYPE=%BUILD_TYPE% -DVCPKG_TARGET_TRIPLET=%TRIPLET_NAME% -DCMAKE_TOOLCHAIN_FILE="C:\vcpkg\scripts\buildsystems\vcpkg.cmake" ..
   - cmake --build . --target ALL_BUILD --config %BUILD_TYPE%
-  - appveyor PushArtifact %BUILD_TYPE%/RadialGM.exe -FileName RadialGM-Win32-$(CONFIGURATION)-$(PLATFORM).exe -DeploymentName RadialGM
+  - appveyor PushArtifact %BUILD_TYPE%\RadialGM.exe -FileName RadialGM-Win32-$(CONFIGURATION)-$(PLATFORM).exe -DeploymentName RadialGM
 
 deploy:
   release: RadialGM-v$(appveyor_build_version)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -52,15 +52,15 @@ install:
   - 7z e -mmt vcpkgdeps.zip -y -oC:\tools\vcpkg\installed\%TRIPLET_NAME%
 
 build_script:
-  - sh: mkdir enigma-dev/CommandLine/protos/build
+  - mkdir -p enigma-dev/CommandLine/protos/build
   - cd enigma-dev/CommandLine/protos/build
   - cmake -G "Visual Studio 15 2017 Win64" -DCMAKE_BUILD_TYPE=%BUILD_TYPE% -Dprotobuf_generate_IMPORT_DIRS="C:\vcpkg\installed\%TRIPLET_NAME%\include" -DVCPKG_TARGET_TRIPLET=%TRIPLET_NAME% -DCMAKE_TOOLCHAIN_FILE="C:\vcpkg\scripts\buildsystems\vcpkg.cmake" ..
   - cmake --build . --target install --config %BUILD_TYPE%
-  - sh: mkdir enigma-dev/CommandLine/libEGM/build
+  - mkdir -p enigma-dev/CommandLine/libEGM/build
   - cd enigma-dev/CommandLine/libEGM/build
   - cmake -G "Visual Studio 15 2017 Win64" -DCMAKE_BUILD_TYPE=%BUILD_TYPE% -DVCPKG_TARGET_TRIPLET=%TRIPLET_NAME% -DCMAKE_TOOLCHAIN_FILE="C:\vcpkg\scripts\buildsystems\vcpkg.cmake" ..
   - cmake --build . --target install --config %BUILD_TYPE%
-  - sh: mkdir RadialGM/build
+  - mkdir -p RadialGM/build
   - cd RadialGM/build
   - cmake -G "Visual Studio 15 2017 Win64" -DCMAKE_BUILD_TYPE=%BUILD_TYPE% -DVCPKG_TARGET_TRIPLET=%TRIPLET_NAME% -DCMAKE_TOOLCHAIN_FILE="C:\vcpkg\scripts\buildsystems\vcpkg.cmake" ..
   - cmake --build . --target ALL_BUILD --config %BUILD_TYPE%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,12 +32,14 @@ for:
   init:
   - call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
   environment:
-    GENERATOR_SUFFIX: "Win64"
+    GENERATOR: "Visual Studio 15 2017 Win64"
 - matrix:
     only:
       - platform: x86
   init:
   - call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars32.bat"
+  environment:
+    GENERATOR: "Visual Studio 15 2017"
 - matrix:
     only:
       - configuration: Release
@@ -68,15 +70,15 @@ install:
 build_script:
   - cd %APPVEYOR_BUILD_FOLDER%\Submodules\enigma-dev\CommandLine\protos
   - mkdir build && cd build
-  - cmake -G "Visual Studio 15 2017 %GENERATOR_SUFFIX%" -DCMAKE_BUILD_TYPE=%BUILD_TYPE% -Dprotobuf_generate_IMPORT_DIRS="%VCPKG_DIR%\installed\%TRIPLET_NAME%\include" -DVCPKG_TARGET_TRIPLET=%TRIPLET_NAME% -DCMAKE_TOOLCHAIN_FILE="%VCPKG_DIR%\scripts\buildsystems\vcpkg.cmake" ..
+  - cmake -G "%GENERATOR%" -DCMAKE_BUILD_TYPE=%BUILD_TYPE% -Dprotobuf_generate_IMPORT_DIRS="%VCPKG_DIR%\installed\%TRIPLET_NAME%\include" -DVCPKG_TARGET_TRIPLET=%TRIPLET_NAME% -DCMAKE_TOOLCHAIN_FILE="%VCPKG_DIR%\scripts\buildsystems\vcpkg.cmake" ..
   - cmake --build . --target install --config %BUILD_TYPE%
   - cd %APPVEYOR_BUILD_FOLDER%\Submodules\enigma-dev\CommandLine\libEGM
   - mkdir build && cd build
-  - cmake -G "Visual Studio 15 2017 %GENERATOR_SUFFIX%" -DCMAKE_BUILD_TYPE=%BUILD_TYPE% -DVCPKG_TARGET_TRIPLET=%TRIPLET_NAME% -DCMAKE_TOOLCHAIN_FILE="%VCPKG_DIR%\scripts\buildsystems\vcpkg.cmake" ..
+  - cmake -G "%GENERATOR%" -DCMAKE_BUILD_TYPE=%BUILD_TYPE% -DVCPKG_TARGET_TRIPLET=%TRIPLET_NAME% -DCMAKE_TOOLCHAIN_FILE="%VCPKG_DIR%\scripts\buildsystems\vcpkg.cmake" ..
   - cmake --build . --target install --config %BUILD_TYPE%
   - cd %APPVEYOR_BUILD_FOLDER%
   - mkdir build && cd build
-  - cmake -G "Visual Studio 15 2017 %GENERATOR_SUFFIX%" -DCMAKE_BUILD_TYPE=%BUILD_TYPE% -DVCPKG_TARGET_TRIPLET=%TRIPLET_NAME% -DCMAKE_TOOLCHAIN_FILE="%VCPKG_DIR%\scripts\buildsystems\vcpkg.cmake" ..
+  - cmake -G "%GENERATOR%" -DCMAKE_BUILD_TYPE=%BUILD_TYPE% -DVCPKG_TARGET_TRIPLET=%TRIPLET_NAME% -DCMAKE_TOOLCHAIN_FILE="%VCPKG_DIR%\scripts\buildsystems\vcpkg.cmake" ..
   - cmake --build . --target ALL_BUILD --config %BUILD_TYPE%
   - appveyor PushArtifact %BUILD_TYPE%\RadialGM.exe -FileName RadialGM-Win32-%CONFIGURATION%-%PLATFORM%.exe -DeploymentName RadialGM
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -48,24 +48,24 @@ for:
     BUILD_TYPE: MinSizeRel
 
 install:
-  - echo $(DEPSURL)
-  - appveyor DownloadFile $(DEPSURL) -FileName vcpkgdeps.zip
-  - 7z e -mmt vcpkgdeps.zip -oC:\tools\vcpkg\installed\$(TRIPLET_NAME)
+  - echo %DEPSURL%
+  - appveyor DownloadFile %DEPSURL% -FileName vcpkgdeps.zip
+  - 7z e -mmt vcpkgdeps.zip -oC:\tools\vcpkg\installed\%TRIPLET_NAME%
 
 build_script:
   - mkdir enigma-dev/CommandLine/protos/build
   - cd enigma-dev/CommandLine/protos/build
-  - cmake -G "Visual Studio 15 2017 Win64" -DCMAKE_BUILD_TYPE=$(BUILD_TYPE) -Dprotobuf_generate_IMPORT_DIRS="C:\vcpkg\installed\$(TRIPLET_NAME)\include" -DVCPKG_TARGET_TRIPLET=$(TRIPLET_NAME) -DCMAKE_TOOLCHAIN_FILE="C:\vcpkg\scripts\buildsystems\vcpkg.cmake" ..
-  - cmake --build . --target install --config $(BUILD_TYPE)
+  - cmake -G "Visual Studio 15 2017 Win64" -DCMAKE_BUILD_TYPE=%BUILD_TYPE% -Dprotobuf_generate_IMPORT_DIRS="C:\vcpkg\installed\%TRIPLET_NAME%\include" -DVCPKG_TARGET_TRIPLET=%TRIPLET_NAME% -DCMAKE_TOOLCHAIN_FILE="C:\vcpkg\scripts\buildsystems\vcpkg.cmake" ..
+  - cmake --build . --target install --config %BUILD_TYPE%
   - mkdir enigma-dev/CommandLine/libEGM/build
   - cd enigma-dev/CommandLine/libEGM/build
-  - cmake -G "Visual Studio 15 2017 Win64" -DCMAKE_BUILD_TYPE=$(BUILD_TYPE) -DVCPKG_TARGET_TRIPLET=$(TRIPLET_NAME) -DCMAKE_TOOLCHAIN_FILE="C:\vcpkg\scripts\buildsystems\vcpkg.cmake" ..
-  - cmake --build . --target install --config $(BUILD_TYPE)
+  - cmake -G "Visual Studio 15 2017 Win64" -DCMAKE_BUILD_TYPE=%BUILD_TYPE% -DVCPKG_TARGET_TRIPLET=%TRIPLET_NAME% -DCMAKE_TOOLCHAIN_FILE="C:\vcpkg\scripts\buildsystems\vcpkg.cmake" ..
+  - cmake --build . --target install --config %BUILD_TYPE%
   - mkdir RadialGM/build
   - cd RadialGM/build
-  - cmake -G "Visual Studio 15 2017 Win64" -DCMAKE_BUILD_TYPE=$(BUILD_TYPE) -DVCPKG_TARGET_TRIPLET=$(TRIPLET_NAME) -DCMAKE_TOOLCHAIN_FILE="C:\vcpkg\scripts\buildsystems\vcpkg.cmake" ..
-  - cmake --build . --target ALL_BUILD --config $(BUILD_TYPE)
-  - appveyor PushArtifact $(BUILD_TYPE)/RadialGM.exe -FileName RadialGM-Win32-$(CONFIGURATION)-$(PLATFORM).exe -DeploymentName RadialGM
+  - cmake -G "Visual Studio 15 2017 Win64" -DCMAKE_BUILD_TYPE=%BUILD_TYPE% -DVCPKG_TARGET_TRIPLET=%TRIPLET_NAME% -DCMAKE_TOOLCHAIN_FILE="C:\vcpkg\scripts\buildsystems\vcpkg.cmake" ..
+  - cmake --build . --target ALL_BUILD --config %BUILD_TYPE%
+  - appveyor PushArtifact %BUILD_TYPE%/RadialGM.exe -FileName RadialGM-Win32-$(CONFIGURATION)-$(PLATFORM).exe -DeploymentName RadialGM
 
 deploy:
   release: RadialGM-v$(appveyor_build_version)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -52,19 +52,19 @@ install:
   - 7z e -mmt vcpkgdeps.zip -y -oC:\tools\vcpkg\installed\%TRIPLET_NAME%
 
 build_script:
-  - mkdir enigma-dev\CommandLine\protos\build
-  - cd enigma-dev\CommandLine\protos\build
-  - cmake -G "Visual Studio 15 2017 Win64" -DCMAKE_BUILD_TYPE=%BUILD_TYPE% -Dprotobuf_generate_IMPORT_DIRS="C:\vcpkg\installed\%TRIPLET_NAME%\include" -DVCPKG_TARGET_TRIPLET=%TRIPLET_NAME% -DCMAKE_TOOLCHAIN_FILE="C:\vcpkg\scripts\buildsystems\vcpkg.cmake" ..
+  #- mkdir enigma-dev\CommandLine\protos\build
+  - cd %APPVEYOR_BUILD_FOLDER%\Submodules\enigma-dev\CommandLine\protos
+  - cmake -G "Visual Studio 15 2017 Win64" -DCMAKE_BUILD_TYPE=%BUILD_TYPE% -Dprotobuf_generate_IMPORT_DIRS="C:\vcpkg\installed\%TRIPLET_NAME%\include" -DVCPKG_TARGET_TRIPLET=%TRIPLET_NAME% -DCMAKE_TOOLCHAIN_FILE="C:\vcpkg\scripts\buildsystems\vcpkg.cmake"
   - cmake --build . --target install --config %BUILD_TYPE%
-  - mkdir enigma-dev\CommandLine\libEGM\build
-  - cd enigma-dev\CommandLine\libEGM\build
-  - cmake -G "Visual Studio 15 2017 Win64" -DCMAKE_BUILD_TYPE=%BUILD_TYPE% -DVCPKG_TARGET_TRIPLET=%TRIPLET_NAME% -DCMAKE_TOOLCHAIN_FILE="C:\vcpkg\scripts\buildsystems\vcpkg.cmake" ..
+  #- mkdir enigma-dev\CommandLine\libEGM\build
+  - cd %APPVEYOR_BUILD_FOLDER%\Submodules\enigma-dev\CommandLine\libEGM
+  - cmake -G "Visual Studio 15 2017 Win64" -DCMAKE_BUILD_TYPE=%BUILD_TYPE% -DVCPKG_TARGET_TRIPLET=%TRIPLET_NAME% -DCMAKE_TOOLCHAIN_FILE="C:\vcpkg\scripts\buildsystems\vcpkg.cmake"
   - cmake --build . --target install --config %BUILD_TYPE%
-  - mkdir RadialGM\build
-  - cd RadialGM\build
-  - cmake -G "Visual Studio 15 2017 Win64" -DCMAKE_BUILD_TYPE=%BUILD_TYPE% -DVCPKG_TARGET_TRIPLET=%TRIPLET_NAME% -DCMAKE_TOOLCHAIN_FILE="C:\vcpkg\scripts\buildsystems\vcpkg.cmake" ..
+  #- mkdir RadialGM\build
+  - cd %APPVEYOR_BUILD_FOLDER%
+  - cmake -G "Visual Studio 15 2017 Win64" -DCMAKE_BUILD_TYPE=%BUILD_TYPE% -DVCPKG_TARGET_TRIPLET=%TRIPLET_NAME% -DCMAKE_TOOLCHAIN_FILE="C:\vcpkg\scripts\buildsystems\vcpkg.cmake"
   - cmake --build . --target ALL_BUILD --config %BUILD_TYPE%
-  - appveyor PushArtifact %BUILD_TYPE%\RadialGM.exe -FileName RadialGM-Win32-$(CONFIGURATION)-$(PLATFORM).exe -DeploymentName RadialGM
+  - appveyor PushArtifact bin\%BUILD_TYPE%\RadialGM.exe -FileName RadialGM-Win32-$(CONFIGURATION)-$(PLATFORM).exe -DeploymentName RadialGM
 
 deploy:
   release: RadialGM-v$(appveyor_build_version)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -46,6 +46,7 @@ for:
 
 install:
   - git submodule update --init --recursive
+  - vcpkg install protobuf:%TRIPLET_NAME%
   - appveyor DownloadFile %DEPSURL% -FileName vcpkgdeps.zip
   - 7z e -mmt vcpkgdeps.zip -y -o%VCPKG_DIR%\installed\%TRIPLET_NAME%
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,41 +16,64 @@ platform:
   - x86
   - x64
 
+configuration:
+  - Debug
+  - Release
+
+environment:
+  TRIPLET_NAME: $(PLATFORM)-windows-static
+  BUILD_TYPE: Debug
+
 for:
 - matrix:
     only:
       - platform: x64
-      # TODO: change to GitHub releases
-      - depsurl: https://ci.appveyor.com/api/buildjobs/xrs6idr9f2grmmy8/artifacts/rgmdeps-x64.zip
+  environment:
+    # TODO: change to GitHub releases
+    DEPSURL: https://ci.appveyor.com/api/buildjobs/xrs6idr9f2grmmy8/artifacts/rgmdeps-x64.zip
   init:
   - call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
 - matrix:
     only:
       - platform: x86
-      # TODO: change to GitHub releases
-      - depsurl: https://ci.appveyor.com/api/buildjobs/uw0lf6xbgwkfp443/artifacts/rgmdeps-x86.zip
+  environment:
+    # TODO: change to GitHub releases
+    DEPSURL: https://ci.appveyor.com/api/buildjobs/uw0lf6xbgwkfp443/artifacts/rgmdeps-x86.zip
   init:
   - call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars32.bat"
+- matrix:
+    only:
+      - configuration: Release
+  environment:
+    BUILD_TYPE: MinSizeRel
 
 install:
   - cd C:\tools\vcpkg\installed
-  - appveyor DownloadFile $depsurl -FileName vcpkgdeps.zip
-  - 7z e -mmt vcpkgdeps.zip -o$(PLATFORM)-windows-static
+  - appveyor DownloadFile $DEPSURL -FileName vcpkgdeps.zip
+  - 7z e -mmt vcpkgdeps.zip -o$(TRIPLET_NAME)
   - cd %APPVEYOR_BUILD_FOLDER%
 
 build_script:
-  - echo Hello Build!
-
-artifacts:
-  - path: RadialGM-Win32-$(PLATFORM).zip
-    name: RadialGM-Win32-$(PLATFORM)
+  - mkdir enigma-dev/CommandLine/protos/build
+  - cd enigma-dev/CommandLine/protos/build
+  - cmake -G "Visual Studio 15 2017 Win64" -DCMAKE_BUILD_TYPE=$(BUILD_TYPE) -Dprotobuf_generate_IMPORT_DIRS="C:\vcpkg\installed\$(TRIPLET_NAME)\include" -DVCPKG_TARGET_TRIPLET=$(TRIPLET_NAME) -DCMAKE_TOOLCHAIN_FILE="C:\vcpkg\scripts\buildsystems\vcpkg.cmake" ..
+  - cmake --build . --target install --config $(BUILD_TYPE)
+  - mkdir enigma-dev/CommandLine/libEGM/build
+  - cd enigma-dev/CommandLine/libEGM/build
+  - cmake -G "Visual Studio 15 2017 Win64" -DCMAKE_BUILD_TYPE=$(BUILD_TYPE) -DVCPKG_TARGET_TRIPLET=$(TRIPLET_NAME) -DCMAKE_TOOLCHAIN_FILE="C:\vcpkg\scripts\buildsystems\vcpkg.cmake" ..
+  - cmake --build . --target install --config $(BUILD_TYPE)
+  - mkdir RadialGM/build
+  - cd RadialGM/build
+  - cmake -G "Visual Studio 15 2017 Win64" -DCMAKE_BUILD_TYPE=$(BUILD_TYPE) -DVCPKG_TARGET_TRIPLET=$(TRIPLET_NAME) -DCMAKE_TOOLCHAIN_FILE="C:\vcpkg\scripts\buildsystems\vcpkg.cmake" ..
+  - cmake --build . --target ALL_BUILD --config $(BUILD_TYPE)
+  - appveyor PushArtifact $(BUILD_TYPE)/RadialGM.exe -FileName RadialGM-Win32-$(CONFIGURATION)-$(PLATFORM).exe -DeploymentName RadialGM
 
 deploy:
   release: RadialGM-v$(appveyor_build_version)
   provider: GitHub
   auth_token:
     secure: $(bot_push_on_green_token)
-  artifact: RadialGM-Win32-$(PLATFORM)
+  artifact: RadialGM
   draft: false
   prerelease: false
   on:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -62,16 +62,16 @@ build_script:
   - echo %BUILD_TYPE%
   - cd %APPVEYOR_BUILD_FOLDER%\Submodules\enigma-dev\CommandLine\protos
   - mkdir build && cd build
-  - cmake -G "%GENERATOR%" -DCMAKE_BUILD_TYPE=%BUILD_TYPE% -Dprotobuf_generate_IMPORT_DIRS="%VCPKG_DIR%\installed\%TRIPLET_NAME%\include" -DVCPKG_TARGET_TRIPLET=%TRIPLET_NAME% -DCMAKE_TOOLCHAIN_FILE="%VCPKG_DIR%\scripts\buildsystems\vcpkg.cmake" ..
-  - cmake --build . --target install --config %BUILD_TYPE%
+  - cmake -G "%GENERATOR%" -DCMAKE_BUILD_TYPE="%BUILD_TYPE%" -Dprotobuf_generate_IMPORT_DIRS="%VCPKG_DIR%\installed\%TRIPLET_NAME%\include" -DVCPKG_TARGET_TRIPLET=%TRIPLET_NAME% -DCMAKE_TOOLCHAIN_FILE="%VCPKG_DIR%\scripts\buildsystems\vcpkg.cmake" ..
+  - cmake --build . --target install --config "%BUILD_TYPE%"
   - cd %APPVEYOR_BUILD_FOLDER%\Submodules\enigma-dev\CommandLine\libEGM
   - mkdir build && cd build
-  - cmake -G "%GENERATOR%" -DCMAKE_BUILD_TYPE=%BUILD_TYPE% -DVCPKG_TARGET_TRIPLET=%TRIPLET_NAME% -DCMAKE_TOOLCHAIN_FILE="%VCPKG_DIR%\scripts\buildsystems\vcpkg.cmake" ..
-  - cmake --build . --target install --config %BUILD_TYPE%
+  - cmake -G "%GENERATOR%" -DCMAKE_BUILD_TYPE="%BUILD_TYPE%" -DVCPKG_TARGET_TRIPLET=%TRIPLET_NAME% -DCMAKE_TOOLCHAIN_FILE="%VCPKG_DIR%\scripts\buildsystems\vcpkg.cmake" ..
+  - cmake --build . --target install --config "%BUILD_TYPE%"
   - cd %APPVEYOR_BUILD_FOLDER%
   - mkdir build && cd build
-  - cmake -G "%GENERATOR%" -DCMAKE_BUILD_TYPE=%BUILD_TYPE% -DVCPKG_TARGET_TRIPLET=%TRIPLET_NAME% -DCMAKE_TOOLCHAIN_FILE="%VCPKG_DIR%\scripts\buildsystems\vcpkg.cmake" ..
-  - cmake --build . --target ALL_BUILD --config %BUILD_TYPE%
+  - cmake -G "%GENERATOR%" -DCMAKE_BUILD_TYPE="%BUILD_TYPE%" -DVCPKG_TARGET_TRIPLET=%TRIPLET_NAME% -DCMAKE_TOOLCHAIN_FILE="%VCPKG_DIR%\scripts\buildsystems\vcpkg.cmake" ..
+  - cmake --build . --target ALL_BUILD --config "%BUILD_TYPE%"
   - appveyor PushArtifact %BUILD_TYPE%\RadialGM.exe -FileName RadialGM-Win32-%CONFIGURATION%-%PLATFORM%.exe -DeploymentName RadialGM
 
 deploy:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -51,10 +51,14 @@ install:
       # find the asset whose name matches the architecture of this build
       foreach ($asset in $latest.assets) {
         Write-Host $asset.name
+        if ($asset.name -eq "rgmdeps-$env:platform.zip") {
+          $assetURL = $asset.browser_download_url
+          break
+        }
       }
+      Write-Host $assetURL
 
       # download and extract the previous deps so we can amend them
-      #$artifactsURL = "https://ci.appveyor.com/api/buildjobs/$archive_job/artifacts/"
       #appveyor DownloadFile ($artifactsURL + $env:ARTIFACT_NAME) -FileName $env:ARTIFACT_NAME
       #7z e -mmt $env:ARTIFACT_NAME C:\tools\vcpkg\installed\$env:TRIPLET
   - exit 1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,10 +8,6 @@ branches:
 # Build worker image (VM template)
 image: Visual Studio 2017
 
-# fetch repository as zip archive for faster clone
-shallow_clone: true
-clone_depth: 1
-
 platform:
   - x86
   - x64
@@ -48,11 +44,11 @@ for:
     BUILD_TYPE: MinSizeRel
 
 install:
+  - git submodule update --init --recursive
   - appveyor DownloadFile %DEPSURL% -FileName vcpkgdeps.zip
   - 7z e -mmt vcpkgdeps.zip -y -oC:\tools\vcpkg\installed\%TRIPLET_NAME%
 
 build_script:
-  - git submodule init --recursive
   #- mkdir enigma-dev\CommandLine\protos\build
   - cd %APPVEYOR_BUILD_FOLDER%\Submodules\enigma-dev\CommandLine\protos
   - cmake -G "Visual Studio 15 2017 Win64" -DCMAKE_BUILD_TYPE=%BUILD_TYPE% -Dprotobuf_generate_IMPORT_DIRS="C:\vcpkg\installed\%TRIPLET_NAME%\include" -DVCPKG_TARGET_TRIPLET=%TRIPLET_NAME% -DCMAKE_TOOLCHAIN_FILE="C:\vcpkg\scripts\buildsystems\vcpkg.cmake"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,6 +31,8 @@ for:
       - platform: x64
   init:
   - call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
+  environment:
+    GENERATOR_SUFFIX: "Win64"
 - matrix:
     only:
       - platform: x86
@@ -66,15 +68,15 @@ install:
 build_script:
   - cd %APPVEYOR_BUILD_FOLDER%\Submodules\enigma-dev\CommandLine\protos
   - mkdir build && cd build
-  - cmake -G "Visual Studio 15 2017" -A %PLATFORM% -DCMAKE_BUILD_TYPE=%BUILD_TYPE% -Dprotobuf_generate_IMPORT_DIRS="%VCPKG_DIR%\installed\%TRIPLET_NAME%\include" -DVCPKG_TARGET_TRIPLET=%TRIPLET_NAME% -DCMAKE_TOOLCHAIN_FILE="%VCPKG_DIR%\scripts\buildsystems\vcpkg.cmake" ..
+  - cmake -G "Visual Studio 15 2017 %GENERATOR_SUFFIX%" -DCMAKE_BUILD_TYPE=%BUILD_TYPE% -Dprotobuf_generate_IMPORT_DIRS="%VCPKG_DIR%\installed\%TRIPLET_NAME%\include" -DVCPKG_TARGET_TRIPLET=%TRIPLET_NAME% -DCMAKE_TOOLCHAIN_FILE="%VCPKG_DIR%\scripts\buildsystems\vcpkg.cmake" ..
   - cmake --build . --target install --config %BUILD_TYPE%
   - cd %APPVEYOR_BUILD_FOLDER%\Submodules\enigma-dev\CommandLine\libEGM
   - mkdir build && cd build
-  - cmake -G "Visual Studio 15 2017" -A %PLATFORM% -DCMAKE_BUILD_TYPE=%BUILD_TYPE% -DVCPKG_TARGET_TRIPLET=%TRIPLET_NAME% -DCMAKE_TOOLCHAIN_FILE="%VCPKG_DIR%\scripts\buildsystems\vcpkg.cmake" ..
+  - cmake -G "Visual Studio 15 2017 %GENERATOR_SUFFIX%" -DCMAKE_BUILD_TYPE=%BUILD_TYPE% -DVCPKG_TARGET_TRIPLET=%TRIPLET_NAME% -DCMAKE_TOOLCHAIN_FILE="%VCPKG_DIR%\scripts\buildsystems\vcpkg.cmake" ..
   - cmake --build . --target install --config %BUILD_TYPE%
   - cd %APPVEYOR_BUILD_FOLDER%
   - mkdir build && cd build
-  - cmake -G "Visual Studio 15 2017" -A %PLATFORM% -DCMAKE_BUILD_TYPE=%BUILD_TYPE% -DVCPKG_TARGET_TRIPLET=%TRIPLET_NAME% -DCMAKE_TOOLCHAIN_FILE="%VCPKG_DIR%\scripts\buildsystems\vcpkg.cmake" ..
+  - cmake -G "Visual Studio 15 2017 %GENERATOR_SUFFIX%" -DCMAKE_BUILD_TYPE=%BUILD_TYPE% -DVCPKG_TARGET_TRIPLET=%TRIPLET_NAME% -DCMAKE_TOOLCHAIN_FILE="%VCPKG_DIR%\scripts\buildsystems\vcpkg.cmake" ..
   - cmake --build . --target ALL_BUILD --config %BUILD_TYPE%
   - appveyor PushArtifact %BUILD_TYPE%\RadialGM.exe -FileName RadialGM-Win32-%CONFIGURATION%-%PLATFORM%.exe -DeploymentName RadialGM
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,8 +36,6 @@ init:
       }
 
 install:
-  - echo %BUILD_TYPE%
-  - echo %GENERATOR%
   - git submodule update --init --recursive
   - ps: |
       # this gets the latest release of RadialGM-deps using GitHub API
@@ -60,6 +58,7 @@ install:
 
 build_script:
   - echo %BUILD_TYPE%
+  - echo %GENERATOR%
   - cd %APPVEYOR_BUILD_FOLDER%\Submodules\enigma-dev\CommandLine\protos
   - mkdir build && cd build
   - cmake -G "%GENERATOR%" -DCMAKE_BUILD_TYPE="%BUILD_TYPE%" -Dprotobuf_generate_IMPORT_DIRS="%VCPKG_DIR%\installed\%TRIPLET_NAME%\include" -DVCPKG_TARGET_TRIPLET=%TRIPLET_NAME% -DCMAKE_TOOLCHAIN_FILE="%VCPKG_DIR%\scripts\buildsystems\vcpkg.cmake" ..

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,6 +8,10 @@ branches:
 # Build worker image (VM template)
 image: Visual Studio 2017
 
+# since we're pushing releases we don't want infinite recursion
+# because the release pushes a tag, hence we aren't building on tags
+skip_tags: true
+
 platform:
   - x86
   - x64
@@ -25,17 +29,11 @@ for:
 - matrix:
     only:
       - platform: x64
-  environment:
-    # TODO: change to GitHub releases
-    DEPSURL: https://ci.appveyor.com/api/buildjobs/xrs6idr9f2grmmy8/artifacts/rgmdeps-x64.zip
   init:
   - call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
 - matrix:
     only:
       - platform: x86
-  environment:
-    # TODO: change to GitHub releases
-    DEPSURL: https://ci.appveyor.com/api/buildjobs/p137pn8p9m1qfxfe/artifacts/rgmdeps-x86.zip
   init:
   - call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars32.bat"
 - matrix:
@@ -45,10 +43,23 @@ for:
     BUILD_TYPE: MinSizeRel
 
 install:
-  - git submodule update --init --recursive
+  #- git submodule update --init --recursive
+  - ps: |
+      # this gets the latest release of RadialGM-deps using GitHub API
+      $apiURL = "https://api.github.com/repos/enigma-dev/radialgm-deps/releases/latest"
+      $latest = Invoke-RestMethod -Method Get -Uri $apiURL
+      # find the asset whose name matches the architecture of this build
+      foreach ($asset in $latest.assets) {
+        Write-Host $asset.name
+      }
+
+      # download and extract the previous deps so we can amend them
+      #$artifactsURL = "https://ci.appveyor.com/api/buildjobs/$archive_job/artifacts/"
+      #appveyor DownloadFile ($artifactsURL + $env:ARTIFACT_NAME) -FileName $env:ARTIFACT_NAME
+      #7z e -mmt $env:ARTIFACT_NAME C:\tools\vcpkg\installed\$env:TRIPLET
+  - exit 1
   - appveyor DownloadFile %DEPSURL% -FileName vcpkgdeps.zip
   - 7z e -mmt vcpkgdeps.zip -y -o%VCPKG_DIR%\installed\%TRIPLET_NAME%
-  - vcpkg install protobuf:%TRIPLET_NAME%
 
 build_script:
   - cd %APPVEYOR_BUILD_FOLDER%\Submodules\enigma-dev\CommandLine\protos

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -52,15 +52,15 @@ install:
   - 7z e -mmt vcpkgdeps.zip -y -oC:\tools\vcpkg\installed\%TRIPLET_NAME%
 
 build_script:
-  - mkdir -p enigma-dev/CommandLine/protos/build
+  - sh: mkdir -p enigma-dev/CommandLine/protos/build
   - cd enigma-dev/CommandLine/protos/build
   - cmake -G "Visual Studio 15 2017 Win64" -DCMAKE_BUILD_TYPE=%BUILD_TYPE% -Dprotobuf_generate_IMPORT_DIRS="C:\vcpkg\installed\%TRIPLET_NAME%\include" -DVCPKG_TARGET_TRIPLET=%TRIPLET_NAME% -DCMAKE_TOOLCHAIN_FILE="C:\vcpkg\scripts\buildsystems\vcpkg.cmake" ..
   - cmake --build . --target install --config %BUILD_TYPE%
-  - mkdir -p enigma-dev/CommandLine/libEGM/build
+  - sh: mkdir -p enigma-dev/CommandLine/libEGM/build
   - cd enigma-dev/CommandLine/libEGM/build
   - cmake -G "Visual Studio 15 2017 Win64" -DCMAKE_BUILD_TYPE=%BUILD_TYPE% -DVCPKG_TARGET_TRIPLET=%TRIPLET_NAME% -DCMAKE_TOOLCHAIN_FILE="C:\vcpkg\scripts\buildsystems\vcpkg.cmake" ..
   - cmake --build . --target install --config %BUILD_TYPE%
-  - mkdir -p RadialGM/build
+  - sh: mkdir -p RadialGM/build
   - cd RadialGM/build
   - cmake -G "Visual Studio 15 2017 Win64" -DCMAKE_BUILD_TYPE=%BUILD_TYPE% -DVCPKG_TARGET_TRIPLET=%TRIPLET_NAME% -DCMAKE_TOOLCHAIN_FILE="C:\vcpkg\scripts\buildsystems\vcpkg.cmake" ..
   - cmake --build . --target ALL_BUILD --config %BUILD_TYPE%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,45 @@
+# branches to build
+branches:
+  # whitelist
+  only:
+    - master
+
+# Build worker image (VM template)
+image: Visual Studio 2017
+
+# fetch repository as zip archive for faster clone
+shallow_clone: true
+clone_depth: 1
+
+platform:
+  - x86
+  - x64
+
+for:
+- matrix:
+    only:
+      - platform: x64
+  init:
+  - call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
+- matrix:
+    only:
+      - platform: x86
+  init:
+  - call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars32.bat"
+
+install:
+
+artifacts:
+  - path: RadialGM-Win32-$(PLATFORM).zip
+    name: RadialGM-Win32-$(PLATFORM)
+
+deploy:
+  release: RadialGM-v$(appveyor_build_version)
+  provider: GitHub
+  auth_token:
+    secure: $(bot_push_on_green_token)
+  artifact: RadialGM-Win32-$(PLATFORM)
+  draft: false
+  prerelease: false
+  on:
+    branch: master

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -48,19 +48,20 @@ for:
     BUILD_TYPE: MinSizeRel
 
 install:
+  - cd %APPVEYOR_BUILD_FOLDER%
   - appveyor DownloadFile %DEPSURL% -FileName vcpkgdeps.zip
   - 7z e -mmt vcpkgdeps.zip -y -oC:\tools\vcpkg\installed\%TRIPLET_NAME%
 
 build_script:
-  - sh: mkdir -p enigma-dev/CommandLine/protos/build
+  - mkdir enigma-dev/CommandLine/protos/build
   - cd enigma-dev/CommandLine/protos/build
   - cmake -G "Visual Studio 15 2017 Win64" -DCMAKE_BUILD_TYPE=%BUILD_TYPE% -Dprotobuf_generate_IMPORT_DIRS="C:\vcpkg\installed\%TRIPLET_NAME%\include" -DVCPKG_TARGET_TRIPLET=%TRIPLET_NAME% -DCMAKE_TOOLCHAIN_FILE="C:\vcpkg\scripts\buildsystems\vcpkg.cmake" ..
   - cmake --build . --target install --config %BUILD_TYPE%
-  - sh: mkdir -p enigma-dev/CommandLine/libEGM/build
+  - mkdir enigma-dev/CommandLine/libEGM/build
   - cd enigma-dev/CommandLine/libEGM/build
   - cmake -G "Visual Studio 15 2017 Win64" -DCMAKE_BUILD_TYPE=%BUILD_TYPE% -DVCPKG_TARGET_TRIPLET=%TRIPLET_NAME% -DCMAKE_TOOLCHAIN_FILE="C:\vcpkg\scripts\buildsystems\vcpkg.cmake" ..
   - cmake --build . --target install --config %BUILD_TYPE%
-  - sh: mkdir -p RadialGM/build
+  - mkdir RadialGM/build
   - cd RadialGM/build
   - cmake -G "Visual Studio 15 2017 Win64" -DCMAKE_BUILD_TYPE=%BUILD_TYPE% -DVCPKG_TARGET_TRIPLET=%TRIPLET_NAME% -DCMAKE_TOOLCHAIN_FILE="C:\vcpkg\scripts\buildsystems\vcpkg.cmake" ..
   - cmake --build . --target ALL_BUILD --config %BUILD_TYPE%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -66,15 +66,15 @@ install:
 build_script:
   - cd %APPVEYOR_BUILD_FOLDER%\Submodules\enigma-dev\CommandLine\protos
   - mkdir build && cd build
-  - cmake -G "Visual Studio 15 2017 Win64" -DCMAKE_BUILD_TYPE=%BUILD_TYPE% -Dprotobuf_generate_IMPORT_DIRS="%VCPKG_DIR%\installed\%TRIPLET_NAME%\include" -DVCPKG_TARGET_TRIPLET=%TRIPLET_NAME% -DCMAKE_TOOLCHAIN_FILE="%VCPKG_DIR%\scripts\buildsystems\vcpkg.cmake" ..
+  - cmake -G "Visual Studio 15 2017" -DCMAKE_BUILD_TYPE=%BUILD_TYPE% -Dprotobuf_generate_IMPORT_DIRS="%VCPKG_DIR%\installed\%TRIPLET_NAME%\include" -DVCPKG_TARGET_TRIPLET=%TRIPLET_NAME% -DCMAKE_TOOLCHAIN_FILE="%VCPKG_DIR%\scripts\buildsystems\vcpkg.cmake" ..
   - cmake --build . --target install --config %BUILD_TYPE%
   - cd %APPVEYOR_BUILD_FOLDER%\Submodules\enigma-dev\CommandLine\libEGM
   - mkdir build && cd build
-  - cmake -G "Visual Studio 15 2017 Win64" -DCMAKE_BUILD_TYPE=%BUILD_TYPE% -DVCPKG_TARGET_TRIPLET=%TRIPLET_NAME% -DCMAKE_TOOLCHAIN_FILE="%VCPKG_DIR%\scripts\buildsystems\vcpkg.cmake" ..
+  - cmake -G "Visual Studio 15 2017" -DCMAKE_BUILD_TYPE=%BUILD_TYPE% -DVCPKG_TARGET_TRIPLET=%TRIPLET_NAME% -DCMAKE_TOOLCHAIN_FILE="%VCPKG_DIR%\scripts\buildsystems\vcpkg.cmake" ..
   - cmake --build . --target install --config %BUILD_TYPE%
   - cd %APPVEYOR_BUILD_FOLDER%
   - mkdir build && cd build
-  - cmake -G "Visual Studio 15 2017 Win64" -DCMAKE_BUILD_TYPE=%BUILD_TYPE% -DVCPKG_TARGET_TRIPLET=%TRIPLET_NAME% -DCMAKE_TOOLCHAIN_FILE="%VCPKG_DIR%\scripts\buildsystems\vcpkg.cmake" ..
+  - cmake -G "Visual Studio 15 2017" -DCMAKE_BUILD_TYPE=%BUILD_TYPE% -DVCPKG_TARGET_TRIPLET=%TRIPLET_NAME% -DCMAKE_TOOLCHAIN_FILE="%VCPKG_DIR%\scripts\buildsystems\vcpkg.cmake" ..
   - cmake --build . --target ALL_BUILD --config %BUILD_TYPE%
   - appveyor PushArtifact %BUILD_TYPE%\RadialGM.exe -FileName RadialGM-Win32-$(CONFIGURATION)-$(PLATFORM).exe -DeploymentName RadialGM
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -52,15 +52,15 @@ install:
   - 7z e -mmt vcpkgdeps.zip -y -oC:\tools\vcpkg\installed\%TRIPLET_NAME%
 
 build_script:
-  - mkdir enigma-dev/CommandLine/protos/build
+  - sh: mkdir enigma-dev/CommandLine/protos/build
   - cd enigma-dev/CommandLine/protos/build
   - cmake -G "Visual Studio 15 2017 Win64" -DCMAKE_BUILD_TYPE=%BUILD_TYPE% -Dprotobuf_generate_IMPORT_DIRS="C:\vcpkg\installed\%TRIPLET_NAME%\include" -DVCPKG_TARGET_TRIPLET=%TRIPLET_NAME% -DCMAKE_TOOLCHAIN_FILE="C:\vcpkg\scripts\buildsystems\vcpkg.cmake" ..
   - cmake --build . --target install --config %BUILD_TYPE%
-  - mkdir enigma-dev/CommandLine/libEGM/build
+  - sh: mkdir enigma-dev/CommandLine/libEGM/build
   - cd enigma-dev/CommandLine/libEGM/build
   - cmake -G "Visual Studio 15 2017 Win64" -DCMAKE_BUILD_TYPE=%BUILD_TYPE% -DVCPKG_TARGET_TRIPLET=%TRIPLET_NAME% -DCMAKE_TOOLCHAIN_FILE="C:\vcpkg\scripts\buildsystems\vcpkg.cmake" ..
   - cmake --build . --target install --config %BUILD_TYPE%
-  - mkdir RadialGM/build
+  - sh: mkdir RadialGM/build
   - cd RadialGM/build
   - cmake -G "Visual Studio 15 2017 Win64" -DCMAKE_BUILD_TYPE=%BUILD_TYPE% -DVCPKG_TARGET_TRIPLET=%TRIPLET_NAME% -DCMAKE_TOOLCHAIN_FILE="C:\vcpkg\scripts\buildsystems\vcpkg.cmake" ..
   - cmake --build . --target ALL_BUILD --config %BUILD_TYPE%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,7 +43,7 @@ for:
     BUILD_TYPE: MinSizeRel
 
 install:
-  #- git submodule update --init --recursive
+  - git submodule update --init --recursive
   - ps: |
       # this gets the latest release of RadialGM-deps using GitHub API
       $apiURL = "https://api.github.com/repos/enigma-dev/radialgm-deps/releases/latest"
@@ -62,9 +62,6 @@ install:
       # download and extract the deps matching this job's architecture
       appveyor DownloadFile $depsURL -FileName $depsName
       7z e -mmt $depsName C:\tools\vcpkg\installed\$env:TRIPLET
-  - exit 1
-  #- appveyor DownloadFile %DEPSURL% -FileName vcpkgdeps.zip
-  #- 7z e -mmt vcpkgdeps.zip -y -o%VCPKG_DIR%\installed\%TRIPLET_NAME%
 
 build_script:
   - cd %APPVEYOR_BUILD_FOLDER%\Submodules\enigma-dev\CommandLine\protos
@@ -85,7 +82,7 @@ deploy:
   release: RadialGM-v$(appveyor_build_version)
   provider: GitHub
   auth_token:
-    secure: $(bot_push_on_green_token)
+    secure: 0dfPI8cYNeLks0iLSmTyzrI/H0K3CfMrBsvfslzZp66w5gqg8pqSf4Edhovsox9k
   artifact: RadialGM
   draft: false
   prerelease: false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,8 +17,8 @@ platform:
   - x64
 
 configuration:
-  - Release
   - Debug
+  - Release
 
 environment:
   VCPKG_DIR: C:\tools\vcpkg
@@ -39,8 +39,6 @@ init:
       }
 
 install:
-  - echo %BUILD_TYPE%
-  - exit 1
   - git submodule update --init --recursive
   - ps: |
       # this gets the latest release of RadialGM-deps using GitHub API

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,7 +38,7 @@ for:
       - platform: x86
   environment:
     # TODO: change to GitHub releases
-    DEPSURL: https://ci.appveyor.com/api/buildjobs/uw0lf6xbgwkfp443/artifacts/rgmdeps-x86.zip
+    DEPSURL: https://ci.appveyor.com/api/buildjobs/p137pn8p9m1qfxfe/artifacts/rgmdeps-x86.zip
   init:
   - call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars32.bat"
 - matrix:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -46,9 +46,9 @@ for:
 
 install:
   - git submodule update --init --recursive
-  - vcpkg install protobuf:%TRIPLET_NAME%
   - appveyor DownloadFile %DEPSURL% -FileName vcpkgdeps.zip
   - 7z e -mmt vcpkgdeps.zip -y -o%VCPKG_DIR%\installed\%TRIPLET_NAME%
+  - vcpkg install protobuf:%TRIPLET_NAME%
 
 build_script:
   #- mkdir enigma-dev\CommandLine\protos\build

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,15 +27,11 @@ environment:
   GENERATOR: "Visual Studio 15 2017"
 
 init:
+  - if %PLATFORM% == x64 call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
+  - if %PLATFORM% == x86 call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars32.bat"
   - ps: |
       if ($env:configuration -eq "Release") {
         $env:BUILD_TYPE = "MinSizeRel"
-      }
-      if ($env:platform -eq "x64") {
-        cmd.exe /C "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
-        $env:GENERATOR = "Visual Studio 15 2017 Win64"
-      } else {
-        cmd.exe /C "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars32.bat"
       }
 
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -52,6 +52,7 @@ install:
   - 7z e -mmt vcpkgdeps.zip -y -oC:\tools\vcpkg\installed\%TRIPLET_NAME%
 
 build_script:
+  - git submodule init --recursive
   #- mkdir enigma-dev\CommandLine\protos\build
   - cd %APPVEYOR_BUILD_FOLDER%\Submodules\enigma-dev\CommandLine\protos
   - cmake -G "Visual Studio 15 2017 Win64" -DCMAKE_BUILD_TYPE=%BUILD_TYPE% -Dprotobuf_generate_IMPORT_DIRS="C:\vcpkg\installed\%TRIPLET_NAME%\include" -DVCPKG_TARGET_TRIPLET=%TRIPLET_NAME% -DCMAKE_TOOLCHAIN_FILE="C:\vcpkg\scripts\buildsystems\vcpkg.cmake"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -48,10 +48,8 @@ for:
     BUILD_TYPE: MinSizeRel
 
 install:
-  - cd C:\tools\vcpkg\installed
   - appveyor DownloadFile $DEPSURL -FileName vcpkgdeps.zip
-  - 7z e -mmt vcpkgdeps.zip -o$(TRIPLET_NAME)
-  - cd %APPVEYOR_BUILD_FOLDER%
+  - 7z e -mmt vcpkgdeps.zip -oC:\tools\vcpkg\installed\$(TRIPLET_NAME)
 
 build_script:
   - mkdir enigma-dev/CommandLine/protos/build

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,36 +17,37 @@ platform:
   - x64
 
 configuration:
-  - Debug
   - Release
+  - Debug
 
 environment:
   VCPKG_DIR: C:\tools\vcpkg
   TRIPLET_NAME: $(PLATFORM)-windows-static
   BUILD_TYPE: Debug
+  GENERATOR: "Visual Studio 15 2017"
+
+init:
+  - call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars32.bat"
 
 for:
-- matrix:
-    only:
-      - platform: x64
-  init:
-  - call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
-  environment:
-    GENERATOR: "Visual Studio 15 2017 Win64"
-- matrix:
-    only:
-      - platform: x86
-  init:
-  - call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars32.bat"
-  environment:
-    GENERATOR: "Visual Studio 15 2017"
-- matrix:
-    only:
-      - configuration: Release
-  environment:
-    BUILD_TYPE: MinSizeRel
+  # override build type for release
+  - matrix:
+      only:
+        - configuration: Release
+    environment:
+      BUILD_TYPE: MinSizeRel
+  - matrix:
+      only:
+        - platform: x64
+    # override init and generator name for x64
+    init:
+      - call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
+    environment:
+      GENERATOR: "Visual Studio 15 2017 Win64"
 
 install:
+  - echo %BUILD_TYPE%
+  - exit 1
   - git submodule update --init --recursive
   - ps: |
       # this gets the latest release of RadialGM-deps using GitHub API
@@ -70,16 +71,16 @@ install:
 build_script:
   - cd %APPVEYOR_BUILD_FOLDER%\Submodules\enigma-dev\CommandLine\protos
   - mkdir build && cd build
-  - cmake -G "%GENERATOR%" -DCMAKE_BUILD_TYPE=%BUILD_TYPE% -Dprotobuf_generate_IMPORT_DIRS="%VCPKG_DIR%\installed\%TRIPLET_NAME%\include" -DVCPKG_TARGET_TRIPLET=%TRIPLET_NAME% -DCMAKE_TOOLCHAIN_FILE="%VCPKG_DIR%\scripts\buildsystems\vcpkg.cmake" ..
-  - cmake --build . --target install --config %BUILD_TYPE%
+  - cmake -G "%GENERATOR%" -DCMAKE_BUILD_TYPE="%BUILD_TYPE%" -Dprotobuf_generate_IMPORT_DIRS="%VCPKG_DIR%\installed\%TRIPLET_NAME%\include" -DVCPKG_TARGET_TRIPLET=%TRIPLET_NAME% -DCMAKE_TOOLCHAIN_FILE="%VCPKG_DIR%\scripts\buildsystems\vcpkg.cmake" ..
+  - cmake --build . --target install --config "%BUILD_TYPE%"
   - cd %APPVEYOR_BUILD_FOLDER%\Submodules\enigma-dev\CommandLine\libEGM
   - mkdir build && cd build
-  - cmake -G "%GENERATOR%" -DCMAKE_BUILD_TYPE=%BUILD_TYPE% -DVCPKG_TARGET_TRIPLET=%TRIPLET_NAME% -DCMAKE_TOOLCHAIN_FILE="%VCPKG_DIR%\scripts\buildsystems\vcpkg.cmake" ..
-  - cmake --build . --target install --config %BUILD_TYPE%
+  - cmake -G "%GENERATOR%" -DCMAKE_BUILD_TYPE="%BUILD_TYPE%" -DVCPKG_TARGET_TRIPLET=%TRIPLET_NAME% -DCMAKE_TOOLCHAIN_FILE="%VCPKG_DIR%\scripts\buildsystems\vcpkg.cmake" ..
+  - cmake --build . --target install --config "%BUILD_TYPE%"
   - cd %APPVEYOR_BUILD_FOLDER%
   - mkdir build && cd build
-  - cmake -G "%GENERATOR%" -DCMAKE_BUILD_TYPE=%BUILD_TYPE% -DVCPKG_TARGET_TRIPLET=%TRIPLET_NAME% -DCMAKE_TOOLCHAIN_FILE="%VCPKG_DIR%\scripts\buildsystems\vcpkg.cmake" ..
-  - cmake --build . --target ALL_BUILD --config %BUILD_TYPE%
+  - cmake -G "%GENERATOR%" -DCMAKE_BUILD_TYPE="%BUILD_TYPE%" -DVCPKG_TARGET_TRIPLET=%TRIPLET_NAME% -DCMAKE_TOOLCHAIN_FILE="%VCPKG_DIR%\scripts\buildsystems\vcpkg.cmake" ..
+  - cmake --build . --target ALL_BUILD --config "%BUILD_TYPE%"
   - appveyor PushArtifact %BUILD_TYPE%\RadialGM.exe -FileName RadialGM-Win32-%CONFIGURATION%-%PLATFORM%.exe -DeploymentName RadialGM
 
 deploy:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,6 +28,7 @@ environment:
 
 init:
   - if %PLATFORM% == x64 call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
+  - if %PLATFORM% == x64 set GENERATOR="Visual Studio 15 2017 Win64"
   - if %PLATFORM% == x86 call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars32.bat"
   - ps: |
       if ($env:configuration -eq "Release") {
@@ -35,6 +36,8 @@ init:
       }
 
 install:
+  - echo %BUILD_TYPE%
+  - echo %GENERATOR%
   - git submodule update --init --recursive
   - ps: |
       # this gets the latest release of RadialGM-deps using GitHub API

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,6 +17,7 @@ configuration:
   - Release
 
 environment:
+  VCPKG_DIR: C:\tools\vcpkg
   TRIPLET_NAME: $(PLATFORM)-windows-static
   BUILD_TYPE: Debug
 
@@ -46,20 +47,20 @@ for:
 install:
   - git submodule update --init --recursive
   - appveyor DownloadFile %DEPSURL% -FileName vcpkgdeps.zip
-  - 7z e -mmt vcpkgdeps.zip -y -oC:\tools\vcpkg\installed\%TRIPLET_NAME%
+  - 7z e -mmt vcpkgdeps.zip -y -o%VCPKG_DIR%\installed\%TRIPLET_NAME%
 
 build_script:
   #- mkdir enigma-dev\CommandLine\protos\build
   - cd %APPVEYOR_BUILD_FOLDER%\Submodules\enigma-dev\CommandLine\protos
-  - cmake -G "Visual Studio 15 2017 Win64" -DCMAKE_BUILD_TYPE=%BUILD_TYPE% -Dprotobuf_generate_IMPORT_DIRS="C:\vcpkg\installed\%TRIPLET_NAME%\include" -DVCPKG_TARGET_TRIPLET=%TRIPLET_NAME% -DCMAKE_TOOLCHAIN_FILE="C:\vcpkg\scripts\buildsystems\vcpkg.cmake"
+  - cmake -G "Visual Studio 15 2017 Win64" -DCMAKE_BUILD_TYPE=%BUILD_TYPE% -Dprotobuf_generate_IMPORT_DIRS="%VCPKG_DIR%\installed\%TRIPLET_NAME%\include" -DVCPKG_TARGET_TRIPLET=%TRIPLET_NAME% -DCMAKE_TOOLCHAIN_FILE="%VCPKG_DIR%\scripts\buildsystems\vcpkg.cmake"
   - cmake --build . --target install --config %BUILD_TYPE%
   #- mkdir enigma-dev\CommandLine\libEGM\build
   - cd %APPVEYOR_BUILD_FOLDER%\Submodules\enigma-dev\CommandLine\libEGM
-  - cmake -G "Visual Studio 15 2017 Win64" -DCMAKE_BUILD_TYPE=%BUILD_TYPE% -DVCPKG_TARGET_TRIPLET=%TRIPLET_NAME% -DCMAKE_TOOLCHAIN_FILE="C:\vcpkg\scripts\buildsystems\vcpkg.cmake"
+  - cmake -G "Visual Studio 15 2017 Win64" -DCMAKE_BUILD_TYPE=%BUILD_TYPE% -DVCPKG_TARGET_TRIPLET=%TRIPLET_NAME% -DCMAKE_TOOLCHAIN_FILE="%VCPKG_DIR%\scripts\buildsystems\vcpkg.cmake"
   - cmake --build . --target install --config %BUILD_TYPE%
   #- mkdir RadialGM\build
   - cd %APPVEYOR_BUILD_FOLDER%
-  - cmake -G "Visual Studio 15 2017 Win64" -DCMAKE_BUILD_TYPE=%BUILD_TYPE% -DVCPKG_TARGET_TRIPLET=%TRIPLET_NAME% -DCMAKE_TOOLCHAIN_FILE="C:\vcpkg\scripts\buildsystems\vcpkg.cmake"
+  - cmake -G "Visual Studio 15 2017 Win64" -DCMAKE_BUILD_TYPE=%BUILD_TYPE% -DVCPKG_TARGET_TRIPLET=%TRIPLET_NAME% -DCMAKE_TOOLCHAIN_FILE="%VCPKG_DIR%\scripts\buildsystems\vcpkg.cmake"
   - cmake --build . --target ALL_BUILD --config %BUILD_TYPE%
   - appveyor PushArtifact bin\%BUILD_TYPE%\RadialGM.exe -FileName RadialGM-Win32-$(CONFIGURATION)-$(PLATFORM).exe -DeploymentName RadialGM
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -51,17 +51,17 @@ install:
   - vcpkg install protobuf:%TRIPLET_NAME%
 
 build_script:
-  #- mkdir enigma-dev\CommandLine\protos\build
   - cd %APPVEYOR_BUILD_FOLDER%\Submodules\enigma-dev\CommandLine\protos
-  - cmake -G "Visual Studio 15 2017 Win64" -DCMAKE_BUILD_TYPE=%BUILD_TYPE% -Dprotobuf_generate_IMPORT_DIRS="%VCPKG_DIR%\installed\%TRIPLET_NAME%\include" -DVCPKG_TARGET_TRIPLET=%TRIPLET_NAME% -DCMAKE_TOOLCHAIN_FILE="%VCPKG_DIR%\scripts\buildsystems\vcpkg.cmake"
+  - mkdir build && cd build
+  - cmake -G "Visual Studio 15 2017 Win64" -DCMAKE_BUILD_TYPE=%BUILD_TYPE% -Dprotobuf_generate_IMPORT_DIRS="%VCPKG_DIR%\installed\%TRIPLET_NAME%\include" -DVCPKG_TARGET_TRIPLET=%TRIPLET_NAME% -DCMAKE_TOOLCHAIN_FILE="%VCPKG_DIR%\scripts\buildsystems\vcpkg.cmake" ..
   - cmake --build . --target install --config %BUILD_TYPE%
-  #- mkdir enigma-dev\CommandLine\libEGM\build
   - cd %APPVEYOR_BUILD_FOLDER%\Submodules\enigma-dev\CommandLine\libEGM
-  - cmake -G "Visual Studio 15 2017 Win64" -DCMAKE_BUILD_TYPE=%BUILD_TYPE% -DVCPKG_TARGET_TRIPLET=%TRIPLET_NAME% -DCMAKE_TOOLCHAIN_FILE="%VCPKG_DIR%\scripts\buildsystems\vcpkg.cmake"
+  - mkdir build && cd build
+  - cmake -G "Visual Studio 15 2017 Win64" -DCMAKE_BUILD_TYPE=%BUILD_TYPE% -DVCPKG_TARGET_TRIPLET=%TRIPLET_NAME% -DCMAKE_TOOLCHAIN_FILE="%VCPKG_DIR%\scripts\buildsystems\vcpkg.cmake" ..
   - cmake --build . --target install --config %BUILD_TYPE%
-  #- mkdir RadialGM\build
   - cd %APPVEYOR_BUILD_FOLDER%
-  - cmake -G "Visual Studio 15 2017 Win64" -DCMAKE_BUILD_TYPE=%BUILD_TYPE% -DVCPKG_TARGET_TRIPLET=%TRIPLET_NAME% -DCMAKE_TOOLCHAIN_FILE="%VCPKG_DIR%\scripts\buildsystems\vcpkg.cmake"
+  - mkdir build && cd build
+  - cmake -G "Visual Studio 15 2017 Win64" -DCMAKE_BUILD_TYPE=%BUILD_TYPE% -DVCPKG_TARGET_TRIPLET=%TRIPLET_NAME% -DCMAKE_TOOLCHAIN_FILE="%VCPKG_DIR%\scripts\buildsystems\vcpkg.cmake" ..
   - cmake --build . --target ALL_BUILD --config %BUILD_TYPE%
   - appveyor PushArtifact bin\%BUILD_TYPE%\RadialGM.exe -FileName RadialGM-Win32-$(CONFIGURATION)-$(PLATFORM).exe -DeploymentName RadialGM
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -48,7 +48,6 @@ for:
     BUILD_TYPE: MinSizeRel
 
 install:
-  - echo %DEPSURL%
   - appveyor DownloadFile %DEPSURL% -FileName vcpkgdeps.zip
   - 7z e -mmt vcpkgdeps.zip -y -oC:\tools\vcpkg\installed\%TRIPLET_NAME%
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,5 @@
-# branches to build
+# don't build "feature" branches
+skip_branch_with_pr: true
 branches:
   # whitelist
   only:
@@ -19,15 +20,26 @@ for:
 - matrix:
     only:
       - platform: x64
+      # TODO: change to GitHub releases
+      - depsurl: https://ci.appveyor.com/api/buildjobs/xrs6idr9f2grmmy8/artifacts/rgmdeps-x64.zip
   init:
   - call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
 - matrix:
     only:
       - platform: x86
+      # TODO: change to GitHub releases
+      - depsurl: https://ci.appveyor.com/api/buildjobs/uw0lf6xbgwkfp443/artifacts/rgmdeps-x86.zip
   init:
   - call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars32.bat"
 
 install:
+  - cd C:\tools\vcpkg\installed
+  - appveyor DownloadFile $depsurl -FileName vcpkgdeps.zip
+  - 7z e -mmt vcpkgdeps.zip -o$(PLATFORM)-windows-static
+  - cd %APPVEYOR_BUILD_FOLDER%
+
+build_script:
+  - echo Hello Build!
 
 artifacts:
   - path: RadialGM-Win32-$(PLATFORM).zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -60,18 +60,19 @@ install:
       7z x -mmt $depsName -oC:\tools\vcpkg
 
 build_script:
+  - echo %BUILD_TYPE%
   - cd %APPVEYOR_BUILD_FOLDER%\Submodules\enigma-dev\CommandLine\protos
   - mkdir build && cd build
-  - cmake -G "%GENERATOR%" -DCMAKE_BUILD_TYPE="%BUILD_TYPE%" -Dprotobuf_generate_IMPORT_DIRS="%VCPKG_DIR%\installed\%TRIPLET_NAME%\include" -DVCPKG_TARGET_TRIPLET=%TRIPLET_NAME% -DCMAKE_TOOLCHAIN_FILE="%VCPKG_DIR%\scripts\buildsystems\vcpkg.cmake" ..
-  - cmake --build . --target install --config "%BUILD_TYPE%"
+  - cmake -G "%GENERATOR%" -DCMAKE_BUILD_TYPE=%BUILD_TYPE% -Dprotobuf_generate_IMPORT_DIRS="%VCPKG_DIR%\installed\%TRIPLET_NAME%\include" -DVCPKG_TARGET_TRIPLET=%TRIPLET_NAME% -DCMAKE_TOOLCHAIN_FILE="%VCPKG_DIR%\scripts\buildsystems\vcpkg.cmake" ..
+  - cmake --build . --target install --config %BUILD_TYPE%
   - cd %APPVEYOR_BUILD_FOLDER%\Submodules\enigma-dev\CommandLine\libEGM
   - mkdir build && cd build
-  - cmake -G "%GENERATOR%" -DCMAKE_BUILD_TYPE="%BUILD_TYPE%" -DVCPKG_TARGET_TRIPLET=%TRIPLET_NAME% -DCMAKE_TOOLCHAIN_FILE="%VCPKG_DIR%\scripts\buildsystems\vcpkg.cmake" ..
-  - cmake --build . --target install --config "%BUILD_TYPE%"
+  - cmake -G "%GENERATOR%" -DCMAKE_BUILD_TYPE=%BUILD_TYPE% -DVCPKG_TARGET_TRIPLET=%TRIPLET_NAME% -DCMAKE_TOOLCHAIN_FILE="%VCPKG_DIR%\scripts\buildsystems\vcpkg.cmake" ..
+  - cmake --build . --target install --config %BUILD_TYPE%
   - cd %APPVEYOR_BUILD_FOLDER%
   - mkdir build && cd build
-  - cmake -G "%GENERATOR%" -DCMAKE_BUILD_TYPE="%BUILD_TYPE%" -DVCPKG_TARGET_TRIPLET=%TRIPLET_NAME% -DCMAKE_TOOLCHAIN_FILE="%VCPKG_DIR%\scripts\buildsystems\vcpkg.cmake" ..
-  - cmake --build . --target ALL_BUILD --config "%BUILD_TYPE%"
+  - cmake -G "%GENERATOR%" -DCMAKE_BUILD_TYPE=%BUILD_TYPE% -DVCPKG_TARGET_TRIPLET=%TRIPLET_NAME% -DCMAKE_TOOLCHAIN_FILE="%VCPKG_DIR%\scripts\buildsystems\vcpkg.cmake" ..
+  - cmake --build . --target ALL_BUILD --config %BUILD_TYPE%
   - appveyor PushArtifact %BUILD_TYPE%\RadialGM.exe -FileName RadialGM-Win32-%CONFIGURATION%-%PLATFORM%.exe -DeploymentName RadialGM
 
 deploy:

--- a/main.cpp
+++ b/main.cpp
@@ -1,6 +1,9 @@
 #include "MainWindow.h"
+#include "gmk.h"
 
 #include <QApplication>
+
+#include <iostream>
 
 int main(int argc, char *argv[]) {
   QApplication a(argc, argv);
@@ -8,6 +11,10 @@ int main(int argc, char *argv[]) {
   a.setOrganizationDomain("enigma-dev.org");
   a.setApplicationName("RadialGM");
   a.setWindowIcon(QIcon(":/icon.ico"));
+
+  int test;
+  std::cerr << sizeof(test) << std::endl;
+  gmk::bind_output_streams(std::cout, std::cerr);
 
   MainWindow w(nullptr);
   if (argc > 1) {

--- a/main.cpp
+++ b/main.cpp
@@ -1,9 +1,6 @@
 #include "MainWindow.h"
-#include "gmk.h"
 
 #include <QApplication>
-
-#include <iostream>
 
 int main(int argc, char *argv[]) {
   QApplication a(argc, argv);
@@ -11,10 +8,6 @@ int main(int argc, char *argv[]) {
   a.setOrganizationDomain("enigma-dev.org");
   a.setApplicationName("RadialGM");
   a.setWindowIcon(QIcon(":/icon.ico"));
-
-  int test;
-  std::cerr << sizeof(test) << std::endl;
-  gmk::bind_output_streams(std::cout, std::cerr);
 
   MainWindow w(nullptr);
   if (argc > 1) {

--- a/qtplugins.cpp
+++ b/qtplugins.cpp
@@ -1,5 +1,10 @@
 // this source file is for importing QT plugins in
 // the static build of RadialGM that uses CMake
 #include <QtPlugin>
+
+Q_IMPORT_PLUGIN(QGifPlugin)
+Q_IMPORT_PLUGIN(QICOPlugin)
+Q_IMPORT_PLUGIN(QJpegPlugin)
+
 Q_IMPORT_PLUGIN(QWindowsIntegrationPlugin);
 Q_IMPORT_PLUGIN(QWindowsVistaStylePlugin);

--- a/qtplugins.cpp
+++ b/qtplugins.cpp
@@ -2,3 +2,4 @@
 // the static build of RadialGM that uses CMake
 #include <QtPlugin>
 Q_IMPORT_PLUGIN(QWindowsIntegrationPlugin);
+Q_IMPORT_PLUGIN(QWindowsVistaStylePlugin);

--- a/qtplugins.cpp
+++ b/qtplugins.cpp
@@ -4,7 +4,6 @@
 
 Q_IMPORT_PLUGIN(QGifPlugin)
 Q_IMPORT_PLUGIN(QICOPlugin)
-Q_IMPORT_PLUGIN(QJpegPlugin)
 
 Q_IMPORT_PLUGIN(QWindowsIntegrationPlugin);
 Q_IMPORT_PLUGIN(QWindowsVistaStylePlugin);

--- a/qtplugins.cpp
+++ b/qtplugins.cpp
@@ -4,6 +4,7 @@
 
 Q_IMPORT_PLUGIN(QGifPlugin)
 Q_IMPORT_PLUGIN(QICOPlugin)
+Q_IMPORT_PLUGIN(QJpegPlugin)
 
 Q_IMPORT_PLUGIN(QWindowsIntegrationPlugin);
 Q_IMPORT_PLUGIN(QWindowsVistaStylePlugin);

--- a/resources.rc
+++ b/resources.rc
@@ -1,0 +1,2 @@
+#define IDI_ICON1 101
+IDI_ICON1 ICON "Images/icon.ico"


### PR DESCRIPTION
This follows #27 using the instructions from #26 to build RGM on AppVeyor. We just download the Qt static build from `RadialGM-deps` and compile RadialGM and deploy it to the GitHub releases page.