### PR TITLE
AppVeyor New VS 2017 Image

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@ pull_requests:
 
 
 # Build worker image (VM template)
-image: Previous Visual Studio 2017
+image: Visual Studio 2017
 
 # since we're pushing releases we don't want infinite recursion
 # because the release pushes a tag, hence we aren't building on tags


### PR DESCRIPTION
The developers at AppVeyor already took care of our issue with vcpkg and their updated Visual Studio 2017 image. We can go back to using the latest one instead of the previous one now.
https://www.appveyor.com/updates/2018/09/01/
https://github.com/appveyor/ci/issues/2600