### PR TITLE
Chinchilla Functionality

### DIFF
--- a/CmakeLists.txt
+++ b/CmakeLists.txt
@@ -109,7 +109,7 @@ endif()
 # Tell CMake to create the RadialGM executable
 add_executable(${EXE} WIN32 ${RGM_UI} ${RGM_HEADERS} ${RGM_SOURCES} ${EDITOR_SOURCES} ${RGM_RC})
 
-set(CMAKE_SHARED_LINKER_FLAGS ${CMAKE_SHARED_LINKER_FLAGS} "/NODEFAULTLIBS:LIBCMT")
+set(CMAKE_SHARED_LINKER_FLAGS ${CMAKE_SHARED_LINKER_FLAGS} "/NODEFAULTLIB:library")
 
 message(STATUS "Initial build flags:")
 set(CompilerFlags

--- a/CmakeLists.txt
+++ b/CmakeLists.txt
@@ -199,7 +199,7 @@ find_library(LIB_QT_WINVISTASTYLE NAMES qwindowsvistastyle PATHS "${QT_DIR}/plug
 find_library(LIB_QT_WIN NAMES qwindows PATHS "${QT_DIR}/plugins/platforms")
 
 target_link_libraries(${EXE} PRIVATE "$<IF:$<CONFIG:Debug>,${LIB_QT_PLATFORM_D},${LIB_QT_PLATFORM}>"
-                      "$<IF:$<CONFIG:Debug>,${LIB_QT_FONT_D},${LIB_QT_FONT}>"
+#                      "$<IF:$<CONFIG:Debug>,${LIB_QT_FONT_D},${LIB_QT_FONT}>"
                       "$<IF:$<CONFIG:Debug>,${LIB_QT_UI_D},${LIB_QT_UI}>"
                       "$<IF:$<CONFIG:Debug>,${LIB_QT_EVENT_D},${LIB_QT_EVENT}>"
                       "$<IF:$<CONFIG:Debug>,${LIB_QT_THEME_D},${LIB_QT_THEME}>"

--- a/CmakeLists.txt
+++ b/CmakeLists.txt
@@ -109,6 +109,8 @@ endif()
 # Tell CMake to create the RadialGM executable
 add_executable(${EXE} WIN32 ${RGM_UI} ${RGM_HEADERS} ${RGM_SOURCES} ${EDITOR_SOURCES} ${RGM_RC})
 
+set(CMAKE_SHARED_LINKER_FLAGS ${CMAKE_SHARED_LINKER_FLAGS} "/NODEFAULTLIBS:LIBCMT")
+
 message(STATUS "Initial build flags:")
 set(CompilerFlags
 	  CMAKE_C_FLAGS_DEBUG

--- a/CmakeLists.txt
+++ b/CmakeLists.txt
@@ -201,6 +201,10 @@ find_library(LIB_WIN_UXTHEME NAMES Uxtheme)
 find_library(LIB_QT_WINVISTASTYLE NAMES qwindowsvistastyle PATHS "${QT_DIR}/plugins/styles")
 find_library(LIB_QT_WIN NAMES qwindows PATHS "${QT_DIR}/plugins/platforms")
 
+if (LIB_QSCINTILLA)
+    target_link_libraries(${EXE} PRIVATE ${LIB_QSCINTILLA})
+endif()
+
 target_link_libraries(${EXE} PRIVATE "$<IF:$<CONFIG:Debug>,${LIB_QT_PLATFORM_D},${LIB_QT_PLATFORM}>"
                       "$<IF:$<CONFIG:Debug>,${LIB_QT_FONT_D},${LIB_QT_FONT}>"
                       "$<IF:$<CONFIG:Debug>,${LIB_QT_UI_D},${LIB_QT_UI}>"
@@ -238,7 +242,3 @@ target_link_libraries(${EXE} PRIVATE ${LIB_DOUBLE_CONVERSION})
 
 # Windows is a turd
 target_link_libraries(${EXE} PRIVATE Ws2_32 Wldap32 Crypt32 Winmm Userenv Netapi32 version Dwmapi Imm32)
-
-if (LIB_QSCINTILLA)
-    target_link_libraries(${EXE} PRIVATE ${LIB_QSCINTILLA})
-endif()

--- a/CmakeLists.txt
+++ b/CmakeLists.txt
@@ -106,6 +106,10 @@ else()
     set(EDITOR_SOURCES Widgets/CodeWidgetScintilla.cpp)
 endif()
 
+if (LIB_QSCINTILLA)
+    target_link_libraries(${EXE} PRIVATE ${LIB_QSCINTILLA})
+endif()
+
 # Tell CMake to create the RadialGM executable
 add_executable(${EXE} WIN32 ${RGM_UI} ${RGM_HEADERS} ${RGM_SOURCES} ${EDITOR_SOURCES} ${RGM_RC})
 
@@ -200,10 +204,6 @@ find_library(LIB_QT_JPEG NAMES qjpeg PATHS "${QT_DIR}/plugins/imageformats")
 find_library(LIB_WIN_UXTHEME NAMES Uxtheme)
 find_library(LIB_QT_WINVISTASTYLE NAMES qwindowsvistastyle PATHS "${QT_DIR}/plugins/styles")
 find_library(LIB_QT_WIN NAMES qwindows PATHS "${QT_DIR}/plugins/platforms")
-
-if (LIB_QSCINTILLA)
-    target_link_libraries(${EXE} PRIVATE ${LIB_QSCINTILLA})
-endif()
 
 target_link_libraries(${EXE} PRIVATE "$<IF:$<CONFIG:Debug>,${LIB_QT_PLATFORM_D},${LIB_QT_PLATFORM}>"
                       "$<IF:$<CONFIG:Debug>,${LIB_QT_FONT_D},${LIB_QT_FONT}>"

--- a/CmakeLists.txt
+++ b/CmakeLists.txt
@@ -206,10 +206,6 @@ find_library(LIB_WIN_UXTHEME NAMES Uxtheme)
 find_library(LIB_QT_WINVISTASTYLE NAMES qwindowsvistastyle PATHS "${QT_DIR}/plugins/styles")
 find_library(LIB_QT_WIN NAMES qwindows PATHS "${QT_DIR}/plugins/platforms")
 
-if (LIB_QSCINTILLA)
-    target_link_libraries(${EXE} PRIVATE ${LIB_QSCINTILLA})
-endif()
-
 target_link_libraries(${EXE} PRIVATE "$<IF:$<CONFIG:Debug>,${LIB_QT_PLATFORM_D},${LIB_QT_PLATFORM}>"
 #                      "$<IF:$<CONFIG:Debug>,${LIB_QT_FONT_D},${LIB_QT_FONT}>"
                       "$<IF:$<CONFIG:Debug>,${LIB_QT_UI_D},${LIB_QT_UI}>"
@@ -222,7 +218,11 @@ target_link_libraries(${EXE} PRIVATE "$<IF:$<CONFIG:Debug>,${LIB_QT_PLATFORM_D},
                       "$<IF:$<CONFIG:Debug>,${LIB_WIN_UXTHEME_D},${LIB_WIN_UXTHEME}>"
                       "$<IF:$<CONFIG:Debug>,${LIB_QT_WINVISTASTYLE_D},${LIB_QT_WINVISTASTYLE}>"
                       "$<IF:$<CONFIG:Debug>,${LIB_QT_WIN_D},${LIB_QT_WIN}>"
-					  )
+                      )
+
+if (LIB_QSCINTILLA)
+    target_link_libraries(${EXE} PRIVATE ${LIB_QSCINTILLA})
+endif()
 
 # Find JPEG
 find_library(LIB_JPEG NAMES jpeg)

--- a/CmakeLists.txt
+++ b/CmakeLists.txt
@@ -126,7 +126,7 @@ foreach(CompilerFlag ${CompilerFlags})
 endforeach()
 
 if (LIB_QSCINTILLA)
-    target_link_libraries(${EXE} PUBLIC ${LIB_QSCINTILLA})
+    target_link_libraries(${EXE} PRIVATE ${LIB_QSCINTILLA})
 endif()
 
 # Find PugiXML

--- a/CmakeLists.txt
+++ b/CmakeLists.txt
@@ -99,10 +99,11 @@ set(RGM_RC
 )
 
 # Check for QScintilla
-set(EDITOR_SOURCES Widgets/CodeWidgetPlain.cpp)
-find_package(qscintilla)
-if (QSCINTILLA_FOUND)
-	set(EDITOR_SOURCES Widgets/CodeWidgetScintilla.cpp)
+find_library(LIB_QSCINTILLA NAMES qscintilla2)
+if (NOT LIB_QSCINTILLA)
+    set(EDITOR_SOURCES Widgets/CodeWidgetPlain.cpp)
+else()
+    set(EDITOR_SOURCES Widgets/CodeWidgetScintilla.cpp)
 endif()
 
 # Tell CMake to create the RadialGM executable
@@ -123,10 +124,6 @@ foreach(CompilerFlag ${CompilerFlags})
   string(REPLACE "/MD" "/MT" ${CompilerFlag} "${${CompilerFlag}}")
   message(STATUS "  '${CompilerFlag}': ${${CompilerFlag}}")
 endforeach()
-
-if (QSCINTILLA_FOUND)
-	target_link_libraries(${EXE} PRIVATE qscintilla)
-endif()
 
 # Find PugiXML
 find_library(LIB_PUGIXML NAMES pugixml)
@@ -213,6 +210,10 @@ target_link_libraries(${EXE} PRIVATE "$<IF:$<CONFIG:Debug>,${LIB_QT_PLATFORM_D},
                       "$<IF:$<CONFIG:Debug>,${LIB_QT_WINVISTASTYLE_D},${LIB_QT_WINVISTASTYLE}>"
                       "$<IF:$<CONFIG:Debug>,${LIB_QT_WIN_D},${LIB_QT_WIN}>"
 					  )
+
+if (LIB_QSCINTILLA)
+    target_link_libraries(${EXE} PRIVATE ${LIB_QSCINTILLA})
+endif()
 
 # Find FreeType
 find_package(Freetype REQUIRED)

--- a/CmakeLists.txt
+++ b/CmakeLists.txt
@@ -198,6 +198,10 @@ find_library(LIB_WIN_UXTHEME NAMES Uxtheme)
 find_library(LIB_QT_WINVISTASTYLE NAMES qwindowsvistastyle PATHS "${QT_DIR}/plugins/styles")
 find_library(LIB_QT_WIN NAMES qwindows PATHS "${QT_DIR}/plugins/platforms")
 
+if (LIB_QSCINTILLA)
+    target_link_libraries(${EXE} PRIVATE ${LIB_QSCINTILLA})
+endif()
+
 target_link_libraries(${EXE} PRIVATE "$<IF:$<CONFIG:Debug>,${LIB_QT_PLATFORM_D},${LIB_QT_PLATFORM}>"
 #                      "$<IF:$<CONFIG:Debug>,${LIB_QT_FONT_D},${LIB_QT_FONT}>"
                       "$<IF:$<CONFIG:Debug>,${LIB_QT_UI_D},${LIB_QT_UI}>"
@@ -210,10 +214,6 @@ target_link_libraries(${EXE} PRIVATE "$<IF:$<CONFIG:Debug>,${LIB_QT_PLATFORM_D},
                       "$<IF:$<CONFIG:Debug>,${LIB_QT_WINVISTASTYLE_D},${LIB_QT_WINVISTASTYLE}>"
                       "$<IF:$<CONFIG:Debug>,${LIB_QT_WIN_D},${LIB_QT_WIN}>"
 					  )
-
-if (LIB_QSCINTILLA)
-    target_link_libraries(${EXE} PRIVATE ${LIB_QSCINTILLA})
-endif()
 
 # Find FreeType
 find_package(Freetype REQUIRED)

--- a/CmakeLists.txt
+++ b/CmakeLists.txt
@@ -109,7 +109,7 @@ endif()
 # Tell CMake to create the RadialGM executable
 add_executable(${EXE} WIN32 ${RGM_UI} ${RGM_HEADERS} ${RGM_SOURCES} ${EDITOR_SOURCES} ${RGM_RC})
 
-set(CMAKE_SHARED_LINKER_FLAGS ${CMAKE_SHARED_LINKER_FLAGS} "/NODEFAULTLIB:library")
+set(CMAKE_SHARED_LINKER_FLAGS ${CMAKE_SHARED_LINKER_FLAGS} "/FORCE:MULTIPLE")
 
 message(STATUS "Initial build flags:")
 set(CompilerFlags

--- a/CmakeLists.txt
+++ b/CmakeLists.txt
@@ -215,10 +215,6 @@ target_link_libraries(${EXE} PRIVATE "$<IF:$<CONFIG:Debug>,${LIB_QT_PLATFORM_D},
                       "$<IF:$<CONFIG:Debug>,${LIB_QT_WIN_D},${LIB_QT_WIN}>"
                       )
 
-if (LIB_QSCINTILLA)
-    #target_link_libraries(${EXE} PRIVATE ${LIB_QSCINTILLA})
-endif()
-
 # Find FreeType
 find_package(Freetype REQUIRED)
 include_directories(${FREETYPE_INCLUDE_DIRS})
@@ -242,3 +238,7 @@ target_link_libraries(${EXE} PRIVATE ${LIB_DOUBLE_CONVERSION})
 
 # Windows is a turd
 target_link_libraries(${EXE} PRIVATE Ws2_32 Wldap32 Crypt32 Winmm Userenv Netapi32 version Dwmapi Imm32)
+
+if (LIB_QSCINTILLA)
+    target_link_libraries(${EXE} PRIVATE ${LIB_QSCINTILLA})
+endif()

--- a/CmakeLists.txt
+++ b/CmakeLists.txt
@@ -176,6 +176,7 @@ find_library(LIB_QT_FONT_D NAMES Qt5FontDatabaseSupportd)
 find_library(LIB_QT_UI_D NAMES Qt5WindowsUIAutomationSupportd)
 find_library(LIB_QT_EVENT_D NAMES Qt5EventDispatcherSupportd)
 find_library(LIB_QT_THEME_D NAMES Qt5ThemeSupportd)
+find_library(LIB_QT_PRINT_D NAMES Qt5PrintSupportd)
 find_library(LIB_QT_ICO_D NAMES qicod PATHS "${QT_DIR}/plugins/imageformats")
 find_library(LIB_QT_GIF_D NAMES qgifd PATHS "${QT_DIR}/plugins/imageformats")
 find_library(LIB_QT_JPEG_D NAMES qjpegd PATHS "${QT_DIR}/plugins/imageformats")
@@ -183,12 +184,14 @@ find_library(LIB_QT_JPEG_D NAMES qjpegd PATHS "${QT_DIR}/plugins/imageformats")
 find_library(LIB_WIN_UXTHEME_D NAMES Uxtheme)
 find_library(LIB_QT_WINVISTASTYLE_D NAMES qwindowsvistastyled PATHS "${QT_DIR}/plugins/styles")
 find_library(LIB_QT_WIN_D NAMES qwindowsd PATHS "${QT_DIR}/plugins/platforms")
+
 # Release
 find_library(LIB_QT_PLATFORM NAMES Qt5PlatformCompositorSupport)
 find_library(LIB_QT_FONT NAMES Qt5FontDatabaseSupport)
 find_library(LIB_QT_UI NAMES Qt5WindowsUIAutomationSupport)
 find_library(LIB_QT_EVENT NAMES Qt5EventDispatcherSupport)
 find_library(LIB_QT_THEME NAMES Qt5ThemeSupport)
+find_library(LIB_QT_PRINT NAMES Qt5PrintSupport)
 # ICO is needed to set Win32 icon on the Window
 # also all of these image plugins are very small about 100kb~ each
 find_library(LIB_QT_ICO NAMES qico PATHS "${QT_DIR}/plugins/imageformats")
@@ -207,6 +210,7 @@ target_link_libraries(${EXE} PRIVATE "$<IF:$<CONFIG:Debug>,${LIB_QT_PLATFORM_D},
                       "$<IF:$<CONFIG:Debug>,${LIB_QT_UI_D},${LIB_QT_UI}>"
                       "$<IF:$<CONFIG:Debug>,${LIB_QT_EVENT_D},${LIB_QT_EVENT}>"
                       "$<IF:$<CONFIG:Debug>,${LIB_QT_THEME_D},${LIB_QT_THEME}>"
+                      "$<IF:$<CONFIG:Debug>,${LIB_QT_PRINT_D},${LIB_QT_PRINT}>"
                       "$<IF:$<CONFIG:Debug>,${LIB_QT_ICO_D},${LIB_QT_ICO}>"
                       "$<IF:$<CONFIG:Debug>,${LIB_QT_GIF_D},${LIB_QT_GIF}>"
                       "$<IF:$<CONFIG:Debug>,${LIB_QT_JPEG_D},${LIB_QT_JPEG}>"

--- a/CmakeLists.txt
+++ b/CmakeLists.txt
@@ -27,9 +27,11 @@ set(RGM_SOURCES
     MainWindow.cpp
     Dialogs/PreferencesDialog.cpp
     Editors/BaseEditor.cpp
+    Editors/CodeEditor.cpp
     Editors/BackgroundEditor.cpp
     Editors/ObjectEditor.cpp
     Editors/SoundEditor.cpp
+    Editors/ScriptEditor.cpp
     Editors/FontEditor.cpp
     Editors/PathEditor.cpp
     Editors/TimelineEditor.cpp
@@ -53,10 +55,12 @@ set(RGM_HEADERS
     MainWindow.h
     Dialogs/PreferencesDialog.h
     Dialogs/PreferencesKeys.h
+    Editors/CodeEditor.h
     Editors/BaseEditor.h
     Editors/BackgroundEditor.h
     Editors/ObjectEditor.h
     Editors/SoundEditor.h
+    Editors/ScriptEditor.h
     Editors/FontEditor.h
     Editors/PathEditor.h
     Editors/TimelineEditor.h
@@ -79,6 +83,7 @@ set(RGM_UI
     MainWindow.ui
     Dialogs/PreferencesDialog.ui
     Dialogs/AddImageDialog.ui
+    Editors/CodeEditor.ui
     Editors/BackgroundEditor.ui
     Editors/ObjectEditor.ui
     Editors/FontEditor.ui
@@ -101,7 +106,7 @@ set(EDITOR_SOURCES Widgets/CodeWidgetPlain.cpp)
 #endif()
 
 # Tell CMake to create the RadialGM executable
-add_executable(${EXE} WIN32 ${RGM_UI} ${RGM_HEADERS} ${RGM_SOURCES} ${RGM_RC})
+add_executable(${EXE} WIN32 ${RGM_UI} ${RGM_HEADERS} ${RGM_SOURCES} ${EDITOR_SOURCES} ${RGM_RC})
 
 message(STATUS "Initial build flags:")
 set(CompilerFlags

--- a/CmakeLists.txt
+++ b/CmakeLists.txt
@@ -45,6 +45,7 @@ set(RGM_SOURCES
     Components/Utility.cpp
     Components/RecentFiles.cpp
     Widgets/BackgroundRenderer.cpp
+    Widgets/CodeWidget.cpp
     Plugins/RGMPlugin.cpp
     Plugins/ServerPlugin.cpp
     qtplugins.cpp

--- a/CmakeLists.txt
+++ b/CmakeLists.txt
@@ -109,8 +109,6 @@ endif()
 # Tell CMake to create the RadialGM executable
 add_executable(${EXE} WIN32 ${RGM_UI} ${RGM_HEADERS} ${RGM_SOURCES} ${EDITOR_SOURCES} ${RGM_RC})
 
-set(CMAKE_SHARED_LINKER_FLAGS ${CMAKE_SHARED_LINKER_FLAGS} "/FORCE:MULTIPLE")
-
 message(STATUS "Initial build flags:")
 set(CompilerFlags
 	  CMAKE_C_FLAGS_DEBUG
@@ -128,7 +126,7 @@ foreach(CompilerFlag ${CompilerFlags})
 endforeach()
 
 if (LIB_QSCINTILLA)
-    target_link_libraries(${EXE} PRIVATE ${LIB_QSCINTILLA})
+    target_link_libraries(${EXE} PUBLIC ${LIB_QSCINTILLA})
 endif()
 
 # Find PugiXML

--- a/CmakeLists.txt
+++ b/CmakeLists.txt
@@ -125,6 +125,11 @@ foreach(CompilerFlag ${CompilerFlags})
   message(STATUS "  '${CompilerFlag}': ${${CompilerFlag}}")
 endforeach()
 
+# Find FreeType
+find_package(Freetype REQUIRED)
+include_directories(${FREETYPE_INCLUDE_DIRS})
+target_link_libraries(${EXE} PRIVATE ${FREETYPE_LIBRARIES})
+
 # Find PugiXML
 find_library(LIB_PUGIXML NAMES pugixml)
 target_link_libraries(${EXE} PRIVATE ${LIB_PUGIXML})
@@ -218,11 +223,6 @@ target_link_libraries(${EXE} PRIVATE "$<IF:$<CONFIG:Debug>,${LIB_QT_PLATFORM_D},
                       "$<IF:$<CONFIG:Debug>,${LIB_QT_WINVISTASTYLE_D},${LIB_QT_WINVISTASTYLE}>"
                       "$<IF:$<CONFIG:Debug>,${LIB_QT_WIN_D},${LIB_QT_WIN}>"
 					  )
-
-# Find FreeType
-find_package(Freetype REQUIRED)
-include_directories(${FREETYPE_INCLUDE_DIRS})
-target_link_libraries(${EXE} PRIVATE ${FREETYPE_LIBRARIES})
 
 # Find JPEG
 find_library(LIB_JPEG NAMES jpeg)

--- a/CmakeLists.txt
+++ b/CmakeLists.txt
@@ -106,10 +106,6 @@ else()
     set(EDITOR_SOURCES Widgets/CodeWidgetScintilla.cpp)
 endif()
 
-if (LIB_QSCINTILLA)
-    target_link_libraries(${EXE} PRIVATE ${LIB_QSCINTILLA})
-endif()
-
 # Tell CMake to create the RadialGM executable
 add_executable(${EXE} WIN32 ${RGM_UI} ${RGM_HEADERS} ${RGM_SOURCES} ${EDITOR_SOURCES} ${RGM_RC})
 
@@ -128,6 +124,10 @@ foreach(CompilerFlag ${CompilerFlags})
   string(REPLACE "/MD" "/MT" ${CompilerFlag} "${${CompilerFlag}}")
   message(STATUS "  '${CompilerFlag}': ${${CompilerFlag}}")
 endforeach()
+
+if (LIB_QSCINTILLA)
+    target_link_libraries(${EXE} PRIVATE ${LIB_QSCINTILLA})
+endif()
 
 # Find PugiXML
 find_library(LIB_PUGIXML NAMES pugixml)

--- a/CmakeLists.txt
+++ b/CmakeLists.txt
@@ -167,8 +167,8 @@ find_package(OpenSSL REQUIRED)
 target_link_libraries(${EXE} PRIVATE OpenSSL::SSL OpenSSL::Crypto)
 
 # Find Qt
-find_package(Qt5 COMPONENTS Core Widgets Gui REQUIRED)
-target_link_libraries(${EXE} PRIVATE Qt5::Core Qt5::WinMain Qt5::Core Qt5::Widgets Qt5::Gui Qt5::Gui)
+find_package(Qt5 Qt5PrintSupport COMPONENTS Core Widgets Gui REQUIRED)
+target_link_libraries(${EXE} PRIVATE Qt5::Core Qt5::WinMain Qt5::Core Qt5::Widgets Qt5::Gui Qt5::Gui Qt5::PrintSupport)
 
 # Debug
 find_library(LIB_QT_PLATFORM_D NAMES Qt5PlatformCompositorSupportd)

--- a/CmakeLists.txt
+++ b/CmakeLists.txt
@@ -100,10 +100,10 @@ set(RGM_RC
 
 # Check for QScintilla
 set(EDITOR_SOURCES Widgets/CodeWidgetPlain.cpp)
-#find_package(QScintilla)
-#if (QSCINTILLA_FOUND)
-#	set(EDITOR_SOURCES Widgets/CodeWidgetScintilla.cpp)
-#endif()
+find_package(qscintilla)
+if (QSCINTILLA_FOUND)
+	set(EDITOR_SOURCES Widgets/CodeWidgetScintilla.cpp)
+endif()
 
 # Tell CMake to create the RadialGM executable
 add_executable(${EXE} WIN32 ${RGM_UI} ${RGM_HEADERS} ${RGM_SOURCES} ${EDITOR_SOURCES} ${RGM_RC})
@@ -124,9 +124,9 @@ foreach(CompilerFlag ${CompilerFlags})
   message(STATUS "  '${CompilerFlag}': ${${CompilerFlag}}")
 endforeach()
 
-#if (QSCINTILLA_FOUND)
-#	target_link_libraries(${EXE} PRIVATE qscintilla)
-#endif()
+if (QSCINTILLA_FOUND)
+	target_link_libraries(${EXE} PRIVATE qscintilla)
+endif()
 
 # Find PugiXML
 find_library(LIB_PUGIXML NAMES pugixml)

--- a/CmakeLists.txt
+++ b/CmakeLists.txt
@@ -202,7 +202,7 @@ find_library(LIB_QT_WINVISTASTYLE NAMES qwindowsvistastyle PATHS "${QT_DIR}/plug
 find_library(LIB_QT_WIN NAMES qwindows PATHS "${QT_DIR}/plugins/platforms")
 
 target_link_libraries(${EXE} PRIVATE "$<IF:$<CONFIG:Debug>,${LIB_QT_PLATFORM_D},${LIB_QT_PLATFORM}>"
-#                      "$<IF:$<CONFIG:Debug>,${LIB_QT_FONT_D},${LIB_QT_FONT}>"
+                      "$<IF:$<CONFIG:Debug>,${LIB_QT_FONT_D},${LIB_QT_FONT}>"
                       "$<IF:$<CONFIG:Debug>,${LIB_QT_UI_D},${LIB_QT_UI}>"
                       "$<IF:$<CONFIG:Debug>,${LIB_QT_EVENT_D},${LIB_QT_EVENT}>"
                       "$<IF:$<CONFIG:Debug>,${LIB_QT_THEME_D},${LIB_QT_THEME}>"
@@ -216,7 +216,7 @@ target_link_libraries(${EXE} PRIVATE "$<IF:$<CONFIG:Debug>,${LIB_QT_PLATFORM_D},
                       )
 
 if (LIB_QSCINTILLA)
-    target_link_libraries(${EXE} PRIVATE ${LIB_QSCINTILLA})
+    #target_link_libraries(${EXE} PRIVATE ${LIB_QSCINTILLA})
 endif()
 
 # Find FreeType

--- a/CmakeLists.txt
+++ b/CmakeLists.txt
@@ -125,11 +125,6 @@ foreach(CompilerFlag ${CompilerFlags})
   message(STATUS "  '${CompilerFlag}': ${${CompilerFlag}}")
 endforeach()
 
-# Find FreeType
-find_package(Freetype REQUIRED)
-include_directories(${FREETYPE_INCLUDE_DIRS})
-target_link_libraries(${EXE} PRIVATE ${FREETYPE_LIBRARIES})
-
 # Find PugiXML
 find_library(LIB_PUGIXML NAMES pugixml)
 target_link_libraries(${EXE} PRIVATE ${LIB_PUGIXML})
@@ -223,6 +218,11 @@ target_link_libraries(${EXE} PRIVATE "$<IF:$<CONFIG:Debug>,${LIB_QT_PLATFORM_D},
 if (LIB_QSCINTILLA)
     target_link_libraries(${EXE} PRIVATE ${LIB_QSCINTILLA})
 endif()
+
+# Find FreeType
+find_package(Freetype REQUIRED)
+include_directories(${FREETYPE_INCLUDE_DIRS})
+target_link_libraries(${EXE} PRIVATE ${FREETYPE_LIBRARIES})
 
 # Find JPEG
 find_library(LIB_JPEG NAMES jpeg)

--- a/CmakeLists.txt
+++ b/CmakeLists.txt
@@ -167,7 +167,7 @@ find_package(OpenSSL REQUIRED)
 target_link_libraries(${EXE} PRIVATE OpenSSL::SSL OpenSSL::Crypto)
 
 # Find Qt
-find_package(Qt5 Qt5PrintSupport COMPONENTS Core Widgets Gui REQUIRED)
+find_package(Qt5 COMPONENTS Core Widgets Gui PrintSupport REQUIRED)
 target_link_libraries(${EXE} PRIVATE Qt5::Core Qt5::WinMain Qt5::Core Qt5::Widgets Qt5::Gui Qt5::Gui Qt5::PrintSupport)
 
 # Debug

--- a/Components/RecentFiles.cpp
+++ b/Components/RecentFiles.cpp
@@ -50,7 +50,9 @@ void RecentFiles::updateActions() {
   for (; i < count; ++i) {
     const QString fileName = QFileInfo(recentFiles.at(i)).fileName();
     QString numberString = QString::number(i + 1);
-    recentFileActs[i]->setText(numberString.insert(numberString.length() - 1, '&') + " " + fileName);
+    numberString = numberString.insert(numberString.length() - 1, '&');
+    QString text = tr("%1 %2").arg(numberString).arg(fileName);
+    recentFileActs[i]->setText(text);
     recentFileActs[i]->setData(recentFiles.at(i));
     recentFileActs[i]->setVisible(true);
   }

--- a/Editors/CodeEditor.cpp
+++ b/Editors/CodeEditor.cpp
@@ -1,7 +1,25 @@
 #include "CodeEditor.h"
-
 CodeEditor::CodeEditor(ProtoModel *model, QWidget *parent) : BaseEditor(model, parent), ui(new Ui::CodeEditor) {
   ui->setupUi(this);
+
+  cursorPositionLabel = new QLabel(ui->statusBar);
+  lineCountLabel = new QLabel(ui->statusBar);
+
+  ui->statusBar->addWidget(cursorPositionLabel);
+  ui->statusBar->addWidget(lineCountLabel);
+
+  // make sure we set the status labels at least once
+  updateCursorPositionLabel(1, 1);
+  updateLineCountLabel(1);
+
+  connect(ui->codeWidget, &CodeWidget::cursorPositionChanged, this, &CodeEditor::updateCursorPositionLabel);
+  connect(ui->codeWidget, &CodeWidget::lineCountChanged, this, &CodeEditor::updateLineCountLabel);
 }
 
 CodeEditor::~CodeEditor() { delete ui; }
+
+void CodeEditor::updateCursorPositionLabel(int line, int index) {
+  this->cursorPositionLabel->setText(tr("Ln %0, Col %1").arg(line).arg(index));
+}
+
+void CodeEditor::updateLineCountLabel(int lines) { this->lineCountLabel->setText(tr("Lines %0").arg(lines)); }

--- a/Editors/CodeEditor.cpp
+++ b/Editors/CodeEditor.cpp
@@ -1,4 +1,6 @@
 #include "CodeEditor.h"
+#include "ui_CodeEditor.h"
+
 CodeEditor::CodeEditor(ProtoModel *model, QWidget *parent) : BaseEditor(model, parent), ui(new Ui::CodeEditor) {
   ui->setupUi(this);
 

--- a/Editors/CodeEditor.cpp
+++ b/Editors/CodeEditor.cpp
@@ -9,17 +9,24 @@ CodeEditor::CodeEditor(ProtoModel *model, QWidget *parent) : BaseEditor(model, p
   ui->statusBar->addWidget(lineCountLabel);
 
   // make sure we set the status labels at least once
-  updateCursorPositionLabel(1, 1);
-  updateLineCountLabel(1);
+  updateCursorPositionLabel();
+  updateLineCountLabel();
 
-  connect(ui->codeWidget, &CodeWidget::cursorPositionChanged, this, &CodeEditor::updateCursorPositionLabel);
-  connect(ui->codeWidget, &CodeWidget::lineCountChanged, this, &CodeEditor::updateLineCountLabel);
+  connect(ui->codeWidget, &CodeWidget::cursorPositionChanged, this, &CodeEditor::setCursorPositionLabel);
+  connect(ui->codeWidget, &CodeWidget::lineCountChanged, this, &CodeEditor::setLineCountLabel);
 }
 
 CodeEditor::~CodeEditor() { delete ui; }
 
-void CodeEditor::updateCursorPositionLabel(int line, int index) {
+void CodeEditor::setCursorPositionLabel(int line, int index) {
   this->cursorPositionLabel->setText(tr("Ln %0, Col %1").arg(line).arg(index));
 }
 
-void CodeEditor::updateLineCountLabel(int lines) { this->lineCountLabel->setText(tr("Lines %0").arg(lines)); }
+void CodeEditor::setLineCountLabel(int lines) { this->lineCountLabel->setText(tr("Lines %0").arg(lines)); }
+
+void CodeEditor::updateCursorPositionLabel() {
+  auto cursorPosition = this->ui->codeWidget->cursorPosition();
+  this->setCursorPositionLabel(cursorPosition.first, cursorPosition.second);
+}
+
+void CodeEditor::updateLineCountLabel() { this->setLineCountLabel(this->ui->codeWidget->lineCount()); }

--- a/Editors/CodeEditor.cpp
+++ b/Editors/CodeEditor.cpp
@@ -1,0 +1,7 @@
+#include "CodeEditor.h"
+
+CodeEditor::CodeEditor(ProtoModel *model, QWidget *parent) : BaseEditor(model, parent), ui(new Ui::CodeEditor) {
+  ui->setupUi(this);
+}
+
+CodeEditor::~CodeEditor() { delete ui; }

--- a/Editors/CodeEditor.h
+++ b/Editors/CodeEditor.h
@@ -1,0 +1,22 @@
+#ifndef CODEEDITOR_H
+#define CODEEDITOR_H
+
+#include "BaseEditor.h"
+#include "ui_CodeEditor.h"
+
+namespace Ui {
+class CodeEditor;
+}
+
+class CodeEditor : public BaseEditor {
+  Q_OBJECT
+
+ public:
+  explicit CodeEditor(ProtoModel *model, QWidget *parent);
+  ~CodeEditor();
+
+ protected:
+  Ui::CodeEditor *ui;
+};
+
+#endif  // CODEEDITOR_H

--- a/Editors/CodeEditor.h
+++ b/Editors/CodeEditor.h
@@ -4,6 +4,8 @@
 #include "BaseEditor.h"
 #include "ui_CodeEditor.h"
 
+#include <QLabel>
+
 namespace Ui {
 class CodeEditor;
 }
@@ -15,8 +17,15 @@ class CodeEditor : public BaseEditor {
   explicit CodeEditor(ProtoModel *model, QWidget *parent);
   ~CodeEditor();
 
+ private slots:
+  void updateCursorPositionLabel(int line, int index);
+  void updateLineCountLabel(int lines);
+
  protected:
   Ui::CodeEditor *ui;
+
+ private:
+  QLabel *cursorPositionLabel, *lineCountLabel;
 };
 
 #endif  // CODEEDITOR_H

--- a/Editors/CodeEditor.h
+++ b/Editors/CodeEditor.h
@@ -2,7 +2,6 @@
 #define CODEEDITOR_H
 
 #include "BaseEditor.h"
-#include "ui_CodeEditor.h"
 
 #include <QLabel>
 

--- a/Editors/CodeEditor.h
+++ b/Editors/CodeEditor.h
@@ -17,9 +17,11 @@ class CodeEditor : public BaseEditor {
   explicit CodeEditor(ProtoModel *model, QWidget *parent);
   ~CodeEditor();
 
- private slots:
-  void updateCursorPositionLabel(int line, int index);
-  void updateLineCountLabel(int lines);
+ public slots:
+  void setCursorPositionLabel(int line, int index);
+  void setLineCountLabel(int lines);
+  void updateCursorPositionLabel();
+  void updateLineCountLabel();
 
  protected:
   Ui::CodeEditor *ui;

--- a/Editors/CodeEditor.ui
+++ b/Editors/CodeEditor.ui
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>CodeEditor</class>
+ <widget class="QWidget" name="CodeEditor">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>656</width>
+    <height>379</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="windowTitle">
+   <string>Background</string>
+  </property>
+  <property name="windowIcon">
+   <iconset resource="../images.qrc">
+    <normaloff>:/resources/background.png</normaloff>:/resources/background.png</iconset>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,1,0">
+   <property name="spacing">
+    <number>0</number>
+   </property>
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item>
+    <widget class="QToolBar" name="mainToolBar">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="iconSize">
+      <size>
+       <width>24</width>
+       <height>24</height>
+      </size>
+     </property>
+     <property name="floatable">
+      <bool>false</bool>
+     </property>
+     <addaction name="actionSave"/>
+     <addaction name="separator"/>
+     <addaction name="actionNewSource"/>
+     <addaction name="actionLoadSource"/>
+     <addaction name="actionSaveSource"/>
+     <addaction name="separator"/>
+    </widget>
+   </item>
+   <item>
+    <widget class="CodeWidget" name="codeWidget" native="true"/>
+   </item>
+   <item>
+    <widget class="QStatusBar" name="statusBar"/>
+   </item>
+  </layout>
+  <action name="actionSave">
+   <property name="icon">
+    <iconset resource="../images.qrc">
+     <normaloff>:/actions/accept.png</normaloff>:/actions/accept.png</iconset>
+   </property>
+   <property name="text">
+    <string>Save and close</string>
+   </property>
+  </action>
+  <action name="actionNewSource">
+   <property name="icon">
+    <iconset resource="../images.qrc">
+     <normaloff>:/actions/new.png</normaloff>:/actions/new.png</iconset>
+   </property>
+   <property name="text">
+    <string>New Source</string>
+   </property>
+   <property name="toolTip">
+    <string>New Source</string>
+   </property>
+  </action>
+  <action name="actionLoadSource">
+   <property name="icon">
+    <iconset resource="../images.qrc">
+     <normaloff>:/actions/open.png</normaloff>:/actions/open.png</iconset>
+   </property>
+   <property name="text">
+    <string>Load Source</string>
+   </property>
+   <property name="toolTip">
+    <string>Load Source</string>
+   </property>
+  </action>
+  <action name="actionSaveSource">
+   <property name="icon">
+    <iconset resource="../images.qrc">
+     <normaloff>:/actions/save.png</normaloff>:/actions/save.png</iconset>
+   </property>
+   <property name="text">
+    <string>Save Source</string>
+   </property>
+   <property name="toolTip">
+    <string>Save Source</string>
+   </property>
+  </action>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>CodeWidget</class>
+   <extends>QWidget</extends>
+   <header>Widgets/CodeWidget.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <resources>
+  <include location="../images.qrc"/>
+ </resources>
+ <connections/>
+</ui>

--- a/Editors/CodeEditor.ui
+++ b/Editors/CodeEditor.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>656</width>
-    <height>379</height>
+    <width>735</width>
+    <height>425</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -61,7 +61,17 @@
      <addaction name="actionNewSource"/>
      <addaction name="actionLoadSource"/>
      <addaction name="actionSaveSource"/>
+     <addaction name="actionPrint"/>
      <addaction name="separator"/>
+     <addaction name="actionUndo"/>
+     <addaction name="actionRedo"/>
+     <addaction name="separator"/>
+     <addaction name="actionCut"/>
+     <addaction name="actionCopy"/>
+     <addaction name="actionPaste"/>
+     <addaction name="separator"/>
+     <addaction name="actionFindAndReplace"/>
+     <addaction name="actionGoToLine"/>
     </widget>
    </item>
    <item>
@@ -114,6 +124,99 @@
    </property>
    <property name="toolTip">
     <string>Save Source</string>
+   </property>
+  </action>
+  <action name="actionPrint">
+   <property name="icon">
+    <iconset resource="../images.qrc">
+     <normaloff>:/actions/print.png</normaloff>:/actions/print.png</iconset>
+   </property>
+   <property name="text">
+    <string>Print</string>
+   </property>
+   <property name="toolTip">
+    <string>Print Source</string>
+   </property>
+  </action>
+  <action name="actionUndo">
+   <property name="icon">
+    <iconset resource="../images.qrc">
+     <normaloff>:/actions/undo.png</normaloff>:/actions/undo.png</iconset>
+   </property>
+   <property name="text">
+    <string>Undo</string>
+   </property>
+   <property name="toolTip">
+    <string>Undo Last Edit</string>
+   </property>
+  </action>
+  <action name="actionRedo">
+   <property name="icon">
+    <iconset resource="../images.qrc">
+     <normaloff>:/actions/redo.png</normaloff>:/actions/redo.png</iconset>
+   </property>
+   <property name="text">
+    <string>Redo</string>
+   </property>
+   <property name="toolTip">
+    <string>Redo Last Edit</string>
+   </property>
+  </action>
+  <action name="actionCut">
+   <property name="icon">
+    <iconset resource="../images.qrc">
+     <normaloff>:/actions/cut.png</normaloff>:/actions/cut.png</iconset>
+   </property>
+   <property name="text">
+    <string>Cut</string>
+   </property>
+   <property name="toolTip">
+    <string>Cut</string>
+   </property>
+  </action>
+  <action name="actionCopy">
+   <property name="icon">
+    <iconset resource="../images.qrc">
+     <normaloff>:/actions/copy.png</normaloff>:/actions/copy.png</iconset>
+   </property>
+   <property name="text">
+    <string>Copy</string>
+   </property>
+   <property name="toolTip">
+    <string>Copy</string>
+   </property>
+  </action>
+  <action name="actionPaste">
+   <property name="icon">
+    <iconset resource="../images.qrc">
+     <normaloff>:/actions/paste.png</normaloff>:/actions/paste.png</iconset>
+   </property>
+   <property name="text">
+    <string>Paste</string>
+   </property>
+  </action>
+  <action name="actionFindAndReplace">
+   <property name="icon">
+    <iconset resource="../images.qrc">
+     <normaloff>:/actions/find.png</normaloff>:/actions/find.png</iconset>
+   </property>
+   <property name="text">
+    <string>Find and Replace</string>
+   </property>
+   <property name="toolTip">
+    <string>Find and Replace</string>
+   </property>
+  </action>
+  <action name="actionGoToLine">
+   <property name="icon">
+    <iconset resource="../images.qrc">
+     <normaloff>:/actions/line-goto.png</normaloff>:/actions/line-goto.png</iconset>
+   </property>
+   <property name="text">
+    <string>Go to line</string>
+   </property>
+   <property name="toolTip">
+    <string>Go to line</string>
    </property>
   </action>
  </widget>

--- a/Editors/CodeEditor.ui
+++ b/Editors/CodeEditor.ui
@@ -21,7 +21,7 @@
   </property>
   <property name="windowIcon">
    <iconset resource="../images.qrc">
-    <normaloff>:/resources/background.png</normaloff>:/resources/background.png</iconset>
+    <normaloff>:/resources/script.png</normaloff>:/resources/script.png</iconset>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout" stretch="0,1,0">
    <property name="spacing">
@@ -206,6 +206,9 @@
    <property name="toolTip">
     <string>Find and Replace</string>
    </property>
+   <property name="visible">
+    <bool>false</bool>
+   </property>
   </action>
   <action name="actionGoToLine">
    <property name="icon">
@@ -232,6 +235,11 @@
     <slot>paste()</slot>
     <slot>undo()</slot>
     <slot>redo()</slot>
+    <slot>newSource()</slot>
+    <slot>loadSource()</slot>
+    <slot>saveSource()</slot>
+    <slot>printSource()</slot>
+    <slot>gotoLineDialog()</slot>
    </slots>
   </customwidget>
  </customwidgets>
@@ -308,6 +316,86 @@
    <signal>triggered()</signal>
    <receiver>codeWidget</receiver>
    <slot>redo()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>-1</x>
+     <y>-1</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>367</x>
+     <y>214</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>actionNewSource</sender>
+   <signal>triggered()</signal>
+   <receiver>codeWidget</receiver>
+   <slot>newSource()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>-1</x>
+     <y>-1</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>367</x>
+     <y>214</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>actionLoadSource</sender>
+   <signal>triggered()</signal>
+   <receiver>codeWidget</receiver>
+   <slot>loadSource()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>-1</x>
+     <y>-1</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>367</x>
+     <y>214</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>actionSaveSource</sender>
+   <signal>triggered()</signal>
+   <receiver>codeWidget</receiver>
+   <slot>saveSource()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>-1</x>
+     <y>-1</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>367</x>
+     <y>214</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>actionPrint</sender>
+   <signal>triggered()</signal>
+   <receiver>codeWidget</receiver>
+   <slot>printSource()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>-1</x>
+     <y>-1</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>367</x>
+     <y>214</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>actionGoToLine</sender>
+   <signal>triggered()</signal>
+   <receiver>codeWidget</receiver>
+   <slot>gotoLineDialog()</slot>
    <hints>
     <hint type="sourcelabel">
      <x>-1</x>

--- a/Editors/CodeEditor.ui
+++ b/Editors/CodeEditor.ui
@@ -226,10 +226,98 @@
    <extends>QWidget</extends>
    <header>Widgets/CodeWidget.h</header>
    <container>1</container>
+   <slots>
+    <slot>cut()</slot>
+    <slot>copy()</slot>
+    <slot>paste()</slot>
+    <slot>undo()</slot>
+    <slot>redo()</slot>
+   </slots>
   </customwidget>
  </customwidgets>
  <resources>
   <include location="../images.qrc"/>
  </resources>
- <connections/>
+ <connections>
+  <connection>
+   <sender>actionCut</sender>
+   <signal>triggered()</signal>
+   <receiver>codeWidget</receiver>
+   <slot>cut()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>-1</x>
+     <y>-1</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>367</x>
+     <y>214</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>actionCopy</sender>
+   <signal>triggered()</signal>
+   <receiver>codeWidget</receiver>
+   <slot>copy()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>-1</x>
+     <y>-1</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>367</x>
+     <y>214</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>actionPaste</sender>
+   <signal>triggered()</signal>
+   <receiver>codeWidget</receiver>
+   <slot>paste()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>-1</x>
+     <y>-1</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>367</x>
+     <y>214</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>actionUndo</sender>
+   <signal>triggered()</signal>
+   <receiver>codeWidget</receiver>
+   <slot>undo()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>-1</x>
+     <y>-1</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>367</x>
+     <y>214</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>actionRedo</sender>
+   <signal>triggered()</signal>
+   <receiver>codeWidget</receiver>
+   <slot>redo()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>-1</x>
+     <y>-1</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>367</x>
+     <y>214</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
 </ui>

--- a/Editors/ScriptEditor.cpp
+++ b/Editors/ScriptEditor.cpp
@@ -1,0 +1,13 @@
+#include "ScriptEditor.h"
+
+#include "codegen/Script.pb.h"
+
+using namespace buffers::resources;
+
+ScriptEditor::ScriptEditor(ProtoModel *model, QWidget *parent) : CodeEditor(model, parent) {
+  mapper->addMapping(ui->codeWidget, Script::kCodeFieldNumber);
+  mapper->toFirst();
+  //ui->codeWidget->setCode()
+}
+
+ScriptEditor::~ScriptEditor() {}

--- a/Editors/ScriptEditor.cpp
+++ b/Editors/ScriptEditor.cpp
@@ -7,7 +7,6 @@ using namespace buffers::resources;
 ScriptEditor::ScriptEditor(ProtoModel *model, QWidget *parent) : CodeEditor(model, parent) {
   mapper->addMapping(ui->codeWidget, Script::kCodeFieldNumber);
   mapper->toFirst();
-  //ui->codeWidget->setCode()
 }
 
 ScriptEditor::~ScriptEditor() {}

--- a/Editors/ScriptEditor.cpp
+++ b/Editors/ScriptEditor.cpp
@@ -7,6 +7,9 @@ using namespace buffers::resources;
 ScriptEditor::ScriptEditor(ProtoModel *model, QWidget *parent) : CodeEditor(model, parent) {
   mapper->addMapping(ui->codeWidget, Script::kCodeFieldNumber);
   mapper->toFirst();
+
+  this->updateCursorPositionLabel();
+  this->updateLineCountLabel();
 }
 
 ScriptEditor::~ScriptEditor() {}

--- a/Editors/ScriptEditor.cpp
+++ b/Editors/ScriptEditor.cpp
@@ -1,4 +1,5 @@
 #include "ScriptEditor.h"
+#include "ui_CodeEditor.h"
 
 #include "codegen/Script.pb.h"
 

--- a/Editors/ScriptEditor.h
+++ b/Editors/ScriptEditor.h
@@ -1,0 +1,14 @@
+#ifndef SCRIPTEDITOR_H
+#define SCRIPTEDITOR_H
+
+#include "Editors/CodeEditor.h"
+
+class ScriptEditor : public CodeEditor {
+  Q_OBJECT
+
+ public:
+  ScriptEditor(ProtoModel *model, QWidget *parent = nullptr);
+  ~ScriptEditor();
+};
+
+#endif  // SCRIPTEDITOR_H

--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -127,11 +127,6 @@ void MainWindow::openSubWindow(buffers::TreeNode *item) {
     subWindow->resize(subWindow->frameSize().expandedTo(editor->size()));
     editor->setParent(subWindow);
 
-    connect(subWindow, &QMdiSubWindow::windowStateChanged, [=](Qt::WindowStates oldState, Qt::WindowStates newState) {
-      if (newState.testFlag(Qt::WindowMaximized) && !oldState.testFlag(Qt::WindowMaximized)) {
-        this->setTabbedMode(true);
-      }
-    });
     subWindow->connect(subWindow, &QObject::destroyed, [=]() {
       resourceModels.remove(item);
       subWindows.remove(item);

--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -61,8 +61,7 @@ void MainWindow::readSettings() {
   settings.beginGroup("MainWindow");
   restoreGeometry(settings.value("geometry").toByteArray());
   restoreState(settings.value("state").toByteArray());
-  ui->actionToggleTabbedView->setChecked(settings.value("tabbedView", false).toBool());
-  this->on_actionToggleTabbedView_triggered();
+  setTabbedMode(settings.value("tabbedView", false).toBool());
   settings.endGroup();
 }
 
@@ -193,19 +192,30 @@ void MainWindow::on_actionPreferences_triggered() {
 
 void MainWindow::on_actionExit_triggered() { QApplication::exit(); }
 
-void MainWindow::on_actionCascade_triggered() { ui->mdiArea->cascadeSubWindows(); }
+void MainWindow::setTabbedMode(bool enabled) {
+  ui->actionToggleTabbedView->setChecked(enabled);
+  ui->mdiArea->setViewMode(enabled ? QMdiArea::TabbedView : QMdiArea::SubWindowView);
+  if (enabled) {
+    QTabBar *tabBar = ui->mdiArea->findChild<QTabBar *>();
+    if (tabBar) {
+      tabBar->setExpanding(false);
+    }
+  }
+}
 
-void MainWindow::on_actionTile_triggered() { ui->mdiArea->tileSubWindows(); }
+void MainWindow::on_actionCascade_triggered() {
+  this->setTabbedMode(false);
+  ui->mdiArea->cascadeSubWindows();
+}
+
+void MainWindow::on_actionTile_triggered() {
+  this->setTabbedMode(false);
+  ui->mdiArea->tileSubWindows();
+}
 
 void MainWindow::on_actionCloseAll_triggered() { ui->mdiArea->closeAllSubWindows(); }
 
-void MainWindow::on_actionToggleTabbedView_triggered() {
-  ui->mdiArea->setViewMode(ui->actionToggleTabbedView->isChecked() ? QMdiArea::TabbedView : QMdiArea::SubWindowView);
-  QTabBar *tabBar = ui->mdiArea->findChild<QTabBar *>();
-  if (tabBar) {
-    tabBar->setExpanding(false);
-  }
-}
+void MainWindow::on_actionToggleTabbedView_triggered() { this->setTabbedMode(ui->actionToggleTabbedView->isChecked()); }
 
 void MainWindow::on_actionNext_triggered() { ui->mdiArea->activateNextSubWindow(); }
 

--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -220,6 +220,12 @@ void MainWindow::on_actionTile_triggered() {
 
 void MainWindow::on_actionCloseAll_triggered() { ui->mdiArea->closeAllSubWindows(); }
 
+void MainWindow::on_actionCloseOthers_triggered() {
+  foreach (QMdiSubWindow *subWindow, ui->mdiArea->subWindowList()) {
+    if (subWindow != ui->mdiArea->activeSubWindow()) subWindow->close();
+  }
+}
+
 void MainWindow::on_actionToggleTabbedView_triggered() { this->setTabbedMode(ui->actionToggleTabbedView->isChecked()); }
 
 void MainWindow::on_actionNext_triggered() { ui->mdiArea->activateNextSubWindow(); }

--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -9,6 +9,7 @@
 #include "Editors/ObjectEditor.h"
 #include "Editors/PathEditor.h"
 #include "Editors/RoomEditor.h"
+#include "Editors/ScriptEditor.h"
 #include "Editors/SoundEditor.h"
 #include "Editors/SpriteEditor.h"
 #include "Editors/TimelineEditor.h"
@@ -95,6 +96,7 @@ void MainWindow::openSubWindow(buffers::TreeNode *item) {
                                 {TypeCase::kBackground, EditorFactory<BackgroundEditor>},
                                 {TypeCase::kPath, EditorFactory<PathEditor>},
                                 {TypeCase::kFont, EditorFactory<FontEditor>},
+                                {TypeCase::kScript, EditorFactory<ScriptEditor>},
                                 {TypeCase::kTimeline, EditorFactory<TimelineEditor>},
                                 {TypeCase::kObject, EditorFactory<ObjectEditor>},
                                 {TypeCase::kRoom, EditorFactory<RoomEditor>}});

--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -61,6 +61,8 @@ void MainWindow::readSettings() {
   settings.beginGroup("MainWindow");
   restoreGeometry(settings.value("geometry").toByteArray());
   restoreState(settings.value("state").toByteArray());
+  ui->actionToggleTabbedView->setChecked(settings.value("tabbedView", false).toBool());
+  this->on_actionToggleTabbedView_triggered();
   settings.endGroup();
 }
 
@@ -71,6 +73,7 @@ void MainWindow::writeSettings() {
   settings.beginGroup("MainWindow");
   settings.setValue("geometry", saveGeometry());
   settings.setValue("state", saveState());
+  settings.setValue("tabbedView", ui->actionToggleTabbedView->isChecked());
   settings.endGroup();
 }
 
@@ -198,6 +201,10 @@ void MainWindow::on_actionCloseAll_triggered() { ui->mdiArea->closeAllSubWindows
 
 void MainWindow::on_actionToggleTabbedView_triggered() {
   ui->mdiArea->setViewMode(ui->actionToggleTabbedView->isChecked() ? QMdiArea::TabbedView : QMdiArea::SubWindowView);
+  QTabBar *tabBar = ui->mdiArea->findChild<QTabBar *>();
+  if (tabBar) {
+    tabBar->setExpanding(false);
+  }
 }
 
 void MainWindow::on_actionNext_triggered() { ui->mdiArea->activateNextSubWindow(); }

--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -127,6 +127,11 @@ void MainWindow::openSubWindow(buffers::TreeNode *item) {
     subWindow->resize(subWindow->frameSize().expandedTo(editor->size()));
     editor->setParent(subWindow);
 
+    connect(subWindow, &QMdiSubWindow::windowStateChanged, [=](Qt::WindowStates oldState, Qt::WindowStates newState) {
+      if (newState.testFlag(Qt::WindowMaximized) && !oldState.testFlag(Qt::WindowMaximized)) {
+        this->setTabbedMode(true);
+      }
+    });
     subWindow->connect(subWindow, &QObject::destroyed, [=]() {
       resourceModels.remove(item);
       subWindows.remove(item);

--- a/MainWindow.h
+++ b/MainWindow.h
@@ -70,6 +70,7 @@ class MainWindow : public QMainWindow {
   void openSubWindow(buffers::TreeNode *item);
   void readSettings();
   void writeSettings();
+  void setTabbedMode(bool enabled);
 };
 
 #endif  // MAINWINDOW_H

--- a/MainWindow.h
+++ b/MainWindow.h
@@ -46,6 +46,7 @@ class MainWindow : public QMainWindow {
   void on_actionCloseOthers_triggered();
   void on_actionNext_triggered();
   void on_actionPrevious_triggered();
+  void updateWindowMenu();
 
   // help menu
   void on_actionDocumentation_triggered();

--- a/MainWindow.h
+++ b/MainWindow.h
@@ -34,6 +34,7 @@ class MainWindow : public QMainWindow {
  private slots:
   // file menu
   void on_actionOpen_triggered();
+  void on_actionClearRecentMenu_triggered();
   void on_actionPreferences_triggered();
   void on_actionExit_triggered();
 
@@ -42,6 +43,7 @@ class MainWindow : public QMainWindow {
   void on_actionTile_triggered();
   void on_actionToggleTabbedView_triggered();
   void on_actionCloseAll_triggered();
+  void on_actionCloseOthers_triggered();
   void on_actionNext_triggered();
   void on_actionPrevious_triggered();
 
@@ -54,8 +56,6 @@ class MainWindow : public QMainWindow {
   void on_actionAbout_triggered();
 
   void on_treeView_doubleClicked(const QModelIndex &index);
-
-  void on_actionClearRecentMenu_triggered();
 
  private:
   QHash<buffers::TreeNode *, ProtoModel *> resourceModels;

--- a/MainWindow.ui
+++ b/MainWindow.ui
@@ -195,6 +195,9 @@
    <addaction name="menuHelp"/>
   </widget>
   <widget class="QToolBar" name="mainToolBar">
+   <property name="windowTitle">
+    <string>Toolbar</string>
+   </property>
    <property name="iconSize">
     <size>
      <width>24</width>

--- a/MainWindow.ui
+++ b/MainWindow.ui
@@ -87,6 +87,9 @@
       <property name="tabShape">
        <enum>QTabWidget::Rounded</enum>
       </property>
+      <property name="tabPosition">
+       <enum>QTabWidget::North</enum>
+      </property>
      </widget>
     </item>
    </layout>
@@ -97,7 +100,7 @@
      <x>0</x>
      <y>0</y>
      <width>1200</width>
-     <height>24</height>
+     <height>31</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">

--- a/MainWindow.ui
+++ b/MainWindow.ui
@@ -140,6 +140,9 @@
     </property>
    </widget>
    <widget class="QMenu" name="menuWindow">
+    <property name="tearOffEnabled">
+     <bool>false</bool>
+    </property>
     <property name="title">
      <string>&amp;Window</string>
     </property>
@@ -152,6 +155,7 @@
     <addaction name="separator"/>
     <addaction name="actionNext"/>
     <addaction name="actionPrevious"/>
+    <addaction name="separator"/>
    </widget>
    <widget class="QMenu" name="menuHelp">
     <property name="title">

--- a/MainWindow.ui
+++ b/MainWindow.ui
@@ -140,9 +140,6 @@
     </property>
    </widget>
    <widget class="QMenu" name="menuWindow">
-    <property name="tearOffEnabled">
-     <bool>false</bool>
-    </property>
     <property name="title">
      <string>&amp;Window</string>
     </property>

--- a/Models/ImmediateMapper.cpp
+++ b/Models/ImmediateMapper.cpp
@@ -27,8 +27,6 @@ void ImmediateDataWidgetMapper::widgetChanged() {
   delegate->setModelData(editor, model, this->indexAt(this->mappedSection(editor)));
 }
 
-#include <QDebug>
-
 void ImmediateDataWidgetMapper::addMapping(QWidget *widget, int section, QByteArray propertyName) {
   // since QDataWidgetMapper makes its widget map private we have no way of
   // getting all of the widgets registered with this mapper
@@ -40,7 +38,6 @@ void ImmediateDataWidgetMapper::addMapping(QWidget *widget, int section, QByteAr
   // all widgets have several properties, but most have a "primary" property with which
   // the user interacts, i.e. "checked" for QCheckBox
   propertyName = this->mappedPropertyName(widget);
-  qDebug() << propertyName;
   // we use the widget's meta object in order to get us a signal that we can listen to
   // so we know when this property changes
   auto widgetMetaObject = widget->metaObject();

--- a/Models/ImmediateMapper.cpp
+++ b/Models/ImmediateMapper.cpp
@@ -27,6 +27,8 @@ void ImmediateDataWidgetMapper::widgetChanged() {
   delegate->setModelData(editor, model, this->indexAt(this->mappedSection(editor)));
 }
 
+#include <QDebug>
+
 void ImmediateDataWidgetMapper::addMapping(QWidget *widget, int section, QByteArray propertyName) {
   // since QDataWidgetMapper makes its widget map private we have no way of
   // getting all of the widgets registered with this mapper
@@ -38,6 +40,7 @@ void ImmediateDataWidgetMapper::addMapping(QWidget *widget, int section, QByteAr
   // all widgets have several properties, but most have a "primary" property with which
   // the user interacts, i.e. "checked" for QCheckBox
   propertyName = this->mappedPropertyName(widget);
+  qDebug() << propertyName;
   // we use the widget's meta object in order to get us a signal that we can listen to
   // so we know when this property changes
   auto widgetMetaObject = widget->metaObject();

--- a/Models/ImmediateMapper.h
+++ b/Models/ImmediateMapper.h
@@ -11,6 +11,7 @@ class ImmediateDataWidgetMapper : public QDataWidgetMapper {
   explicit ImmediateDataWidgetMapper(QObject *parent);
 
   void addMapping(QWidget *widget, int section, QByteArray propertyName = "");
+  void removeMapping(QWidget *widget);
   void clearMapping();
   QModelIndex indexAt(int section);
 

--- a/Models/ProtoModel.cpp
+++ b/Models/ProtoModel.cpp
@@ -110,7 +110,7 @@ QVariant ProtoModel::data(const QModelIndex &index, int role) const {
     case CppType::CPPTYPE_ENUM:
       return refl->GetInt32(*protobuf, field);
     case CppType::CPPTYPE_STRING:
-      return refl->GetString(*protobuf, field).c_str();
+      return QString::fromStdString(refl->GetString(*protobuf, field));
   }
 
   return QVariant();

--- a/RadialGM.pro
+++ b/RadialGM.pro
@@ -4,7 +4,7 @@
 #
 #-------------------------------------------------
 
-QT       += core gui
+QT       += core gui printsupport
 CONFIG   += c++11
 
 greaterThan(QT_MAJOR_VERSION, 4): QT += widgets

--- a/RadialGM.pro
+++ b/RadialGM.pro
@@ -21,9 +21,9 @@ QMAKE_TARGET_DESCRIPTION = ENIGMA Development Environment
 QMAKE_TARGET_COPYRIGHT = "Copyright \\251 2007-2018 ENIGMA Dev Team"
 
 # Uncomment if you want QPlainTextEdit used in place of QScintilla
-#CONFIG += RGM_DISABLE_SYNTAXHIGHLIGHTING
+#CONFIG += rgm_disable_syntaxhighlight
 
-RGM_DISABLE_SYNTAXHIGHLIGHTING {
+rgm_disable_syntaxhighlight {
   SOURCES += Widgets/CodeWidgetPlain.cpp
 } else {
   SOURCES += Widgets/CodeWidgetScintilla.cpp

--- a/RadialGM.pro
+++ b/RadialGM.pro
@@ -68,6 +68,7 @@ SOURCES += \
     Editors/RoomEditor.cpp \
     Editors/SpriteEditor.cpp \
     Widgets/BackgroundRenderer.cpp \
+    Widgets/CodeWidget.cpp \
     Models/TreeModel.cpp \
     Components/ArtManager.cpp \
     Models/ProtoModel.cpp \
@@ -78,7 +79,7 @@ SOURCES += \
     Plugins/ServerPlugin.cpp \
     Components/RecentFiles.cpp \
     Editors/CodeEditor.cpp \
-    Editors/ScriptEditor.cpp
+    Editors/ScriptEditor.cpp \
 
 HEADERS += \
     MainWindow.h \
@@ -93,6 +94,7 @@ HEADERS += \
     Editors/RoomEditor.h \
     Editors/SpriteEditor.h \
     Widgets/BackgroundRenderer.h \
+    Widgets/CodeWidget.h \
     Models/TreeModel.h \
     Components/ArtManager.h \
     Models/ProtoModel.h \
@@ -101,7 +103,6 @@ HEADERS += \
     Components/Utility.h \
     Plugins/RGMPlugin.h \
     Plugins/ServerPlugin.h \
-    Widgets/CodeWidget.h \
     Components/RecentFiles.h \
     main.h \
     Dialogs/PreferencesKeys.h \

--- a/RadialGM.pro
+++ b/RadialGM.pro
@@ -21,9 +21,9 @@ QMAKE_TARGET_DESCRIPTION = ENIGMA Development Environment
 QMAKE_TARGET_COPYRIGHT = "Copyright \\251 2007-2018 ENIGMA Dev Team"
 
 # Uncomment if you want QPlainTextEdit used in place of QScintilla
-#DEFINES += RGM_DISABLE_SYNTAXHIGHLIGHTING
+#CONFIG += RGM_DISABLE_SYNTAXHIGHLIGHTING
 
-contains(DEFINES, RGM_DISABLE_SYNTAXHIGHLIGHTING) {
+RGM_DISABLE_SYNTAXHIGHLIGHTING {
   SOURCES += Widgets/CodeWidgetPlain.cpp
 } else {
   SOURCES += Widgets/CodeWidgetScintilla.cpp

--- a/RadialGM.pro
+++ b/RadialGM.pro
@@ -76,7 +76,9 @@ SOURCES += \
     Components/Utility.cpp \
     Plugins/RGMPlugin.cpp \
     Plugins/ServerPlugin.cpp \
-    Components/RecentFiles.cpp
+    Components/RecentFiles.cpp \
+    Editors/CodeEditor.cpp \
+    Editors/ScriptEditor.cpp
 
 HEADERS += \
     MainWindow.h \
@@ -102,7 +104,9 @@ HEADERS += \
     Widgets/CodeWidget.h \
     Components/RecentFiles.h \
     main.h \
-    Dialogs/PreferencesKeys.h
+    Dialogs/PreferencesKeys.h \
+    Editors/CodeEditor.h \
+    Editors/ScriptEditor.h
 
 FORMS += \
     MainWindow.ui \
@@ -115,7 +119,8 @@ FORMS += \
     Editors/TimelineEditor.ui \
     Editors/RoomEditor.ui \
     Editors/SpriteEditor.ui \
-    Editors/SoundEditor.ui
+    Editors/SoundEditor.ui \
+    Editors/CodeEditor.ui
 
 RESOURCES += \
     images.qrc

--- a/Widgets/CodeWidget.cpp
+++ b/Widgets/CodeWidget.cpp
@@ -1,0 +1,54 @@
+#include "CodeWidget.h"
+
+#include <QFileDialog>
+#include <QInputDialog>
+#include <QMessageBox>
+#include <QTextStream>
+
+void CodeWidget::newSource() {
+  QMessageBox::StandardButton reply;
+  reply = QMessageBox::question(this, tr("New Source"), tr("Are you sure you want to clear the source and start over?"),
+                                QMessageBox::Yes | QMessageBox::No);
+  if (reply == QMessageBox::Yes) {
+    this->setCode("");
+  }
+}
+
+void CodeWidget::loadSource() {
+  QFileDialog fileDialog(this);
+  fileDialog.setWindowModality(Qt::WindowModal);
+  fileDialog.setAcceptMode(QFileDialog::AcceptOpen);
+  fileDialog.setFileMode(QFileDialog::ExistingFile);
+  fileDialog.setMimeTypeFilters(this->fileFilters());
+  if (fileDialog.exec() != QDialog::Accepted) return;
+  const QString fn = fileDialog.selectedFiles().first();
+  if (fn.isEmpty()) return;
+  QFile file(fn);
+
+  file.open(QIODevice::ReadOnly | QIODevice::Text);
+  QTextStream in(&file);
+  this->setCode(in.readAll());
+}
+
+void CodeWidget::saveSource() {
+  QFileDialog fileDialog(this);
+  fileDialog.setWindowModality(Qt::WindowModal);
+  fileDialog.setAcceptMode(QFileDialog::AcceptSave);
+  fileDialog.setMimeTypeFilters(this->fileFilters());
+  if (fileDialog.exec() != QDialog::Accepted) return;
+
+  const QString fn = fileDialog.selectedFiles().first();
+  if (fn.isEmpty()) return;
+  QFile file(fn);
+
+  file.open(QIODevice::WriteOnly | QIODevice::Text);
+  QTextStream out(&file);
+  out << this->code();
+}
+
+void CodeWidget::gotoLineDialog() {
+  bool ok;
+  int lineNumber = QInputDialog::getInt(this, tr("Go to Line"), tr("Line:"), 1, 1, lineCount(), 1, &ok);
+  if (!ok) return;
+  gotoLine(lineNumber);
+}

--- a/Widgets/CodeWidget.h
+++ b/Widgets/CodeWidget.h
@@ -5,12 +5,19 @@
 #include <QWidget>
 
 class CodeWidget : public QWidget {
+  Q_OBJECT
+  Q_PROPERTY(QString code READ code WRITE setCode USER true)
+
  public:
   explicit CodeWidget(QWidget* parent);
   ~CodeWidget();
 
+  QString code() const;
+  void setCode(QString);
+
  protected:
   QFont font;
+  QWidget* textWidget = nullptr;
 };
 
 #endif  // CODEWIDGET_H

--- a/Widgets/CodeWidget.h
+++ b/Widgets/CodeWidget.h
@@ -1,7 +1,11 @@
 #ifndef CODEWIDGET_H
 #define CODEWIDGET_H
 
+#include <QFileDialog>
 #include <QFont>
+#include <QInputDialog>
+#include <QMessageBox>
+#include <QTextStream>
 #include <QWidget>
 
 class CodeWidget : public QWidget {
@@ -14,17 +18,76 @@ class CodeWidget : public QWidget {
 
   QString code() const;
   void setCode(QString);
+  int lineCount();
 
  public slots:
+  void newSource() {
+    QMessageBox::StandardButton reply;
+    reply =
+        QMessageBox::question(this, tr("New Source"), tr("Are you sure you want to clear the source and start over?"),
+                              QMessageBox::Yes | QMessageBox::No);
+    if (reply == QMessageBox::Yes) {
+      this->setCode("");
+    }
+  }
+
+  void loadSource() {
+    QFileDialog fileDialog(this);
+    fileDialog.setWindowModality(Qt::WindowModal);
+    fileDialog.setAcceptMode(QFileDialog::AcceptOpen);
+    fileDialog.setFileMode(QFileDialog::ExistingFile);
+    fileDialog.setMimeTypeFilters(this->fileFilters());
+    if (fileDialog.exec() != QDialog::Accepted) return;
+    const QString fn = fileDialog.selectedFiles().first();
+    if (fn.isEmpty()) return;
+    QFile file(fn);
+
+    file.open(QIODevice::ReadOnly | QIODevice::Text);
+    QTextStream in(&file);
+    this->setCode(in.readAll());
+  }
+
+  void saveSource() {
+    QFileDialog fileDialog(this);
+    fileDialog.setWindowModality(Qt::WindowModal);
+    fileDialog.setAcceptMode(QFileDialog::AcceptSave);
+    fileDialog.setMimeTypeFilters(this->fileFilters());
+    if (fileDialog.exec() != QDialog::Accepted) return;
+
+    const QString fn = fileDialog.selectedFiles().first();
+    if (fn.isEmpty()) return;
+    QFile file(fn);
+
+    file.open(QIODevice::WriteOnly | QIODevice::Text);
+    QTextStream out(&file);
+    out << this->code();
+  }
+
+  void printSource() {}
+
+  void gotoLineDialog() {
+    bool ok;
+    int lineNumber = QInputDialog::getInt(this, tr("Go to Line"), tr("Line:"), 1, 1, lineCount(), 1, &ok);
+    if (!ok) return;
+    gotoLine(lineNumber);
+  }
+
   void undo();
   void redo();
   void cut();
   void copy();
   void paste();
+  void gotoLine(int line);
 
  protected:
   QFont font;
   QWidget* textWidget = nullptr;
+
+ private:
+  QStringList fileFilters() {
+    return (QStringList() << "text/plain"
+                          << "application/octet-stream");
+  }
 };
 
 #endif  // CODEWIDGET_H

--- a/Widgets/CodeWidget.h
+++ b/Widgets/CodeWidget.h
@@ -15,6 +15,13 @@ class CodeWidget : public QWidget {
   QString code() const;
   void setCode(QString);
 
+ public slots:
+  void undo();
+  void redo();
+  void cut();
+  void copy();
+  void paste();
+
  protected:
   QFont font;
   QWidget* textWidget = nullptr;

--- a/Widgets/CodeWidget.h
+++ b/Widgets/CodeWidget.h
@@ -11,7 +11,9 @@
 
 class CodeWidget : public QWidget {
   Q_OBJECT
-  Q_PROPERTY(QString code READ code WRITE setCode USER true)
+  // this is a shim property over the real property
+  // NOTE: don't forget the notify signal or the mapper won't work!
+  Q_PROPERTY(QString code READ code WRITE setCode NOTIFY codeChanged USER true)
 
  public:
   explicit CodeWidget(QWidget* parent);
@@ -80,6 +82,11 @@ class CodeWidget : public QWidget {
   void copy();
   void paste();
   void gotoLine(int line);
+
+ signals:
+  void cursorPositionChanged(int line, int index);
+  void lineCountChanged(int lines);
+  void codeChanged();
 
  protected:
   QFont font;

--- a/Widgets/CodeWidget.h
+++ b/Widgets/CodeWidget.h
@@ -5,6 +5,7 @@
 #include <QFont>
 #include <QInputDialog>
 #include <QMessageBox>
+#include <QPrinter>
 #include <QTextStream>
 #include <QWidget>
 
@@ -63,7 +64,7 @@ class CodeWidget : public QWidget {
     out << this->code();
   }
 
-  void printSource() {}
+  void printSource();
 
   void gotoLineDialog() {
     bool ok;
@@ -72,6 +73,7 @@ class CodeWidget : public QWidget {
     gotoLine(lineNumber);
   }
 
+  void print(QPrinter* printer);
   void undo();
   void redo();
   void cut();

--- a/Widgets/CodeWidget.h
+++ b/Widgets/CodeWidget.h
@@ -22,6 +22,7 @@ class CodeWidget : public QWidget {
   QString code() const;
   void setCode(QString);
   int lineCount();
+  QPair<int, int> cursorPosition();
 
  public slots:
   void newSource() {

--- a/Widgets/CodeWidget.h
+++ b/Widgets/CodeWidget.h
@@ -1,12 +1,8 @@
 #ifndef CODEWIDGET_H
 #define CODEWIDGET_H
 
-#include <QFileDialog>
 #include <QFont>
-#include <QInputDialog>
-#include <QMessageBox>
 #include <QPrinter>
-#include <QTextStream>
 #include <QWidget>
 
 class CodeWidget : public QWidget {
@@ -25,56 +21,11 @@ class CodeWidget : public QWidget {
   QPair<int, int> cursorPosition();
 
  public slots:
-  void newSource() {
-    QMessageBox::StandardButton reply;
-    reply =
-        QMessageBox::question(this, tr("New Source"), tr("Are you sure you want to clear the source and start over?"),
-                              QMessageBox::Yes | QMessageBox::No);
-    if (reply == QMessageBox::Yes) {
-      this->setCode("");
-    }
-  }
-
-  void loadSource() {
-    QFileDialog fileDialog(this);
-    fileDialog.setWindowModality(Qt::WindowModal);
-    fileDialog.setAcceptMode(QFileDialog::AcceptOpen);
-    fileDialog.setFileMode(QFileDialog::ExistingFile);
-    fileDialog.setMimeTypeFilters(this->fileFilters());
-    if (fileDialog.exec() != QDialog::Accepted) return;
-    const QString fn = fileDialog.selectedFiles().first();
-    if (fn.isEmpty()) return;
-    QFile file(fn);
-
-    file.open(QIODevice::ReadOnly | QIODevice::Text);
-    QTextStream in(&file);
-    this->setCode(in.readAll());
-  }
-
-  void saveSource() {
-    QFileDialog fileDialog(this);
-    fileDialog.setWindowModality(Qt::WindowModal);
-    fileDialog.setAcceptMode(QFileDialog::AcceptSave);
-    fileDialog.setMimeTypeFilters(this->fileFilters());
-    if (fileDialog.exec() != QDialog::Accepted) return;
-
-    const QString fn = fileDialog.selectedFiles().first();
-    if (fn.isEmpty()) return;
-    QFile file(fn);
-
-    file.open(QIODevice::WriteOnly | QIODevice::Text);
-    QTextStream out(&file);
-    out << this->code();
-  }
-
+  void newSource();
+  void loadSource();
+  void saveSource();
   void printSource();
-
-  void gotoLineDialog() {
-    bool ok;
-    int lineNumber = QInputDialog::getInt(this, tr("Go to Line"), tr("Line:"), 1, 1, lineCount(), 1, &ok);
-    if (!ok) return;
-    gotoLine(lineNumber);
-  }
+  void gotoLineDialog();
 
   void print(QPrinter* printer);
   void undo();

--- a/Widgets/CodeWidgetPlain.cpp
+++ b/Widgets/CodeWidgetPlain.cpp
@@ -11,6 +11,14 @@ CodeWidget::CodeWidget(QWidget* parent) : QWidget(parent), font(QFont("Courier",
   this->textWidget = plainTextEdit;
   plainTextEdit->setFont(font);
 
+  connect(plainTextEdit, &QPlainTextEdit::textChanged, this, &CodeWidget::codeChanged);
+  connect(plainTextEdit, &QPlainTextEdit::blockCountChanged, this, &CodeWidget::lineCountChanged);
+
+  connect(plainTextEdit, &QPlainTextEdit::cursorPositionChanged, [=]() {
+    QTextCursor cursor = plainTextEdit->textCursor();
+    emit cursorPositionChanged(cursor.blockNumber() + 1, cursor.positionInBlock() + 1);
+  });
+
   QVBoxLayout* rootLayout = new QVBoxLayout(this);
   rootLayout->setMargin(0);
   rootLayout->addWidget(plainTextEdit);

--- a/Widgets/CodeWidgetPlain.cpp
+++ b/Widgets/CodeWidgetPlain.cpp
@@ -5,8 +5,17 @@
 
 CodeWidget::CodeWidget(QWidget* parent) : QWidget(parent), font(QFont("Courier", 10)) {
   QPlainTextEdit* plainTextEdit = new QPlainTextEdit(this);
+  this->textWidget = plainTextEdit;
   plainTextEdit->setFont(font);
-  this->layout()->addWidget(plainTextEdit);
+
+  QVBoxLayout* rootLayout = new QVBoxLayout(this);
+  rootLayout->setMargin(0);
+  rootLayout->addWidget(plainTextEdit);
+  this->setLayout(rootLayout);
 }
 
 CodeWidget::~CodeWidget() {}
+
+QString CodeWidget::code() const { return static_cast<QPlainTextEdit*>(this->textWidget)->toPlainText(); }
+
+void CodeWidget::setCode(QString code) { static_cast<QPlainTextEdit*>(this->textWidget)->setPlainText(code); }

--- a/Widgets/CodeWidgetPlain.cpp
+++ b/Widgets/CodeWidgetPlain.cpp
@@ -2,6 +2,7 @@
 
 #include <QLayout>
 #include <QPlainTextEdit>
+#include <QPrintDialog>
 #include <QTextBlock>
 #include <QTextCursor>
 
@@ -38,4 +39,17 @@ void CodeWidget::gotoLine(int line) {
   auto plainTextEdit = static_cast<QPlainTextEdit*>(this->textWidget);
   QTextCursor textCursor(plainTextEdit->document()->findBlockByLineNumber(line - 1));
   plainTextEdit->setTextCursor(textCursor);
+}
+
+void CodeWidget::printSource() {
+  QPrinter printer;
+  QPrintDialog printDialog(&printer, this);
+  auto plainTextEdit = static_cast<QPlainTextEdit*>(this->textWidget);
+  if (plainTextEdit->textCursor().hasSelection()) printDialog.addEnabledOption(QAbstractPrintDialog::PrintSelection);
+  if (printDialog.exec() == QDialog::Accepted) this->print(&printer);
+}
+
+void CodeWidget::print(QPrinter* printer) {
+  auto plainTextEdit = static_cast<QPlainTextEdit*>(this->textWidget);
+  plainTextEdit->document()->print(printer);
 }

--- a/Widgets/CodeWidgetPlain.cpp
+++ b/Widgets/CodeWidgetPlain.cpp
@@ -2,6 +2,8 @@
 
 #include <QLayout>
 #include <QPlainTextEdit>
+#include <QTextBlock>
+#include <QTextCursor>
 
 CodeWidget::CodeWidget(QWidget* parent) : QWidget(parent), font(QFont("Courier", 10)) {
   QPlainTextEdit* plainTextEdit = new QPlainTextEdit(this);
@@ -29,3 +31,11 @@ void CodeWidget::cut() { static_cast<QPlainTextEdit*>(this->textWidget)->cut(); 
 void CodeWidget::copy() { static_cast<QPlainTextEdit*>(this->textWidget)->copy(); }
 
 void CodeWidget::paste() { static_cast<QPlainTextEdit*>(this->textWidget)->paste(); }
+
+int CodeWidget::lineCount() { return static_cast<QPlainTextEdit*>(this->textWidget)->blockCount(); }
+
+void CodeWidget::gotoLine(int line) {
+  auto plainTextEdit = static_cast<QPlainTextEdit*>(this->textWidget);
+  QTextCursor textCursor(plainTextEdit->document()->findBlockByLineNumber(line - 1));
+  plainTextEdit->setTextCursor(textCursor);
+}

--- a/Widgets/CodeWidgetPlain.cpp
+++ b/Widgets/CodeWidgetPlain.cpp
@@ -19,3 +19,13 @@ CodeWidget::~CodeWidget() {}
 QString CodeWidget::code() const { return static_cast<QPlainTextEdit*>(this->textWidget)->toPlainText(); }
 
 void CodeWidget::setCode(QString code) { static_cast<QPlainTextEdit*>(this->textWidget)->setPlainText(code); }
+
+void CodeWidget::undo() { static_cast<QPlainTextEdit*>(this->textWidget)->undo(); }
+
+void CodeWidget::redo() { static_cast<QPlainTextEdit*>(this->textWidget)->redo(); }
+
+void CodeWidget::cut() { static_cast<QPlainTextEdit*>(this->textWidget)->cut(); }
+
+void CodeWidget::copy() { static_cast<QPlainTextEdit*>(this->textWidget)->copy(); }
+
+void CodeWidget::paste() { static_cast<QPlainTextEdit*>(this->textWidget)->paste(); }

--- a/Widgets/CodeWidgetPlain.cpp
+++ b/Widgets/CodeWidgetPlain.cpp
@@ -43,6 +43,12 @@ void CodeWidget::paste() { static_cast<QPlainTextEdit*>(this->textWidget)->paste
 
 int CodeWidget::lineCount() { return static_cast<QPlainTextEdit*>(this->textWidget)->blockCount(); }
 
+QPair<int, int> CodeWidget::cursorPosition() {
+  auto plainTextEdit = static_cast<QPlainTextEdit*>(this->textWidget);
+  auto cursor = plainTextEdit->textCursor();
+  return QPair<int, int>(cursor.blockNumber() + 1, cursor.positionInBlock() + 1);
+}
+
 void CodeWidget::gotoLine(int line) {
   auto plainTextEdit = static_cast<QPlainTextEdit*>(this->textWidget);
   QTextCursor textCursor(plainTextEdit->document()->findBlockByLineNumber(line - 1));

--- a/Widgets/CodeWidgetScintilla.cpp
+++ b/Widgets/CodeWidgetScintilla.cpp
@@ -31,11 +31,17 @@ CodeWidget::CodeWidget(QWidget* parent) : QWidget(parent), font(QFont("Courier",
 
   codeEdit->setLexer(cppLexer);
 
-  connect(codeEdit, &QsciScintilla::textChanged, [=]() {
+  connect(codeEdit, &QsciScintilla::textChanged, this, &CodeWidget::codeChanged);
+
+  connect(codeEdit, &QsciScintilla::linesChanged, [=]() {
     const int padding = 8;
     auto maxLineString = QString::number(codeEdit->lines());
     codeEdit->setMarginWidth(0, fontMetrics.width(maxLineString) + padding);
+    emit lineCountChanged(codeEdit->lines());
   });
+
+  connect(codeEdit, &QsciScintilla::cursorPositionChanged,
+          [=](int line, int index) { emit cursorPositionChanged(line + 1, index + 1); });
 
   QVBoxLayout* rootLayout = new QVBoxLayout(this);
   rootLayout->setMargin(0);

--- a/Widgets/CodeWidgetScintilla.cpp
+++ b/Widgets/CodeWidgetScintilla.cpp
@@ -32,3 +32,13 @@ CodeWidget::~CodeWidget() {}
 QString CodeWidget::code() const { return static_cast<QsciScintilla*>(this->textWidget)->text(); }
 
 void CodeWidget::setCode(QString code) { static_cast<QsciScintilla*>(this->textWidget)->setText(code); }
+
+void CodeWidget::undo() { static_cast<QsciScintilla*>(this->textWidget)->undo(); }
+
+void CodeWidget::redo() { static_cast<QsciScintilla*>(this->textWidget)->redo(); }
+
+void CodeWidget::cut() { static_cast<QsciScintilla*>(this->textWidget)->cut(); }
+
+void CodeWidget::copy() { static_cast<QsciScintilla*>(this->textWidget)->copy(); }
+
+void CodeWidget::paste() { static_cast<QsciScintilla*>(this->textWidget)->paste(); }

--- a/Widgets/CodeWidgetScintilla.cpp
+++ b/Widgets/CodeWidgetScintilla.cpp
@@ -1,12 +1,12 @@
 #include "CodeWidget.h"
 
-#include <Qsci/qscilexercpp.h>
-#include <Qsci/qsciprinter.h>
-#include <Qsci/qsciscintilla.h>
-
 #include <QFontMetrics>
 #include <QLayout>
 #include <QPrintDialog>
+
+#include <Qsci/qscilexercpp.h>
+#include <Qsci/qsciprinter.h>
+#include <Qsci/qsciscintilla.h>
 
 namespace {
 QsciLexerCPP* cppLexer = nullptr;

--- a/Widgets/CodeWidgetScintilla.cpp
+++ b/Widgets/CodeWidgetScintilla.cpp
@@ -1,10 +1,12 @@
 #include "CodeWidget.h"
 
 #include <Qsci/qscilexercpp.h>
+#include <Qsci/qsciprinter.h>
 #include <Qsci/qsciscintilla.h>
 
 #include <QFontMetrics>
 #include <QLayout>
+#include <QPrintDialog>
 
 namespace {
 QsciLexerCPP* cppLexer = nullptr;
@@ -60,3 +62,17 @@ void CodeWidget::paste() { static_cast<QsciScintilla*>(this->textWidget)->paste(
 int CodeWidget::lineCount() { return static_cast<QsciScintilla*>(this->textWidget)->lines(); }
 
 void CodeWidget::gotoLine(int line) { static_cast<QsciScintilla*>(this->textWidget)->setCursorPosition(line - 1, 0); }
+
+void CodeWidget::printSource() {
+  QsciPrinter sciPrinter;
+  QPrintDialog printDialog(&sciPrinter, this);
+  auto codeEdit = static_cast<QsciScintilla*>(this->textWidget);
+  if (codeEdit->hasSelectedText()) printDialog.addEnabledOption(QAbstractPrintDialog::PrintSelection);
+  if (printDialog.exec() == QDialog::Accepted) this->print(&sciPrinter);
+}
+
+void CodeWidget::print(QPrinter* printer) {
+  auto sciPrinter = static_cast<QsciPrinter*>(printer);
+  auto codeEdit = static_cast<QsciScintilla*>(this->textWidget);
+  sciPrinter->printRange(codeEdit);
+}

--- a/Widgets/CodeWidgetScintilla.cpp
+++ b/Widgets/CodeWidgetScintilla.cpp
@@ -1,13 +1,23 @@
 #include "CodeWidget.h"
 
-#include <QFontMetrics>
-#include <QLayout>
-
 #include <Qsci/qscilexercpp.h>
 #include <Qsci/qsciscintilla.h>
 
+#include <QFontMetrics>
+#include <QLayout>
+
+namespace {
+QsciLexerCPP* cppLexer = nullptr;
+}
+
 CodeWidget::CodeWidget(QWidget* parent) : QWidget(parent), font(QFont("Courier", 10)) {
   QFontMetrics fontMetrics(font);
+
+  if (cppLexer == nullptr) {
+    cppLexer = new QsciLexerCPP();
+    cppLexer->setFont(font);
+  }
+
   QsciScintilla* codeEdit = new QsciScintilla(this);
   this->textWidget = codeEdit;
 
@@ -15,11 +25,15 @@ CodeWidget::CodeWidget(QWidget* parent) : QWidget(parent), font(QFont("Courier",
   codeEdit->setCaretLineBackgroundColor(QColor("#ffe4e4"));
 
   codeEdit->setMarginLineNumbers(0, true);
-  codeEdit->setMarginWidth(0, fontMetrics.width("000"));
   codeEdit->setMarginsFont(font);
-  QsciLexerCPP* lexer = new QsciLexerCPP();
-  lexer->setDefaultFont(font);
-  codeEdit->setLexer(lexer);
+
+  codeEdit->setLexer(cppLexer);
+
+  connect(codeEdit, &QsciScintilla::textChanged, [=]() {
+    const int padding = 8;
+    auto maxLineString = QString::number(codeEdit->lines());
+    codeEdit->setMarginWidth(0, fontMetrics.width(maxLineString) + padding);
+  });
 
   QVBoxLayout* rootLayout = new QVBoxLayout(this);
   rootLayout->setMargin(0);

--- a/Widgets/CodeWidgetScintilla.cpp
+++ b/Widgets/CodeWidgetScintilla.cpp
@@ -1,12 +1,12 @@
 #include "CodeWidget.h"
 
-#include <QFontMetrics>
-#include <QLayout>
-#include <QPrintDialog>
-
 #include <Qsci/qscilexercpp.h>
 #include <Qsci/qsciprinter.h>
 #include <Qsci/qsciscintilla.h>
+
+#include <QFontMetrics>
+#include <QLayout>
+#include <QPrintDialog>
 
 namespace {
 QsciLexerCPP* cppLexer = nullptr;

--- a/Widgets/CodeWidgetScintilla.cpp
+++ b/Widgets/CodeWidgetScintilla.cpp
@@ -42,3 +42,7 @@ void CodeWidget::cut() { static_cast<QsciScintilla*>(this->textWidget)->cut(); }
 void CodeWidget::copy() { static_cast<QsciScintilla*>(this->textWidget)->copy(); }
 
 void CodeWidget::paste() { static_cast<QsciScintilla*>(this->textWidget)->paste(); }
+
+int CodeWidget::lineCount() { return static_cast<QsciScintilla*>(this->textWidget)->lines(); }
+
+void CodeWidget::gotoLine(int line) { static_cast<QsciScintilla*>(this->textWidget)->setCursorPosition(line - 1, 0); }

--- a/Widgets/CodeWidgetScintilla.cpp
+++ b/Widgets/CodeWidgetScintilla.cpp
@@ -8,18 +8,27 @@
 
 CodeWidget::CodeWidget(QWidget* parent) : QWidget(parent), font(QFont("Courier", 10)) {
   QFontMetrics fontMetrics(font);
-  QsciScintilla* textEdit = new QsciScintilla(this);
+  QsciScintilla* codeEdit = new QsciScintilla(this);
+  this->textWidget = codeEdit;
 
-  textEdit->setCaretLineVisible(true);
-  textEdit->setCaretLineBackgroundColor(QColor("#ffe4e4"));
+  codeEdit->setCaretLineVisible(true);
+  codeEdit->setCaretLineBackgroundColor(QColor("#ffe4e4"));
 
-  textEdit->setMarginLineNumbers(0, true);
-  textEdit->setMarginWidth(0, fontMetrics.width("000"));
-  textEdit->setMarginsFont(font);
+  codeEdit->setMarginLineNumbers(0, true);
+  codeEdit->setMarginWidth(0, fontMetrics.width("000"));
+  codeEdit->setMarginsFont(font);
   QsciLexerCPP* lexer = new QsciLexerCPP();
   lexer->setDefaultFont(font);
-  textEdit->setLexer(lexer);
-  this->layout()->addWidget(textEdit);
+  codeEdit->setLexer(lexer);
+
+  QVBoxLayout* rootLayout = new QVBoxLayout(this);
+  rootLayout->setMargin(0);
+  rootLayout->addWidget(codeEdit);
+  this->setLayout(rootLayout);
 }
 
 CodeWidget::~CodeWidget() {}
+
+QString CodeWidget::code() const { return static_cast<QsciScintilla*>(this->textWidget)->text(); }
+
+void CodeWidget::setCode(QString code) { static_cast<QsciScintilla*>(this->textWidget)->setText(code); }

--- a/Widgets/CodeWidgetScintilla.cpp
+++ b/Widgets/CodeWidgetScintilla.cpp
@@ -67,6 +67,13 @@ void CodeWidget::paste() { static_cast<QsciScintilla*>(this->textWidget)->paste(
 
 int CodeWidget::lineCount() { return static_cast<QsciScintilla*>(this->textWidget)->lines(); }
 
+QPair<int, int> CodeWidget::cursorPosition() {
+  auto sci = static_cast<QsciScintilla*>(this->textWidget);
+  int line, index;
+  sci->getCursorPosition(&line, &index);
+  return QPair<int, int>(line + 1, index + 1);
+}
+
 void CodeWidget::gotoLine(int line) { static_cast<QsciScintilla*>(this->textWidget)->setCursorPosition(line - 1, 0); }
 
 void CodeWidget::printSource() {

--- a/images.qrc
+++ b/images.qrc
@@ -38,6 +38,8 @@
         <file alias="pause.png">Images/actions/pause.png</file>
         <file alias="play.png">Images/actions/play.png</file>
         <file alias="snap-to-grid.png">Images/actions/snap-to-grid.png</file>
+        <file alias="print.png">Images/actions/print.png</file>
+        <file alias="line-goto.png">Images/actions/line-goto.png</file>
     </qresource>
     <qresource prefix="/resources">
         <file alias="background.png">Images/resources/background.png</file>

--- a/main.cpp
+++ b/main.cpp
@@ -16,6 +16,7 @@ int main(int argc, char *argv[]) {
   a.setOrganizationDomain("enigma-dev.org");
   a.setApplicationName("RadialGM");
   a.setWindowIcon(QIcon(":/icon.ico"));
+  a.setAttribute(Qt::AA_DisableWindowContextHelpButton);
 
   defaultStyle = a.style()->objectName();
 

--- a/qtplugins.cpp
+++ b/qtplugins.cpp
@@ -2,6 +2,7 @@
 // the static build of RadialGM that uses CMake
 #include <QtPlugin>
 
+Q_IMPORT_PLUGIN(qscintilla2)
 Q_IMPORT_PLUGIN(QGifPlugin)
 Q_IMPORT_PLUGIN(QICOPlugin)
 Q_IMPORT_PLUGIN(QJpegPlugin)

--- a/qtplugins.cpp
+++ b/qtplugins.cpp
@@ -6,5 +6,5 @@ Q_IMPORT_PLUGIN(QGifPlugin)
 Q_IMPORT_PLUGIN(QICOPlugin)
 Q_IMPORT_PLUGIN(QJpegPlugin)
 
-//Q_IMPORT_PLUGIN(QWindowsIntegrationPlugin);
+Q_IMPORT_PLUGIN(QWindowsIntegrationPlugin);
 Q_IMPORT_PLUGIN(QWindowsVistaStylePlugin);

--- a/qtplugins.cpp
+++ b/qtplugins.cpp
@@ -2,13 +2,9 @@
 // the static build of RadialGM that uses CMake
 #include <QtPlugin>
 
-namespace RGM {
-
 Q_IMPORT_PLUGIN(QGifPlugin)
 Q_IMPORT_PLUGIN(QICOPlugin)
 Q_IMPORT_PLUGIN(QJpegPlugin)
 
-Q_IMPORT_PLUGIN(QWindowsIntegrationPlugin);
+//Q_IMPORT_PLUGIN(QWindowsIntegrationPlugin);
 Q_IMPORT_PLUGIN(QWindowsVistaStylePlugin);
-
-}

--- a/qtplugins.cpp
+++ b/qtplugins.cpp
@@ -2,9 +2,13 @@
 // the static build of RadialGM that uses CMake
 #include <QtPlugin>
 
+namespace RGM {
+
 Q_IMPORT_PLUGIN(QGifPlugin)
 Q_IMPORT_PLUGIN(QICOPlugin)
 Q_IMPORT_PLUGIN(QJpegPlugin)
 
 Q_IMPORT_PLUGIN(QWindowsIntegrationPlugin);
 Q_IMPORT_PLUGIN(QWindowsVistaStylePlugin);
+
+}

--- a/qtplugins.cpp
+++ b/qtplugins.cpp
@@ -2,7 +2,6 @@
 // the static build of RadialGM that uses CMake
 #include <QtPlugin>
 
-Q_IMPORT_PLUGIN(qscintilla2)
 Q_IMPORT_PLUGIN(QGifPlugin)
 Q_IMPORT_PLUGIN(QICOPlugin)
 Q_IMPORT_PLUGIN(QJpegPlugin)


### PR DESCRIPTION
Attempting to cleanup and organize how we want the editors that are for code to be implemented. RGM can still be built in two modes, one that uses QScintilla, and one that uses QPlainTextEdit.

* CodeWidget.h declares the interface for a code editing widget
* CodeWidget.cpp defines an implementation of code widget common to all other implementations
* CodeWidgetPlain.cpp defines an implementation of code widget using QPlainTextEdit
* CodeWidgetScintilla.cpp defines an implementation of code widget using QScintilla
* Changed the CMake lists and qmake pro file to link print support, but it doesn't work for some reason in the AppVeyor build
* Uses widget promotion to add the code widget to the code editor, which script editor derives from
* Now serializes with the main window settings whether tabbed view was enabled, and automatically restores that when you reopen RGM
* Changed tabbed view to use non-expanding tab headers, because not just Rusky but everyone else prefers that including me (applied when switching into tabbed mode)
* Uses qmake `CONFIG` (usable in qmake conditionals) instead of `DEFINES` (available to preprocessor/do not want) to toggle syntax highlighting enabled build
* Disabled the context help button for all windows by default using `Qt::AA_DisableWindowContextHelpButton` (this is silly, Qt should have always been that way). If we decide to use that and have a QWhatsThis or whatever, then it should be overriden on a per window or dialog basis for where we provide the behavior.
* Gave the main window's toolbar a window title "Toolbar" so that you can discern what it is when right-clicking the the toolbar or menubar to hide/show docks.
![Toolbar Window Title](https://user-images.githubusercontent.com/3212801/46378913-21764700-c66b-11e8-8bec-6325fe43895b.png)
* Made the "Cascade" and "Tile" actions first switch to MDI mode so the tab headers aren't still visible, because they shouldn't be
* Added actions to the "Window" menu to switch active windows. This is primarily oriented at MDI users, to facilitate switching windows when maximized, but can also be used by TDI users because the added mnemonics facilitate faster switching. Further, Notepad++ even has this behavior in its "Window" menu and it's a TDI as well, so definitely a good argument for bringing this back from LGM. The alternative I had experimented with but later decided against was switching into tabbed mode when maximizing an MDI window. I decided against that because it's unnatural and does not meet the established expectations of MDI users.
![Open Window Actions](https://user-images.githubusercontent.com/3212801/46580714-00f61600-c9f8-11e8-869a-953a1520144e.png)
* Improved the efficiency of model synchronization with ImmediateMapper by removing and readding the widget changed notification connection while updating the model. Without this the script editor would lag because the code widget would constantly be reloaded because changing the code widget would trigger a model update which triggered a widget update and so on.
* Implemented the "Close All Others" action under the "Window" menu which closes every subwindow or tab except the active one.

![Scintilla Script Editing Windows Vista Style TDI](https://user-images.githubusercontent.com/3212801/46510479-43143180-c817-11e8-9af1-e46b1fd17794.png)
![Plain Text Script Editing Fusion Style MDI](https://user-images.githubusercontent.com/3212801/46510417-cb460700-c816-11e8-90ba-1d1aa537abfa.png)
