### PR TITLE
Recursive Models and Room Editor Rendering

### DIFF
--- a/CmakeLists.txt
+++ b/CmakeLists.txt
@@ -41,12 +41,17 @@ set(RGM_SOURCES
     Models/SpriteModel.cpp
     Models/ProtoModel.cpp
     Models/ImmediateMapper.cpp
+    Models/ResourceModelMap.cpp
+    Models/RepeatedProtoModel.cpp
+    Models/TreeSortFilterProxyModel.cpp
     Components/ArtManager.cpp
     Components/Utility.cpp
     Components/RecentFiles.cpp
+    Components/QMenuView.cpp
     Widgets/BackgroundRenderer.cpp
     Widgets/CodeWidget.cpp
     Widgets/ColorPicker.cpp
+    Widgets/RoomRenderer.cpp
     Plugins/RGMPlugin.cpp
     Plugins/ServerPlugin.cpp
     qtplugins.cpp
@@ -72,12 +77,17 @@ set(RGM_HEADERS
     Models/ProtoModel.h
     Models/ImmediateMapper.h
     Models/SpriteModel.h
+    Models/ResourceModelMap.h
+    Models/RepeatedProtoModel.h
+    Models/TreeSortFilterProxyModel.h
     Components/ArtManager.h
     Components/RecentFiles.h
     Components/Utility.h
+    Components/QMenuView.h
     Widgets/BackgroundRenderer.h
     Widgets/CodeWidget.h
     Widgets/ColorPicker.h
+    Widgets/RoomRenderer.h
     Plugins/RGMPlugin.h
     Plugins/ServerPlugin.h
 )

--- a/CmakeLists.txt
+++ b/CmakeLists.txt
@@ -40,6 +40,7 @@ set(RGM_SOURCES
     Models/TreeModel.cpp
     Models/SpriteModel.cpp
     Models/ProtoModel.cpp
+    Models/ModelMapper.cpp
     Models/ImmediateMapper.cpp
     Models/ResourceModelMap.cpp
     Models/RepeatedProtoModel.cpp
@@ -75,6 +76,7 @@ set(RGM_HEADERS
     Editors/SpriteEditor.h
     Models/TreeModel.h
     Models/ProtoModel.h
+    Models/ModelMapper.h
     Models/ImmediateMapper.h
     Models/SpriteModel.h
     Models/ResourceModelMap.h

--- a/Components/ArtManager.cpp
+++ b/Components/ArtManager.cpp
@@ -1,6 +1,7 @@
 #include "ArtManager.h"
 
 #include <QDirIterator>
+#include <QPixmapCache>
 
 QHash<QString, QIcon> ArtManager::icons;
 QBrush ArtManager::transparenyBrush;
@@ -14,16 +15,27 @@ void ArtManager::Init() {
   }
 
   transparenyBrush = QBrush(Qt::black, QPixmap(":/transparent.png"));
+
+  QPixmapCache::setCacheLimit(500000);  // 500mb cache limit
 }
 
 ArtManager::ArtManager() {}
 
-
 const QIcon& ArtManager::GetIcon(const QString& name) {
-  if (!icons.contains(name))
-    icons[name] = QIcon(name);
+  if (!icons.contains(name)) icons[name] = QIcon(name);
 
   return icons[name];
 }
 
 const QBrush& ArtManager::GetTransparenyBrush() { return transparenyBrush; }
+
+const QPixmap& ArtManager::GetCachedPixmap(const QString& name) {
+  QPixmap pm;
+  if (!QPixmapCache::find(name, &pm)) {
+    pm.load(name);
+    QPixmapCache::insert(name, pm);
+  }
+  return std::move(pm);
+}
+
+void ArtManager::clearCache() { QPixmapCache::clear(); }

--- a/Components/ArtManager.cpp
+++ b/Components/ArtManager.cpp
@@ -18,6 +18,12 @@ void ArtManager::Init() {
 
 ArtManager::ArtManager() {}
 
-const QIcon& ArtManager::GetIcon(const QString& name) { return icons[name]; }
+
+const QIcon& ArtManager::GetIcon(const QString& name) {
+  if (!icons.contains(name))
+    icons[name] = QIcon(name);
+
+  return icons[name];
+}
 
 const QBrush& ArtManager::GetTransparenyBrush() { return transparenyBrush; }

--- a/Components/ArtManager.h
+++ b/Components/ArtManager.h
@@ -10,6 +10,8 @@ class ArtManager {
   static void Init();
   static const QIcon& GetIcon(const QString& name);
   static const QBrush& GetTransparenyBrush();
+  static const QPixmap& GetCachedPixmap(const QString& name);
+  static void clearCache();
 
  private:
   ArtManager();

--- a/Components/QMenuView.cpp
+++ b/Components/QMenuView.cpp
@@ -1,0 +1,247 @@
+/*
+ XINX
+ Copyright (C) 2007-2011 by Ulrich Van Den Hekke
+ xinx@shadoware.org
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful.
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/*
+ * This class is inspired from the Nokia class MenuModel, used in the browser
+ * application in demos.
+ */
+
+// Xinx header
+#include "QMenuView_p.h"
+
+Q_DECLARE_METATYPE(QModelIndex);
+
+/* QMenuViewPrivate */
+
+QMenuViewPrivate::QMenuViewPrivate(QMenuView* menu) : _menu(menu)
+{
+}
+
+QMenuViewPrivate::~QMenuViewPrivate()
+{
+}
+
+
+QAction * QMenuViewPrivate::makeAction(const QModelIndex &index)
+{
+  QIcon icon = qvariant_cast<QIcon>(index.data(Qt::DecorationRole));
+  QAction * action = new QAction(icon, index.data().toString(), this);
+  action->setEnabled(index.flags().testFlag(Qt::ItemIsEnabled));
+  // improvements for Qlipper (petr vanek <petr@yarpen.cz>
+  action->setFont(qvariant_cast<QFont>(index.data(Qt::FontRole)));
+  action->setToolTip(index.data(Qt::ToolTipRole).toString());
+  // end of qlipper improvements
+  QVariant v;
+  v.setValue(index);
+  action->setData(v);
+
+  return action;
+}
+
+
+void QMenuViewPrivate::triggered(QAction *action)
+{
+  QVariant v = action->data();
+  if (v.canConvert<QModelIndex>())
+  {
+    QModelIndex idx = qvariant_cast<QModelIndex>(v);
+    emit _menu->triggered(idx);
+  }
+}
+
+void QMenuViewPrivate::hovered(QAction *action)
+{
+  QVariant v = action->data();
+  if (v.canConvert<QModelIndex>())
+  {
+    QModelIndex idx = qvariant_cast<QModelIndex>(v);
+    QString hoveredString = idx.data(Qt::StatusTipRole).toString();
+    if (!hoveredString.isEmpty())
+      emit _menu->hovered(hoveredString);
+  }
+}
+
+void QMenuViewPrivate::aboutToShow()
+{
+  QMenu * menu = qobject_cast<QMenu*>(sender());
+  if (menu)
+  {
+    QVariant v = menu->menuAction()->data();
+    if (v.canConvert<QModelIndex>())
+    {
+      QModelIndex idx = qvariant_cast<QModelIndex>(v);
+      _menu->createMenu(idx, menu, menu);
+      disconnect(menu, SIGNAL(aboutToShow()), this, SLOT(aboutToShow()));
+      return;
+    }
+  }
+
+  _menu->clear();
+
+  if (_menu->prePopulated())
+    _menu->addSeparator();
+
+  _menu->createMenu(m_root, _menu, _menu);
+
+  _menu->postPopulated();
+}
+
+/* QMenuView */
+
+/*!
+ * \ingroup Components
+ * \class QMenuView
+ * \since 0.9.0.0
+ *
+ * \brief The QMenuView provides a menu based view on a QAbstractItemModel class.
+ *
+ * \bc 0.10.0.0
+ *
+ * This class is used to transform a hierarchical model based on the class
+ * QAbstractItemModel into a menu. It can be used to create an action menu, history,
+ * or snipets menu.
+ *
+ * \image html qmenuview.png
+ * \image latex qmenuview.png
+ *
+ * When the model is defined, the structure of the menu is automatically generated. This
+ * class ignores call to QAbstractItemModel::beginInsertRows() and QAbstractItemModel::endInsertRows().
+ * Menu is generated when the user opens it.
+ */
+
+/*!
+ * \brief Creates the new menu view based on a QMenu object.
+ * \param parent The parent object of the menu.
+ */
+QMenuView::QMenuView(QWidget * parent) : QMenu(parent), d(new QMenuViewPrivate(this))
+{
+  connect(this, SIGNAL(triggered(QAction*)), d.data(), SLOT(triggered(QAction*)));
+  connect(this, SIGNAL(hovered(QAction*)), d.data(), SLOT(hovered(QAction*)));
+  connect(this, SIGNAL(aboutToShow()), d.data(), SLOT(aboutToShow()));
+}
+
+//! Destroy the menu.
+QMenuView::~QMenuView()
+{
+  setModel(0);
+}
+
+/*!
+ * \fn void QMenuView::hovered(const QString &text) const
+ * \brief The signal when a menu action is highlighted.
+ *
+ * \p text is the Qt::StatusTipRole of the index that caused the signal to be emitted.
+ *
+ * Often this is used to update status information.
+ *
+ * \sa triggered()
+ */
+
+/*!
+ * \fn void QMenuView::triggered(const QModelIndex & index) const
+ * \brief This signal is emitted when an action in this menu is triggered.
+ *
+ * \p index is the index's action that caused the signal to be emitted.
+ *
+ * \sa hovered()
+ */
+
+//! Add any actions before the tree, return true if any actions are added.
+bool QMenuView::prePopulated()
+{
+  return false;
+}
+
+//! Add any actions after the tree
+void QMenuView::postPopulated()
+{
+}
+
+/*!
+ * \brief Set the new model to \p model.
+ * \param model The new model to use for the creation of menus.
+ */
+void QMenuView::setModel(QAbstractItemModel * model)
+{
+  d->m_model = model;
+}
+
+/*!
+ * \brief Return the current model of the menu.
+ */
+QAbstractItemModel * QMenuView::model() const
+{
+  return d->m_model;
+}
+
+/*!
+ * \brief Change the root index to \p index.
+ *
+ * This can be used to show only a part of the QAbstractItemModel.
+ * \param index The index to use to show the menu. if QModelIndex(), all the model is show.
+ */
+void QMenuView::setRootIndex(const QModelIndex & index)
+{
+  d->m_root = index;
+}
+
+/*!
+ * \brief Returns the current root index.
+ *
+ * Default root index is QModelIndex()
+ */
+QModelIndex QMenuView::rootIndex() const
+{
+  return d->m_root;
+}
+
+//! Puts all of the children of parent into menu
+void QMenuView::createMenu(const QModelIndex &parent, QMenu *parentMenu, QMenu *menu)
+{
+  if (! menu)
+  {
+    QIcon icon = qvariant_cast<QIcon>(parent.data(Qt::DecorationRole));
+
+    QVariant v;
+    v.setValue(parent);
+
+    menu = new QMenu(parent.data().toString(), this);
+    menu->setIcon(icon);
+    parentMenu->addMenu(menu);
+    menu->menuAction()->setData(v);
+    menu->setEnabled(parent.flags().testFlag(Qt::ItemIsEnabled));
+
+    connect(menu, SIGNAL(aboutToShow()), d.data(), SLOT(aboutToShow()));
+
+    return;
+  }
+
+  int end = d->m_model->rowCount(parent);
+  for (int i = 0; i < end; ++i)
+  {
+    QModelIndex idx = d->m_model->index(i, 0, parent);
+    if (d->m_model->hasChildren(idx))
+    {
+      createMenu(idx, menu);
+    }
+    else
+    {
+      menu->addAction(d->makeAction(idx));
+    }
+  }
+}

--- a/Components/QMenuView.h
+++ b/Components/QMenuView.h
@@ -1,0 +1,58 @@
+/*
+ XINX
+ Copyright (C) 2007-2011 by Ulrich Van Den Hekke
+ xinx@shadoware.org
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful.
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+#ifndef _QMENUVIEW_H_
+#define _QMENUVIEW_H_
+
+// Qt header
+#include <QMenu>
+#include <QAbstractItemModel>
+
+//#include <components-config.h>
+#define COMPONENTSEXPORT
+
+class QMenuViewPrivate;
+
+class COMPONENTSEXPORT QMenuView : public QMenu
+{
+  Q_OBJECT
+public:
+  QMenuView(QWidget * parent = 0);
+  virtual ~QMenuView();
+
+  virtual void setModel(QAbstractItemModel * model);
+  QAbstractItemModel * model() const;
+
+  virtual void setRootIndex(const QModelIndex & index);
+  QModelIndex rootIndex() const;
+protected:
+  virtual bool prePopulated();
+  virtual void postPopulated();
+  void createMenu(const QModelIndex &parent, QMenu *parentMenu = 0, QMenu *menu = 0);
+signals:
+  void hovered(const QString &text) const;
+  void triggered(const QModelIndex & index) const;
+private:
+  QScopedPointer<QMenuViewPrivate> d;
+  friend class QMenuViewPrivate;
+};
+
+
+#endif /* _QMENUVIEW_H_ */

--- a/Components/QMenuView_p.h
+++ b/Components/QMenuView_p.h
@@ -1,0 +1,51 @@
+/*
+XINX
+Copyright (C) 2007-2011 by Ulrich Van Den Hekke
+xinx@shadoware.org
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful.
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+#ifndef _QMENUVIEW_P_H_
+#define _QMENUVIEW_P_H_
+
+// Qt header
+#include <QMenu>
+#include <QAbstractItemModel>
+
+#include "QMenuView.h"
+//#include <components-config.h>
+
+//! \private
+class QMenuViewPrivate : public QObject
+{
+  Q_OBJECT
+public:
+  QMenuViewPrivate(QMenuView * menu);
+  virtual ~QMenuViewPrivate();
+
+  QAction *makeAction(const QModelIndex &index);
+
+  QMenuView * _menu;
+  QAbstractItemModel * m_model;
+  QPersistentModelIndex m_root;
+public slots:
+  void aboutToShow();
+  void triggered(QAction *action);
+  void hovered(QAction *action);
+};
+
+
+#endif /* _QMENUVIEW_P_H_ */

--- a/Editors/BackgroundEditor.cpp
+++ b/Editors/BackgroundEditor.cpp
@@ -22,7 +22,6 @@ BackgroundEditor::BackgroundEditor(ProtoModel* model, QWidget* parent)
 
   resMapper->addMapping(ui->smoothCheckBox, Background::kSmoothEdgesFieldNumber);
   resMapper->addMapping(ui->preloadCheckBox, Background::kPreloadFieldNumber);
-  resMapper->addMapping(ui->transparentCheckBox, Background::kTransparentFieldNumber);
   resMapper->addMapping(ui->tilesetGroupBox, Background::kUseAsTilesetFieldNumber);
   resMapper->addMapping(ui->tileWidthSpinBox, Background::kTileWidthFieldNumber);
   resMapper->addMapping(ui->tileHeightSpinBox, Background::kTileHeightFieldNumber);

--- a/Editors/BackgroundEditor.cpp
+++ b/Editors/BackgroundEditor.cpp
@@ -35,9 +35,9 @@ BackgroundEditor::BackgroundEditor(ProtoModel* model, QWidget* parent)
 
 BackgroundEditor::~BackgroundEditor() { delete ui; }
 
-void BackgroundEditor::dataChanged(const QModelIndex& topLeft, const QModelIndex& bottomRight,
+void BackgroundEditor::dataChanged(const QModelIndex& topLeft, const QModelIndex& bottomRight, const QVariant& oldValue,
                                    const QVector<int>& roles) {
-  BaseEditor::dataChanged(topLeft, bottomRight, roles);
+  BaseEditor::dataChanged(topLeft, bottomRight, oldValue, roles);
   ui->backgroundRenderer->update();
 }
 

--- a/Editors/BackgroundEditor.cpp
+++ b/Editors/BackgroundEditor.cpp
@@ -18,7 +18,7 @@ BackgroundEditor::BackgroundEditor(ProtoModel* model, QWidget* parent)
     : BaseEditor(model, parent), ui(new Ui::BackgroundEditor) {
   ui->setupUi(this);
 
-  ui->backgroundRenderer->SetResourceModel(model);
+  ui->backgroundRenderer->SetResourceModel(resMapper->GetModel());
 
   resMapper->addMapping(ui->smoothCheckBox, Background::kSmoothEdgesFieldNumber);
   resMapper->addMapping(ui->preloadCheckBox, Background::kPreloadFieldNumber);

--- a/Editors/BackgroundEditor.cpp
+++ b/Editors/BackgroundEditor.cpp
@@ -20,17 +20,17 @@ BackgroundEditor::BackgroundEditor(ProtoModel* model, QWidget* parent)
 
   ui->backgroundRenderer->SetResourceModel(model);
 
-  mapper->addMapping(ui->smoothCheckBox, Background::kSmoothEdgesFieldNumber);
-  mapper->addMapping(ui->preloadCheckBox, Background::kPreloadFieldNumber);
-  mapper->addMapping(ui->transparentCheckBox, Background::kTransparentFieldNumber);
-  mapper->addMapping(ui->tilesetGroupBox, Background::kUseAsTilesetFieldNumber);
-  mapper->addMapping(ui->tileWidthSpinBox, Background::kTileWidthFieldNumber);
-  mapper->addMapping(ui->tileHeightSpinBox, Background::kTileHeightFieldNumber);
-  mapper->addMapping(ui->horizontalOffsetSpinBox, Background::kHorizontalOffsetFieldNumber);
-  mapper->addMapping(ui->verticalOffsetSpinBox, Background::kVerticalOffsetFieldNumber);
-  mapper->addMapping(ui->horizontalSpacingSpinBox, Background::kHorizontalSpacingFieldNumber);
-  mapper->addMapping(ui->verticalSpacingSpinBox, Background::kVerticalSpacingFieldNumber);
-  mapper->toFirst();
+  resMapper->addMapping(ui->smoothCheckBox, Background::kSmoothEdgesFieldNumber);
+  resMapper->addMapping(ui->preloadCheckBox, Background::kPreloadFieldNumber);
+  resMapper->addMapping(ui->transparentCheckBox, Background::kTransparentFieldNumber);
+  resMapper->addMapping(ui->tilesetGroupBox, Background::kUseAsTilesetFieldNumber);
+  resMapper->addMapping(ui->tileWidthSpinBox, Background::kTileWidthFieldNumber);
+  resMapper->addMapping(ui->tileHeightSpinBox, Background::kTileHeightFieldNumber);
+  resMapper->addMapping(ui->horizontalOffsetSpinBox, Background::kHorizontalOffsetFieldNumber);
+  resMapper->addMapping(ui->verticalOffsetSpinBox, Background::kVerticalOffsetFieldNumber);
+  resMapper->addMapping(ui->horizontalSpacingSpinBox, Background::kHorizontalSpacingFieldNumber);
+  resMapper->addMapping(ui->verticalSpacingSpinBox, Background::kVerticalSpacingFieldNumber);
+  resMapper->toFirst();
 }
 
 BackgroundEditor::~BackgroundEditor() { delete ui; }
@@ -41,7 +41,7 @@ void BackgroundEditor::dataChanged(const QModelIndex& /*topLeft*/, const QModelI
 }
 
 void BackgroundEditor::on_actionSave_triggered() {
-  model->SetDirty(false);
+  resMapper->SetDirty(false);
   this->parentWidget()->close();
 }
 

--- a/Editors/BackgroundEditor.cpp
+++ b/Editors/BackgroundEditor.cpp
@@ -35,8 +35,9 @@ BackgroundEditor::BackgroundEditor(ProtoModel* model, QWidget* parent)
 
 BackgroundEditor::~BackgroundEditor() { delete ui; }
 
-void BackgroundEditor::dataChanged(const QModelIndex& /*topLeft*/, const QModelIndex& /*bottomRight*/,
-                                   const QVector<int>& /*roles*/) {
+void BackgroundEditor::dataChanged(const QModelIndex& topLeft, const QModelIndex& bottomRight,
+                                   const QVector<int>& roles) {
+  BaseEditor::dataChanged(topLeft, bottomRight, roles);
   ui->backgroundRenderer->update();
 }
 

--- a/Editors/BackgroundEditor.h
+++ b/Editors/BackgroundEditor.h
@@ -17,7 +17,7 @@ class BackgroundEditor : public BaseEditor {
   ~BackgroundEditor();
 
  private slots:
-  void dataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight,
+  void dataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight, const QVariant &oldValue = QVariant(0),
                    const QVector<int> &roles = QVector<int>()) override;
   void on_actionSave_triggered();
   void on_actionZoomIn_triggered();

--- a/Editors/BackgroundEditor.ui
+++ b/Editors/BackgroundEditor.ui
@@ -116,13 +116,6 @@
         </widget>
        </item>
        <item>
-        <widget class="QCheckBox" name="transparentCheckBox">
-         <property name="text">
-          <string>&amp;Transparent</string>
-         </property>
-        </widget>
-       </item>
-       <item>
         <widget class="QCheckBox" name="preloadCheckBox">
          <property name="text">
           <string>Pre&amp;load texture</string>

--- a/Editors/BaseEditor.cpp
+++ b/Editors/BaseEditor.cpp
@@ -3,12 +3,10 @@
 #include <QCloseEvent>
 #include <QMessageBox>
 
-BaseEditor::BaseEditor(ProtoModel* treeNodeModel, QWidget* parent) :
-    QWidget(parent),
-    nodeMapper(new ModelMapper(treeNodeModel, this)) {
-    buffers::TreeNode* n = static_cast<buffers::TreeNode*>(treeNodeModel->GetBuffer());
-    resMapper = new ModelMapper(treeNodeModel->GetSubModel(ResTypeFields[n->type_case()]), this);
-
+BaseEditor::BaseEditor(ProtoModel* treeNodeModel, QWidget* parent)
+    : QWidget(parent), nodeMapper(new ModelMapper(treeNodeModel, this)) {
+  buffers::TreeNode* n = static_cast<buffers::TreeNode*>(treeNodeModel->GetBuffer());
+  resMapper = new ModelMapper(treeNodeModel->GetSubModel(ResTypeFields[n->type_case()]), this);
 }
 
 void BaseEditor::closeEvent(QCloseEvent* event) {
@@ -39,11 +37,11 @@ void BaseEditor::SetModelData(int index, const QVariant& value) {
 
 QVariant BaseEditor::GetModelData(int index) { return resMapper->data(resMapper->index(index), Qt::DisplayRole); }
 
-void BaseEditor::dataChanged(const QModelIndex& topLeft, const QModelIndex& /*bottomRight*/,
+void BaseEditor::dataChanged(const QModelIndex& topLeft, const QModelIndex& /*bottomRight*/, const QVariant& oldValue,
                              const QVector<int>& /*roles*/) {
   buffers::TreeNode* n = static_cast<buffers::TreeNode*>(nodeMapper->GetModel()->GetBuffer());
   if (n == topLeft.internalPointer() && topLeft.row() == TreeNode::kNameFieldNumber) {
     //name changed
-    std::cout << n->name() << std::endl;
+    std::cout << "new: " << n->name() << " old: " << oldValue.toString().toStdString() << std::endl;
   }
 }

--- a/Editors/BaseEditor.cpp
+++ b/Editors/BaseEditor.cpp
@@ -39,5 +39,11 @@ void BaseEditor::SetModelData(int index, const QVariant& value) {
 
 QVariant BaseEditor::GetModelData(int index) { return resMapper->data(resMapper->index(index), Qt::DisplayRole); }
 
-void BaseEditor::dataChanged(const QModelIndex& /*topLeft*/, const QModelIndex& /*bottomRight*/,
-                             const QVector<int>& /*roles*/) {}
+void BaseEditor::dataChanged(const QModelIndex& topLeft, const QModelIndex& /*bottomRight*/,
+                             const QVector<int>& /*roles*/) {
+  buffers::TreeNode* n = static_cast<buffers::TreeNode*>(nodeMapper->GetModel()->GetBuffer());
+  if (n == topLeft.internalPointer() && topLeft.row() == TreeNode::kNameFieldNumber) {
+    //name changed
+    std::cout << n->name() << std::endl;
+  }
+}

--- a/Editors/BaseEditor.cpp
+++ b/Editors/BaseEditor.cpp
@@ -43,5 +43,6 @@ void BaseEditor::dataChanged(const QModelIndex& topLeft, const QModelIndex& /*bo
   if (n == topLeft.internalPointer() && topLeft.row() == TreeNode::kNameFieldNumber) {
     //name changed
     std::cout << "new: " << n->name() << " old: " << oldValue.toString().toStdString() << std::endl;
+    emit ResourceRenamed(n->type_case(), oldValue.toString(), QString::fromStdString(n->name()));
   }
 }

--- a/Editors/BaseEditor.cpp
+++ b/Editors/BaseEditor.cpp
@@ -7,7 +7,7 @@ BaseEditor::BaseEditor(ProtoModel* model, QWidget* parent)
     : QWidget(parent), model(model), mapper(new ImmediateDataWidgetMapper(this)) {
   mapper->setOrientation(Qt::Vertical);
   mapper->setModel(model);
-  connect(model, &ProtoModel::dataChanged, this, &BaseEditor::dataChanged);
+  //connect(model, &ProtoModel::dataChanged, this, &BaseEditor::dataChanged);
 }
 
 void BaseEditor::closeEvent(QCloseEvent* event) {

--- a/Editors/BaseEditor.cpp
+++ b/Editors/BaseEditor.cpp
@@ -4,14 +4,11 @@
 #include <QMessageBox>
 
 BaseEditor::BaseEditor(ProtoModel* model, QWidget* parent)
-    : QWidget(parent), model(model), mapper(new ImmediateDataWidgetMapper(this)) {
-  mapper->setOrientation(Qt::Vertical);
-  mapper->setModel(model);
-  //connect(model, &ProtoModel::dataChanged, this, &BaseEditor::dataChanged);
+    : QWidget(parent), resMapper(new ModelMapper(model, this)) {
 }
 
 void BaseEditor::closeEvent(QCloseEvent* event) {
-  if (model->IsDirty()) {
+  if (resMapper->IsDirty()) {
     QMessageBox::StandardButton reply;
     reply = QMessageBox::question(this, tr("Unsaved Changes"), tr("Would you like to save the changes?"),
                                   QMessageBox::Yes | QMessageBox::No | QMessageBox::Cancel);
@@ -20,22 +17,22 @@ void BaseEditor::closeEvent(QCloseEvent* event) {
       event->ignore();
       return;
     } else if (reply == QMessageBox::No) {
-      mapper->clearMapping();
-      model->RestoreBuffer();
+      resMapper->clearMapping();
+      resMapper->RestoreBuffer();
     }
   }
 
-  model->SetDirty(false);
+  resMapper->SetDirty(false);
   event->accept();
 }
 
-void BaseEditor::ReplaceBuffer(google::protobuf::Message* buffer) { model->ReplaceBuffer(buffer); }
+void BaseEditor::ReplaceBuffer(google::protobuf::Message* buffer) { resMapper->ReplaceBuffer(buffer); }
 
 void BaseEditor::SetModelData(int index, const QVariant& value) {
-  model->setData(model->index(index), value, Qt::DisplayRole);
+  resMapper->setData(resMapper->index(index), value, Qt::DisplayRole);
 }
 
-QVariant BaseEditor::GetModelData(int index) { return model->data(model->index(index), Qt::DisplayRole); }
+QVariant BaseEditor::GetModelData(int index) { return resMapper->data(resMapper->index(index), Qt::DisplayRole); }
 
 void BaseEditor::dataChanged(const QModelIndex& /*topLeft*/, const QModelIndex& /*bottomRight*/,
                              const QVector<int>& /*roles*/) {}

--- a/Editors/BaseEditor.cpp
+++ b/Editors/BaseEditor.cpp
@@ -41,8 +41,6 @@ void BaseEditor::dataChanged(const QModelIndex& topLeft, const QModelIndex& /*bo
                              const QVector<int>& /*roles*/) {
   buffers::TreeNode* n = static_cast<buffers::TreeNode*>(nodeMapper->GetModel()->GetBuffer());
   if (n == topLeft.internalPointer() && topLeft.row() == TreeNode::kNameFieldNumber) {
-    //name changed
-    std::cout << "new: " << n->name() << " old: " << oldValue.toString().toStdString() << std::endl;
     emit ResourceRenamed(n->type_case(), oldValue.toString(), QString::fromStdString(n->name()));
   }
 }

--- a/Editors/BaseEditor.cpp
+++ b/Editors/BaseEditor.cpp
@@ -3,8 +3,12 @@
 #include <QCloseEvent>
 #include <QMessageBox>
 
-BaseEditor::BaseEditor(ProtoModel* model, QWidget* parent)
-    : QWidget(parent), resMapper(new ModelMapper(model, this)) {
+BaseEditor::BaseEditor(ProtoModel* treeNodeModel, QWidget* parent) :
+    QWidget(parent),
+    nodeMapper(new ModelMapper(treeNodeModel, this)) {
+    buffers::TreeNode* n = static_cast<buffers::TreeNode*>(treeNodeModel->GetBuffer());
+    resMapper = new ModelMapper(treeNodeModel->GetSubModel(ResTypeFields[n->type_case()]), this);
+
 }
 
 void BaseEditor::closeEvent(QCloseEvent* event) {
@@ -17,8 +21,9 @@ void BaseEditor::closeEvent(QCloseEvent* event) {
       event->ignore();
       return;
     } else if (reply == QMessageBox::No) {
+      nodeMapper->clearMapping();
+      nodeMapper->RestoreBuffer();
       resMapper->clearMapping();
-      resMapper->RestoreBuffer();
     }
   }
 

--- a/Editors/BaseEditor.h
+++ b/Editors/BaseEditor.h
@@ -3,14 +3,38 @@
 
 #include "Models/ModelMapper.h"
 
+#include "codegen/treenode.pb.h"
+
 #include <QObject>
 #include <QWidget>
+
+using TypeCase = buffers::TreeNode::TypeCase;
+using TreeNode = buffers::TreeNode;
+using Background = buffers::resources::Background;
+using Font =  buffers::resources::Font;
+using Object = buffers::resources::Object;
+using Path = buffers::resources::Path;
+using Room = buffers::resources::Room;
+using Sound = buffers::resources::Sound;
+using Sprite = buffers::resources::Sprite;
+using Timeline = buffers::resources::Timeline;
+
+static const QHash<int, int> ResTypeFields = {
+    { TypeCase::kSprite,     TreeNode::kSpriteFieldNumber     },
+    { TypeCase::kSound,      TreeNode::kSoundFieldNumber      },
+    { TypeCase::kBackground, TreeNode::kBackgroundFieldNumber },
+    { TypeCase::kPath,       TreeNode::kPathFieldNumber       },
+    { TypeCase::kFont,       TreeNode::kFontFieldNumber       },
+    { TypeCase::kTimeline,   TreeNode::kTimelineFieldNumber   },
+    { TypeCase::kObject,     TreeNode::kObjectFieldNumber     },
+    { TypeCase::kRoom,       TreeNode::kRoomFieldNumber       }
+};
 
 class BaseEditor : public QWidget {
   Q_OBJECT
 
  public:
-  explicit BaseEditor(ProtoModel *model, QWidget *parent);
+  explicit BaseEditor(ProtoModel *treeNodeModel, QWidget *parent);
 
   virtual void closeEvent(QCloseEvent *event);
   void ReplaceBuffer(google::protobuf::Message *buffer);
@@ -22,6 +46,7 @@ class BaseEditor : public QWidget {
                            const QVector<int> &roles = QVector<int>());
 
  protected:
+  ModelMapper* nodeMapper;
   ModelMapper* resMapper;
 };
 

--- a/Editors/BaseEditor.h
+++ b/Editors/BaseEditor.h
@@ -3,21 +3,8 @@
 
 #include "Models/ModelMapper.h"
 
-#include "codegen/treenode.pb.h"
-
 #include <QObject>
 #include <QWidget>
-
-using TypeCase = buffers::TreeNode::TypeCase;
-using TreeNode = buffers::TreeNode;
-using Background = buffers::resources::Background;
-using Font =  buffers::resources::Font;
-using Object = buffers::resources::Object;
-using Path = buffers::resources::Path;
-using Room = buffers::resources::Room;
-using Sound = buffers::resources::Sound;
-using Sprite = buffers::resources::Sprite;
-using Timeline = buffers::resources::Timeline;
 
 static const QHash<int, int> ResTypeFields = {
     { TypeCase::kSprite,     TreeNode::kSpriteFieldNumber     },

--- a/Editors/BaseEditor.h
+++ b/Editors/BaseEditor.h
@@ -6,16 +6,14 @@
 #include <QObject>
 #include <QWidget>
 
-static const QHash<int, int> ResTypeFields = {
-    { TypeCase::kSprite,     TreeNode::kSpriteFieldNumber     },
-    { TypeCase::kSound,      TreeNode::kSoundFieldNumber      },
-    { TypeCase::kBackground, TreeNode::kBackgroundFieldNumber },
-    { TypeCase::kPath,       TreeNode::kPathFieldNumber       },
-    { TypeCase::kFont,       TreeNode::kFontFieldNumber       },
-    { TypeCase::kTimeline,   TreeNode::kTimelineFieldNumber   },
-    { TypeCase::kObject,     TreeNode::kObjectFieldNumber     },
-    { TypeCase::kRoom,       TreeNode::kRoomFieldNumber       }
-};
+static const QHash<int, int> ResTypeFields = {{TypeCase::kSprite, TreeNode::kSpriteFieldNumber},
+                                              {TypeCase::kSound, TreeNode::kSoundFieldNumber},
+                                              {TypeCase::kBackground, TreeNode::kBackgroundFieldNumber},
+                                              {TypeCase::kPath, TreeNode::kPathFieldNumber},
+                                              {TypeCase::kFont, TreeNode::kFontFieldNumber},
+                                              {TypeCase::kTimeline, TreeNode::kTimelineFieldNumber},
+                                              {TypeCase::kObject, TreeNode::kObjectFieldNumber},
+                                              {TypeCase::kRoom, TreeNode::kRoomFieldNumber}};
 
 class BaseEditor : public QWidget {
   Q_OBJECT
@@ -30,11 +28,11 @@ class BaseEditor : public QWidget {
 
  public slots:
   virtual void dataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight,
-                           const QVector<int> &roles = QVector<int>());
+                           const QVariant &oldValue = QVariant(0), const QVector<int> &roles = QVector<int>());
 
  protected:
-  ModelMapper* nodeMapper;
-  ModelMapper* resMapper;
+  ModelMapper *nodeMapper;
+  ModelMapper *resMapper;
 };
 
 #endif  // BASEEDTIOR_H

--- a/Editors/BaseEditor.h
+++ b/Editors/BaseEditor.h
@@ -26,6 +26,9 @@ class BaseEditor : public QWidget {
   void SetModelData(int index, const QVariant &value);
   QVariant GetModelData(int index);
 
+ signals:
+  void ResourceRenamed(TypeCase type, const QString& oldName, const QString& newName);
+
  public slots:
   virtual void dataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight,
                            const QVariant &oldValue = QVariant(0), const QVector<int> &roles = QVector<int>());

--- a/Editors/BaseEditor.h
+++ b/Editors/BaseEditor.h
@@ -1,8 +1,7 @@
 #ifndef BASEEDTIOR_H
 #define BASEEDTIOR_H
 
-#include "Models/ImmediateMapper.h"
-#include "Models/ProtoModel.h"
+#include "Models/ModelMapper.h"
 
 #include <QObject>
 #include <QWidget>
@@ -18,13 +17,12 @@ class BaseEditor : public QWidget {
   void SetModelData(int index, const QVariant &value);
   QVariant GetModelData(int index);
 
- protected slots:
+ public slots:
   virtual void dataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight,
                            const QVector<int> &roles = QVector<int>());
 
  protected:
-  ProtoModel *model;
-  ImmediateDataWidgetMapper *mapper;
+  ModelMapper* resMapper;
 };
 
 #endif  // BASEEDTIOR_H

--- a/Editors/RoomEditor.cpp
+++ b/Editors/RoomEditor.cpp
@@ -8,6 +8,8 @@
 #include <QGraphicsPixmapItem>
 #include <QGraphicsScene>
 
+#include <algorithm>
+
 using namespace buffers::resources;
 
 RoomEditor::RoomEditor(ProtoModel* model, QWidget* parent) : BaseEditor(model, parent), ui(new Ui::RoomEditor) {
@@ -27,14 +29,113 @@ RoomEditor::RoomEditor(ProtoModel* model, QWidget* parent) : BaseEditor(model, p
   Room* room = static_cast<Room*>(model->GetBuffer());
 
   QGraphicsScene* scene = new QGraphicsScene(0, 0, room->width(), room->height(), this);
-  scene->addRect(scene->sceneRect(), QPen(Qt::gray), QBrush(Qt::gray));
 
-  for (auto inst : room->instances()) {
-    auto obj = MainWindow::resourceMap->GetResourceByName(buffers::TreeNode::kObject, inst.object_type());
-    auto spr = MainWindow::resourceMap->GetResourceByName(buffers::TreeNode::kSprite, obj->data(buffers::resources::Object::kSpriteNameFieldNumber).toString());
-    QString imgFile = spr->GetString(buffers::resources::Sprite::kSubimagesFieldNumber, 0);
-    auto item = scene->addPixmap(QPixmap(imgFile));
+  QColor roomColor = Qt::transparent;
+  if (room->show_color()) roomColor = room->color();
+  scene->addRect(scene->sceneRect(), QPen(roomColor), QBrush(roomColor));
+
+  for (auto bkg : room->backgrounds()) {
+      if (bkg.visible()) {
+        ProtoModel* bkgRes = MainWindow::resourceMap->GetResourceByName(buffers::TreeNode::kBackground,
+                                                                        bkg.background_name());
+        if (bkgRes != nullptr) {
+          QString imgFile = bkgRes->data(buffers::resources::Background::kImageFieldNumber).toString();
+          int w = bkgRes->data(buffers::resources::Background::kWidthFieldNumber).toInt();
+          int h = bkgRes->data(buffers::resources::Background::kHeightFieldNumber).toInt();
+          auto item = scene->addPixmap(ArtManager::GetIcon(imgFile).pixmap(w, h));
+          item->setPos(bkg.x(), bkg.y());
+          if (bkg.stretch()) {
+            item->setTransform(item->transform().scale(room->width() / qreal(w), room->height() / qreal(h)));
+          } else {
+            if (bkg.htiled() && bkg.vtiled()) {
+              for (int i = 0; i < static_cast<int>(room->width()); i += w) {
+                for (int j = 0; j < static_cast<int>(room->height()); j += h) {
+                    auto b = scene->addPixmap(ArtManager::GetIcon(imgFile).pixmap(w, h));
+                    b->setPos(i, j);
+                }
+              }
+            } else {
+              if (bkg.htiled()) {
+                for (int i = w; i < static_cast<int>(room->width()); i += w) {
+                  auto b = scene->addPixmap(ArtManager::GetIcon(imgFile).pixmap(w, h));
+                  b->setPos(i, 0);
+                }
+              }
+              if (bkg.vtiled()) {
+                for (int i = h; i < static_cast<int>(room->height()); i += h) {
+                  auto b = scene->addPixmap(ArtManager::GetIcon(imgFile).pixmap(w, h));
+                  b->setPos(0, i);
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+
+  google::protobuf::RepeatedField<buffers::resources::Room::Tile>
+          sortedTiles(room->mutable_tiles()->begin(), room->mutable_tiles()->end());
+
+  std::sort(sortedTiles.begin(), sortedTiles.end(),
+            [](const buffers::resources::Room::Tile& a, const buffers::resources::Room::Tile& b) {
+               return a.depth() > b.depth();
+            });
+  for (auto tile : sortedTiles) {
+
+    ProtoModel* bkg = MainWindow::resourceMap->GetResourceByName(buffers::TreeNode::kBackground,
+                                                                 tile.background_name());
+    if (bkg != nullptr) {
+      QString imgFile = bkg->data(buffers::resources::Background::kImageFieldNumber).toString();
+      int w = static_cast<int>(tile.width());
+      int h = static_cast<int>(tile.height());
+      auto item = scene->addPixmap(ArtManager::GetIcon(imgFile).pixmap(w, h));
+      item->setPos(tile.x(), tile.y());
+      item->setOffset(tile.xoffset(), tile.yoffset());
+      qreal xscale = (tile.has_xscale()) ? tile.xscale() : 1;
+      qreal yscale = (tile.has_yscale()) ? tile.yscale() : 1;
+      item->setTransform(item->transform().scale(xscale, yscale));
+    }
+  }
+
+  google::protobuf::RepeatedField<buffers::resources::Room::Instance>
+          sortedInstances(room->mutable_instances()->begin(), room->mutable_instances()->end());
+
+  std::sort(sortedInstances.begin(), sortedInstances.end(),
+            [](const buffers::resources::Room::Instance& a, const buffers::resources::Room::Instance& b) {
+               ProtoModel* objA = MainWindow::resourceMap->GetResourceByName(buffers::TreeNode::kObject, a.object_type());
+               ProtoModel* objB = MainWindow::resourceMap->GetResourceByName(buffers::TreeNode::kObject, b.object_type());
+               if (objA != nullptr && objB != nullptr)
+                 return objA->data(buffers::resources::Object::kDepthFieldNumber) >
+                         objB->data(buffers::resources::Object::kDepthFieldNumber);
+               return false;
+            });
+  for (auto inst : sortedInstances) {
+    QString imgFile;
+    int w = 18;
+    int h = 18;
+    int xoff = 0;
+    int yoff = 0;
+
+    ProtoModel* obj = MainWindow::resourceMap->GetResourceByName(buffers::TreeNode::kObject, inst.object_type());
+    if (obj != nullptr) {
+      ProtoModel* spr = MainWindow::resourceMap->GetResourceByName(buffers::TreeNode::kSprite,
+                                           obj->data(buffers::resources::Object::kSpriteNameFieldNumber).toString());
+      if (spr != nullptr) {
+        imgFile = spr->GetString(buffers::resources::Sprite::kSubimagesFieldNumber, 0);
+        w = spr->data(buffers::resources::Sprite::kWidthFieldNumber).toInt();
+        h = spr->data(buffers::resources::Sprite::kHeightFieldNumber).toInt();
+        xoff = spr->data(buffers::resources::Sprite::kOriginXFieldNumber).toInt();
+        yoff = spr->data(buffers::resources::Sprite::kOriginYFieldNumber).toInt();
+      }
+    }
+
+    if (imgFile.isEmpty())
+      imgFile = "object";
+
+    auto item = scene->addPixmap(ArtManager::GetIcon(imgFile).pixmap(w, h));
     item->setPos(inst.x(), inst.y());
+    item->setOffset(-xoff, -yoff);
     item->setRotation(inst.rotation());
     item->setTransform(item->transform().scale(inst.xscale(), inst.yscale()));
   }

--- a/Editors/RoomEditor.cpp
+++ b/Editors/RoomEditor.cpp
@@ -46,18 +46,15 @@ RoomEditor::RoomEditor(ProtoModel* model, QWidget* parent) : BaseEditor(model, p
   ui->layersAssetsView->header()->swapSections(Room::Instance::kNameFieldNumber,
                                                Room::Instance::kObjectTypeFieldNumber);
 
-  ui->roomPreview->viewport()->installEventFilter(this);
-  //ui->roomPreview->setBackgroundRole(QPalette::Dark);
+  ui->roomPreview->widget()->installEventFilter(this);
 }
 
 RoomEditor::~RoomEditor() { delete ui; }
-#include <QDebug>
+
 bool RoomEditor::eventFilter(QObject* obj, QEvent* event) {
-  if (obj == ui->roomPreview->viewport()) {
-    //TODO: fix the transparency pattern on viewport
-    qDebug() << "bing bing bing" << event->type();
+  if (obj == ui->roomPreview->widget()) {
     if (event->type() == QEvent::Paint) {
-      QPainter painter(ui->roomPreview->viewport());
+      QPainter painter(ui->roomPreview->widget());
       painter.scale(4, 4);
       painter.fillRect(painter.viewport(), ArtManager::GetTransparenyBrush());
       return false;

--- a/Editors/RoomEditor.cpp
+++ b/Editors/RoomEditor.cpp
@@ -109,8 +109,8 @@ RoomEditor::RoomEditor(ProtoModel* model, QWidget* parent) : BaseEditor(model, p
       ui->layersAssetsView->resizeColumnToContents(c);
   }
 
-  ui->layersAssetsView->horizontalHeader()->swapSections(Room::Instance::kNameFieldNumber,
-                                                         Room::Instance::kObjectTypeFieldNumber);
+  ui->layersAssetsView->header()->swapSections(Room::Instance::kNameFieldNumber,
+                                               Room::Instance::kObjectTypeFieldNumber);
 
   google::protobuf::RepeatedField<Room::Instance> sortedInstances(room->mutable_instances()->begin(),
                                                                   room->mutable_instances()->end());

--- a/Editors/RoomEditor.cpp
+++ b/Editors/RoomEditor.cpp
@@ -71,7 +71,7 @@ RoomEditor::RoomEditor(ProtoModel* model, QWidget* parent) : BaseEditor(model, p
   RepeatedProtoModel* m = roomModel->GetRepeatedSubModel(Room::kInstancesFieldNumber);
   ui->layersAssetsView->setModel(m);
   connect(ui->layersAssetsView->selectionModel(), &QItemSelectionModel::selectionChanged,
-          [=](const QItemSelection& selected, const QItemSelection& deselected) {
+          [=](const QItemSelection& selected, const QItemSelection& /*deselected*/) {
             if (selected.empty()) return;
             auto selectedIndex = selected.indexes().first();
             auto currentInstanceModel =
@@ -127,9 +127,7 @@ bool RoomEditor::eventFilter(QObject* obj, QEvent* event) {
   return QWidget::eventFilter(obj, event);
 }
 
-void RoomEditor::SelectedObjectChanged(QAction *action) {
-  ui->currentObject->setText(action->text());
-}
+void RoomEditor::SelectedObjectChanged(QAction* action) { ui->currentObject->setText(action->text()); }
 
 void RoomEditor::updateCursorPositionLabel(const QPoint& pos) {
   this->cursorPositionLabel->setText(tr("X %0, Y %1").arg(pos.x()).arg(pos.y()));

--- a/Editors/RoomEditor.cpp
+++ b/Editors/RoomEditor.cpp
@@ -32,10 +32,14 @@ RoomEditor::RoomEditor(ProtoModel* model, QWidget* parent) : BaseEditor(model, p
 
   RepeatedProtoModel* m = roomModel->GetRepeatedSubModel(Room::kInstancesFieldNumber);
   ui->layersAssetsView->setModel(m);
-  if (!m->empty()) {
-    auto currentInstanceModel = roomModel->data(Room::kInstancesFieldNumber, 0).value<void*>();
-    ui->layersPropertiesView->setModel(static_cast<ProtoModel*>(currentInstanceModel));
-  }
+  connect(ui->layersAssetsView->selectionModel(), &QItemSelectionModel::selectionChanged,
+          [=](const QItemSelection& selected, const QItemSelection& deselected) {
+            if (selected.empty()) return;
+            auto selectedIndex = selected.indexes().first();
+            auto currentInstanceModel =
+                roomModel->data(Room::kInstancesFieldNumber, selectedIndex.row()).value<void*>();
+            ui->layersPropertiesView->setModel(static_cast<ProtoModel*>(currentInstanceModel));
+          });
 
   for (int c = 0; c < m->columnCount(); ++c) {
     if (c != Room::Instance::kNameFieldNumber && c != Room::Instance::kObjectTypeFieldNumber &&

--- a/Editors/RoomEditor.cpp
+++ b/Editors/RoomEditor.cpp
@@ -101,6 +101,9 @@ RoomEditor::RoomEditor(ProtoModel* model, QWidget* parent) : BaseEditor(model, p
     }
   }
 
+  QList<QVariant> instances = resMapper->data(Room::kInstancesFieldNumber).toList();
+  ui->layersTableView->setModel(static_cast<ProtoModel*>(instances[0].value<void*>()));
+
   google::protobuf::RepeatedField<Room::Instance>
           sortedInstances(room->mutable_instances()->begin(), room->mutable_instances()->end());
 

--- a/Editors/RoomEditor.cpp
+++ b/Editors/RoomEditor.cpp
@@ -1,13 +1,70 @@
 #include "RoomEditor.h"
+#include "Components/ArtManager.h"
+#include "MainWindow.h"
 #include "ui_RoomEditor.h"
 
+#include "codegen/Room.pb.h"
+
+#include <QGraphicsPixmapItem>
 #include <QGraphicsScene>
+
+using namespace buffers::resources;
 
 RoomEditor::RoomEditor(ProtoModel* model, QWidget* parent) : BaseEditor(model, parent), ui(new Ui::RoomEditor) {
   ui->setupUi(this);
 
-  QGraphicsScene* scene = new QGraphicsScene(this);
+  mapper->addMapping(ui->speedSpinBox, Room::kSpeedFieldNumber);
+  mapper->addMapping(ui->widthSpinBox, Room::kWidthFieldNumber);
+  mapper->addMapping(ui->heightSpinBox, Room::kHeightFieldNumber);
+  mapper->addMapping(ui->clearCheckBox, Room::kClearDisplayBufferFieldNumber);
+  mapper->addMapping(ui->persistentCheckBox, Room::kPersistentFieldNumber);
+  mapper->addMapping(ui->captionLineEdit, Room::kCaptionFieldNumber);
+
+  mapper->addMapping(ui->enableViewsCheckBox, Room::kEnableViewsFieldNumber);
+  mapper->addMapping(ui->clearViewportCheckBox, Room::kClearViewBackgroundFieldNumber);
+  mapper->toFirst();
+
+  Room* room = static_cast<Room*>(model->GetBuffer());
+
+  QGraphicsScene* scene = new QGraphicsScene(0, 0, room->width(), room->height(), this);
+  scene->addRect(scene->sceneRect(), QPen(Qt::gray), QBrush(Qt::gray));
+
+  for (auto inst : room->instances()) {
+    const auto object_type = inst.object_type();
+    auto item = scene->addPixmap(QPixmap(":/resources/sprite.png"));
+    item->setPos(inst.x(), inst.y());
+    item->setRotation(inst.rotation());
+    item->setTransform(item->transform().scale(inst.xscale(), inst.yscale()));
+  }
+
+  ui->graphicsView->viewport()->installEventFilter(this);
   ui->graphicsView->setScene(scene);
 }
 
 RoomEditor::~RoomEditor() { delete ui; }
+
+bool RoomEditor::eventFilter(QObject* obj, QEvent* event) {
+  if (obj == ui->graphicsView->viewport()) {
+    if (event->type() == QEvent::Paint) {
+      QPainter painter(ui->graphicsView->viewport());
+      painter.scale(4, 4);
+      painter.fillRect(painter.viewport(), ArtManager::GetTransparenyBrush());
+      return false;
+    }
+  }
+
+  return QWidget::eventFilter(obj, event);
+}
+
+void RoomEditor::setZoom(qreal zoom) {
+  if (zoom > 3200) zoom = 3200;
+  if (zoom < 0.0625) zoom = 0.0625;
+  this->zoom = zoom;
+  ui->graphicsView->setTransform(QTransform::fromScale(zoom, zoom));
+}
+
+void RoomEditor::on_actionZoomIn_triggered() { this->setZoom(zoom * 2); }
+
+void RoomEditor::on_actionZoomOut_triggered() { this->setZoom(zoom / 2); }
+
+void RoomEditor::on_actionZoom_triggered() { this->setZoom(1.0); }

--- a/Editors/RoomEditor.cpp
+++ b/Editors/RoomEditor.cpp
@@ -10,6 +10,7 @@
 
 #include <QGraphicsPixmapItem>
 #include <QGraphicsScene>
+#include <QMouseEvent>
 
 #include <algorithm>
 

--- a/Editors/RoomEditor.cpp
+++ b/Editors/RoomEditor.cpp
@@ -13,6 +13,9 @@
 RoomEditor::RoomEditor(ProtoModel* model, QWidget* parent) : BaseEditor(model, parent), ui(new Ui::RoomEditor) {
   ui->setupUi(this);
 
+  ProtoModel* roomModel = model->GetSubModel(TreeNode::kRoomFieldNumber);
+  ui->roomRenderer->SetResourceModel(roomModel);
+
   nodeMapper->addMapping(ui->roomName, TreeNode::kNameFieldNumber);
   nodeMapper->toFirst();
 
@@ -26,75 +29,6 @@ RoomEditor::RoomEditor(ProtoModel* model, QWidget* parent) : BaseEditor(model, p
   resMapper->addMapping(ui->enableViewsCheckBox, Room::kEnableViewsFieldNumber);
   resMapper->addMapping(ui->clearViewportCheckBox, Room::kClearViewBackgroundFieldNumber);
   resMapper->toFirst();
-
-  ProtoModel* roomModel = model->GetSubModel(TreeNode::kRoomFieldNumber);
-
-  Room* room = static_cast<Room*>(roomModel->GetBuffer());
-
-  QGraphicsScene* scene = new QGraphicsScene(0, 0, room->width(), room->height(), this);
-
-  QColor roomColor = Qt::transparent;
-  if (room->show_color()) roomColor = room->color();
-  scene->addRect(scene->sceneRect(), QPen(roomColor), QBrush(roomColor));
-
-  for (auto bkg : room->backgrounds()) {  //TODO: need to draw last if foreground
-    if (bkg.visible()) {
-      ProtoModel* bkgRes = MainWindow::resourceMap->GetResourceByName(TreeNode::kBackground, bkg.background_name())
-                               ->GetSubModel(TreeNode::kBackgroundFieldNumber);
-      if (bkgRes != nullptr) {
-        QString imgFile = bkgRes->data(Background::kImageFieldNumber).toString();
-        int w = bkgRes->data(Background::kWidthFieldNumber).toInt();
-        int h = bkgRes->data(Background::kHeightFieldNumber).toInt();
-        auto item = scene->addPixmap(ArtManager::GetIcon(imgFile).pixmap(w, h));
-        item->setPos(bkg.x(), bkg.y());
-        if (bkg.stretch()) {
-          item->setTransform(item->transform().scale(room->width() / qreal(w), room->height() / qreal(h)));
-        } else {
-          if (bkg.htiled() && bkg.vtiled()) {
-            for (int i = 0; i < static_cast<int>(room->width()); i += w) {
-              for (int j = 0; j < static_cast<int>(room->height()); j += h) {
-                auto b = scene->addPixmap(ArtManager::GetIcon(imgFile).pixmap(w, h));
-                b->setPos(i, j);
-              }
-            }
-          } else {
-            if (bkg.htiled()) {
-              for (int i = w; i < static_cast<int>(room->width()); i += w) {
-                auto b = scene->addPixmap(ArtManager::GetIcon(imgFile).pixmap(w, h));
-                b->setPos(i, 0);
-              }
-            }
-            if (bkg.vtiled()) {
-              for (int i = h; i < static_cast<int>(room->height()); i += h) {
-                auto b = scene->addPixmap(ArtManager::GetIcon(imgFile).pixmap(w, h));
-                b->setPos(0, i);
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-
-  google::protobuf::RepeatedField<Room::Tile> sortedTiles(room->mutable_tiles()->begin(), room->mutable_tiles()->end());
-
-  std::sort(sortedTiles.begin(), sortedTiles.end(),
-            [](const Room::Tile& a, const Room::Tile& b) { return a.depth() > b.depth(); });
-  for (auto tile : sortedTiles) {
-    ProtoModel* bkg = MainWindow::resourceMap->GetResourceByName(TreeNode::kBackground, tile.background_name())
-                          ->GetSubModel(TreeNode::kBackgroundFieldNumber);
-    if (bkg != nullptr) {
-      QString imgFile = bkg->data(Background::kImageFieldNumber).toString();
-      int w = static_cast<int>(tile.width());
-      int h = static_cast<int>(tile.height());
-      auto item = scene->addPixmap(ArtManager::GetIcon(imgFile).pixmap(w, h));
-      item->setPos(tile.x(), tile.y());
-      item->setOffset(-tile.xoffset(), -tile.yoffset());
-      qreal xscale = (tile.has_xscale()) ? tile.xscale() : 1;
-      qreal yscale = (tile.has_yscale()) ? tile.yscale() : 1;
-      item->setTransform(item->transform().scale(xscale, yscale));
-    }
-  }
 
   RepeatedProtoModel* m = roomModel->GetRepeatedSubModel(Room::kInstancesFieldNumber);
   ui->layersAssetsView->setModel(m);
@@ -112,59 +46,18 @@ RoomEditor::RoomEditor(ProtoModel* model, QWidget* parent) : BaseEditor(model, p
   ui->layersAssetsView->header()->swapSections(Room::Instance::kNameFieldNumber,
                                                Room::Instance::kObjectTypeFieldNumber);
 
-  google::protobuf::RepeatedField<Room::Instance> sortedInstances(room->mutable_instances()->begin(),
-                                                                  room->mutable_instances()->end());
-
-  std::sort(sortedInstances.begin(), sortedInstances.end(), [](const Room::Instance& a, const Room::Instance& b) {
-    ProtoModel* objA = MainWindow::resourceMap->GetResourceByName(TreeNode::kObject, a.object_type())
-                           ->GetSubModel(TreeNode::kObjectFieldNumber);
-    ProtoModel* objB = MainWindow::resourceMap->GetResourceByName(TreeNode::kObject, b.object_type())
-                           ->GetSubModel(TreeNode::kObjectFieldNumber);
-    if (objA != nullptr && objB != nullptr)
-      return objA->data(Object::kDepthFieldNumber) > objB->data(Object::kDepthFieldNumber);
-    return false;
-  });
-  for (auto inst : sortedInstances) {
-    QString imgFile;
-    int w = 18;
-    int h = 18;
-    int xoff = 0;
-    int yoff = 0;
-
-    ProtoModel* obj = MainWindow::resourceMap->GetResourceByName(TreeNode::kObject, inst.object_type());
-    if (obj != nullptr) {
-      obj = obj->GetSubModel(TreeNode::kObjectFieldNumber);
-      ProtoModel* spr = MainWindow::resourceMap->GetResourceByName(
-          TreeNode::kSprite, obj->data(Object::kSpriteNameFieldNumber).toString());
-      if (spr != nullptr) {
-        spr = spr->GetSubModel(TreeNode::kSpriteFieldNumber);
-        imgFile = spr->GetString(Sprite::kSubimagesFieldNumber, 0);
-        w = spr->data(Sprite::kWidthFieldNumber).toInt();
-        h = spr->data(Sprite::kHeightFieldNumber).toInt();
-        xoff = spr->data(Sprite::kOriginXFieldNumber).toInt();
-        yoff = spr->data(Sprite::kOriginYFieldNumber).toInt();
-      }
-    }
-
-    if (imgFile.isEmpty()) imgFile = "object";
-
-    auto item = scene->addPixmap(ArtManager::GetIcon(imgFile).pixmap(w, h));
-    item->setPos(inst.x(), inst.y());
-    item->setOffset(-xoff, -yoff);
-    item->setRotation(inst.rotation());
-    item->setTransform(item->transform().scale(inst.xscale(), inst.yscale()));
-  }
-
-  ui->graphicsView->viewport()->installEventFilter(this);
-  ui->graphicsView->setScene(scene);
+  ui->roomPreview->viewport()->installEventFilter(this);
+  //ui->roomPreview->setBackgroundRole(QPalette::Dark);
 }
 
 RoomEditor::~RoomEditor() { delete ui; }
-
+#include <QDebug>
 bool RoomEditor::eventFilter(QObject* obj, QEvent* event) {
-  if (obj == ui->graphicsView->viewport()) {
+  if (obj == ui->roomPreview->viewport()) {
+    //TODO: fix the transparency pattern on viewport
+    qDebug() << "bing bing bing" << event->type();
     if (event->type() == QEvent::Paint) {
-      QPainter painter(ui->graphicsView->viewport());
+      QPainter painter(ui->roomPreview->viewport());
       painter.scale(4, 4);
       painter.fillRect(painter.viewport(), ArtManager::GetTransparenyBrush());
       return false;
@@ -174,15 +67,8 @@ bool RoomEditor::eventFilter(QObject* obj, QEvent* event) {
   return QWidget::eventFilter(obj, event);
 }
 
-void RoomEditor::setZoom(qreal zoom) {
-  if (zoom > 3200) zoom = 3200;
-  if (zoom < 0.0625) zoom = 0.0625;
-  this->zoom = zoom;
-  ui->graphicsView->setTransform(QTransform::fromScale(zoom, zoom));
-}
+void RoomEditor::on_actionZoomIn_triggered() { ui->roomRenderer->SetZoom(zoom * 2); }
 
-void RoomEditor::on_actionZoomIn_triggered() { this->setZoom(zoom * 2); }
+void RoomEditor::on_actionZoomOut_triggered() { ui->roomRenderer->SetZoom(zoom / 2); }
 
-void RoomEditor::on_actionZoomOut_triggered() { this->setZoom(zoom / 2); }
-
-void RoomEditor::on_actionZoom_triggered() { this->setZoom(1.0); }
+void RoomEditor::on_actionZoom_triggered() { ui->roomRenderer->SetZoom(1.0); }

--- a/Editors/RoomEditor.cpp
+++ b/Editors/RoomEditor.cpp
@@ -1,9 +1,11 @@
 #include "RoomEditor.h"
 #include "Components/ArtManager.h"
+#include "Components/QMenuView.h"
 #include "MainWindow.h"
 #include "ui_RoomEditor.h"
 
 #include "Models/ImmediateMapper.h"
+#include "Models/TreeSortFilterProxyModel.h"
 #include "codegen/Room.pb.h"
 
 #include <QGraphicsPixmapItem>
@@ -53,6 +55,15 @@ RoomEditor::RoomEditor(ProtoModel* model, QWidget* parent) : BaseEditor(model, p
   viewMapper->addMapping(ui->followingHSpeedSpinBox, View::kHspeedFieldNumber);
   viewMapper->addMapping(ui->followingVSpeedSpinBox, View::kVspeedFieldNumber);
   viewMapper->toFirst();
+
+  QMenuView* objMenu = new QMenuView(this);
+  TreeSortFilterProxyModel* treeProxy = new TreeSortFilterProxyModel(this);
+  treeProxy->SetFilterType(TreeNode::TypeCase::kObject);
+  treeProxy->setSourceModel(MainWindow::treeModel);
+  objMenu->setModel(treeProxy);
+  ui->objectSelectButton->setMenu(objMenu);
+
+  connect(objMenu, &QMenu::triggered, this, &RoomEditor::SelectedObjectChanged);
 
   connect(ui->currentViewComboBox, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
           [=](int index) { viewMapper->setCurrentIndex(index); });
@@ -114,6 +125,10 @@ bool RoomEditor::eventFilter(QObject* obj, QEvent* event) {
   }
 
   return QWidget::eventFilter(obj, event);
+}
+
+void RoomEditor::SelectedObjectChanged(QAction *action) {
+  ui->currentObject->setText(action->text());
 }
 
 void RoomEditor::updateCursorPositionLabel(const QPoint& pos) {

--- a/Editors/RoomEditor.cpp
+++ b/Editors/RoomEditor.cpp
@@ -101,8 +101,12 @@ RoomEditor::RoomEditor(ProtoModel* model, QWidget* parent) : BaseEditor(model, p
     }
   }
 
-  QVariant instance = resMapper->data(Room::kInstancesFieldNumber, 0);
-  ui->layersTableView->setModel(static_cast<ProtoModel*>(instance.value<void*>()));
+  RepeatedProtoModel* m = roomModel->GetRepeatedSubModel(Room::kInstancesFieldNumber);
+  ui->layersTableView->setModel(m);
+  for (int c = 0; c < m->columnCount(); ++c) {
+    if (c != Room::Instance::kNameFieldNumber && c != Room::Instance::kObjectTypeFieldNumber && c != Room::Instance::kIdFieldNumber)
+      ui->layersTableView->hideColumn(c);
+  }
 
   google::protobuf::RepeatedField<Room::Instance>
           sortedInstances(room->mutable_instances()->begin(), room->mutable_instances()->end());

--- a/Editors/RoomEditor.cpp
+++ b/Editors/RoomEditor.cpp
@@ -30,8 +30,10 @@ RoomEditor::RoomEditor(ProtoModel* model, QWidget* parent) : BaseEditor(model, p
   scene->addRect(scene->sceneRect(), QPen(Qt::gray), QBrush(Qt::gray));
 
   for (auto inst : room->instances()) {
-    const auto object_type = inst.object_type();
-    auto item = scene->addPixmap(QPixmap(":/resources/sprite.png"));
+    auto obj = MainWindow::resourceMap->GetResourceByName(buffers::TreeNode::kObject, inst.object_type());
+    auto spr = MainWindow::resourceMap->GetResourceByName(buffers::TreeNode::kSprite, obj->data(buffers::resources::Object::kSpriteNameFieldNumber).toString());
+    QString imgFile = spr->GetString(buffers::resources::Sprite::kSubimagesFieldNumber, 0);
+    auto item = scene->addPixmap(QPixmap(imgFile));
     item->setPos(inst.x(), inst.y());
     item->setRotation(inst.rotation());
     item->setTransform(item->transform().scale(inst.xscale(), inst.yscale()));

--- a/Editors/RoomEditor.cpp
+++ b/Editors/RoomEditor.cpp
@@ -3,12 +3,15 @@
 #include "MainWindow.h"
 #include "ui_RoomEditor.h"
 
+#include "Models/ImmediateMapper.h"
 #include "codegen/Room.pb.h"
 
 #include <QGraphicsPixmapItem>
 #include <QGraphicsScene>
 
 #include <algorithm>
+
+using View = buffers::resources::Room::View;
 
 RoomEditor::RoomEditor(ProtoModel* model, QWidget* parent) : BaseEditor(model, parent), ui(new Ui::RoomEditor) {
   ui->setupUi(this);
@@ -29,6 +32,30 @@ RoomEditor::RoomEditor(ProtoModel* model, QWidget* parent) : BaseEditor(model, p
   resMapper->addMapping(ui->enableViewsCheckBox, Room::kEnableViewsFieldNumber);
   resMapper->addMapping(ui->clearViewportCheckBox, Room::kClearViewBackgroundFieldNumber);
   resMapper->toFirst();
+
+  RepeatedProtoModel* vm = roomModel->GetRepeatedSubModel(Room::kViewsFieldNumber);
+  ImmediateDataWidgetMapper* viewMapper = new ImmediateDataWidgetMapper(this);
+  viewMapper->setModel(vm);
+  viewMapper->addMapping(ui->viewVisibleCheckBox, View::kVisibleFieldNumber);
+
+  viewMapper->addMapping(ui->cameraXSpinBox, View::kXviewFieldNumber);
+  viewMapper->addMapping(ui->cameraYSpinBox, View::kYviewFieldNumber);
+  viewMapper->addMapping(ui->cameraWidthSpinBox, View::kWviewFieldNumber);
+  viewMapper->addMapping(ui->cameraHeightSpinBox, View::kHviewFieldNumber);
+
+  viewMapper->addMapping(ui->viewportXSpinBox, View::kXportFieldNumber);
+  viewMapper->addMapping(ui->viewportYSpinBox, View::kYportFieldNumber);
+  viewMapper->addMapping(ui->viewportWidthSpinBox, View::kWportFieldNumber);
+  viewMapper->addMapping(ui->viewportHeightSpinBox, View::kHportFieldNumber);
+
+  viewMapper->addMapping(ui->followingHBorderSpinBox, View::kHborderFieldNumber);
+  viewMapper->addMapping(ui->followingVBorderSpinBox, View::kVborderFieldNumber);
+  viewMapper->addMapping(ui->followingHSpeedSpinBox, View::kHspeedFieldNumber);
+  viewMapper->addMapping(ui->followingVSpeedSpinBox, View::kVspeedFieldNumber);
+  viewMapper->toFirst();
+
+  connect(ui->currentViewComboBox, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
+          [=](int index) { viewMapper->setCurrentIndex(index); });
 
   RepeatedProtoModel* m = roomModel->GetRepeatedSubModel(Room::kInstancesFieldNumber);
   ui->layersAssetsView->setModel(m);

--- a/Editors/RoomEditor.cpp
+++ b/Editors/RoomEditor.cpp
@@ -106,7 +106,11 @@ RoomEditor::RoomEditor(ProtoModel* model, QWidget* parent) : BaseEditor(model, p
   for (int c = 0; c < m->columnCount(); ++c) {
     if (c != Room::Instance::kNameFieldNumber && c != Room::Instance::kObjectTypeFieldNumber && c != Room::Instance::kIdFieldNumber)
       ui->layersTableView->hideColumn(c);
+    else
+      ui->layersTableView->resizeColumnToContents(c);
   }
+
+  ui->layersTableView->horizontalHeader()->swapSections(Room::Instance::kNameFieldNumber, Room::Instance::kObjectTypeFieldNumber);
 
   google::protobuf::RepeatedField<Room::Instance>
           sortedInstances(room->mutable_instances()->begin(), room->mutable_instances()->end());

--- a/Editors/RoomEditor.cpp
+++ b/Editors/RoomEditor.cpp
@@ -15,16 +15,16 @@ using namespace buffers::resources;
 RoomEditor::RoomEditor(ProtoModel* model, QWidget* parent) : BaseEditor(model, parent), ui(new Ui::RoomEditor) {
   ui->setupUi(this);
 
-  mapper->addMapping(ui->speedSpinBox, Room::kSpeedFieldNumber);
-  mapper->addMapping(ui->widthSpinBox, Room::kWidthFieldNumber);
-  mapper->addMapping(ui->heightSpinBox, Room::kHeightFieldNumber);
-  mapper->addMapping(ui->clearCheckBox, Room::kClearDisplayBufferFieldNumber);
-  mapper->addMapping(ui->persistentCheckBox, Room::kPersistentFieldNumber);
-  mapper->addMapping(ui->captionLineEdit, Room::kCaptionFieldNumber);
+  resMapper->addMapping(ui->speedSpinBox, Room::kSpeedFieldNumber);
+  resMapper->addMapping(ui->widthSpinBox, Room::kWidthFieldNumber);
+  resMapper->addMapping(ui->heightSpinBox, Room::kHeightFieldNumber);
+  resMapper->addMapping(ui->clearCheckBox, Room::kClearDisplayBufferFieldNumber);
+  resMapper->addMapping(ui->persistentCheckBox, Room::kPersistentFieldNumber);
+  resMapper->addMapping(ui->captionLineEdit, Room::kCaptionFieldNumber);
 
-  mapper->addMapping(ui->enableViewsCheckBox, Room::kEnableViewsFieldNumber);
-  mapper->addMapping(ui->clearViewportCheckBox, Room::kClearViewBackgroundFieldNumber);
-  mapper->toFirst();
+  resMapper->addMapping(ui->enableViewsCheckBox, Room::kEnableViewsFieldNumber);
+  resMapper->addMapping(ui->clearViewportCheckBox, Room::kClearViewBackgroundFieldNumber);
+  resMapper->toFirst();
 
   Room* room = static_cast<Room*>(model->GetBuffer());
 
@@ -34,7 +34,7 @@ RoomEditor::RoomEditor(ProtoModel* model, QWidget* parent) : BaseEditor(model, p
   if (room->show_color()) roomColor = room->color();
   scene->addRect(scene->sceneRect(), QPen(roomColor), QBrush(roomColor));
 
-  for (auto bkg : room->backgrounds()) {
+  for (auto bkg : room->backgrounds()) { //TODO: need to draw last if foreground
       if (bkg.visible()) {
         ProtoModel* bkgRes = MainWindow::resourceMap->GetResourceByName(buffers::TreeNode::kBackground,
                                                                         bkg.background_name());

--- a/Editors/RoomEditor.cpp
+++ b/Editors/RoomEditor.cpp
@@ -97,20 +97,20 @@ RoomEditor::RoomEditor(ProtoModel* model, QWidget* parent) : BaseEditor(model, p
   }
 
   RepeatedProtoModel* m = roomModel->GetRepeatedSubModel(Room::kInstancesFieldNumber);
-  ui->layersTableView->setModel(m);
+  ui->layersAssetsView->setModel(m);
   auto currentInstanceModel = roomModel->data(Room::kInstancesFieldNumber, 0).value<void*>();
   ui->layersPropertiesView->setModel(static_cast<ProtoModel*>(currentInstanceModel));
 
   for (int c = 0; c < m->columnCount(); ++c) {
     if (c != Room::Instance::kNameFieldNumber && c != Room::Instance::kObjectTypeFieldNumber &&
         c != Room::Instance::kIdFieldNumber)
-      ui->layersTableView->hideColumn(c);
+      ui->layersAssetsView->hideColumn(c);
     else
-      ui->layersTableView->resizeColumnToContents(c);
+      ui->layersAssetsView->resizeColumnToContents(c);
   }
 
-  ui->layersTableView->horizontalHeader()->swapSections(Room::Instance::kNameFieldNumber,
-                                                        Room::Instance::kObjectTypeFieldNumber);
+  ui->layersAssetsView->horizontalHeader()->swapSections(Room::Instance::kNameFieldNumber,
+                                                         Room::Instance::kObjectTypeFieldNumber);
 
   google::protobuf::RepeatedField<Room::Instance> sortedInstances(room->mutable_instances()->begin(),
                                                                   room->mutable_instances()->end());

--- a/Editors/RoomEditor.cpp
+++ b/Editors/RoomEditor.cpp
@@ -32,8 +32,10 @@ RoomEditor::RoomEditor(ProtoModel* model, QWidget* parent) : BaseEditor(model, p
 
   RepeatedProtoModel* m = roomModel->GetRepeatedSubModel(Room::kInstancesFieldNumber);
   ui->layersAssetsView->setModel(m);
-  auto currentInstanceModel = roomModel->data(Room::kInstancesFieldNumber, 0).value<void*>();
-  ui->layersPropertiesView->setModel(static_cast<ProtoModel*>(currentInstanceModel));
+  if (!m->empty()) {
+    auto currentInstanceModel = roomModel->data(Room::kInstancesFieldNumber, 0).value<void*>();
+    ui->layersPropertiesView->setModel(static_cast<ProtoModel*>(currentInstanceModel));
+  }
 
   for (int c = 0; c < m->columnCount(); ++c) {
     if (c != Room::Instance::kNameFieldNumber && c != Room::Instance::kObjectTypeFieldNumber &&

--- a/Editors/RoomEditor.cpp
+++ b/Editors/RoomEditor.cpp
@@ -101,8 +101,8 @@ RoomEditor::RoomEditor(ProtoModel* model, QWidget* parent) : BaseEditor(model, p
     }
   }
 
-  QList<QVariant> instances = resMapper->data(Room::kInstancesFieldNumber).toList();
-  ui->layersTableView->setModel(static_cast<ProtoModel*>(instances[0].value<void*>()));
+  QVariant instance = resMapper->data(Room::kInstancesFieldNumber, 0);
+  ui->layersTableView->setModel(static_cast<ProtoModel*>(instance.value<void*>()));
 
   google::protobuf::RepeatedField<Room::Instance>
           sortedInstances(room->mutable_instances()->begin(), room->mutable_instances()->end());

--- a/Editors/RoomEditor.cpp
+++ b/Editors/RoomEditor.cpp
@@ -64,8 +64,8 @@ bool RoomEditor::eventFilter(QObject* obj, QEvent* event) {
   return QWidget::eventFilter(obj, event);
 }
 
-void RoomEditor::on_actionZoomIn_triggered() { ui->roomRenderer->SetZoom(zoom * 2); }
+void RoomEditor::on_actionZoomIn_triggered() { ui->roomRenderer->SetZoom(ui->roomRenderer->GetZoom() * 2); }
 
-void RoomEditor::on_actionZoomOut_triggered() { ui->roomRenderer->SetZoom(zoom / 2); }
+void RoomEditor::on_actionZoomOut_triggered() { ui->roomRenderer->SetZoom(ui->roomRenderer->GetZoom() / 2); }
 
 void RoomEditor::on_actionZoom_triggered() { ui->roomRenderer->SetZoom(1.0); }

--- a/Editors/RoomEditor.h
+++ b/Editors/RoomEditor.h
@@ -5,6 +5,7 @@
 #include "Components/ArtManager.h"
 
 #include <QGraphicsScene>
+#include <QLabel>
 #include <QPainter>
 
 namespace Ui {
@@ -24,9 +25,11 @@ class RoomEditor : public BaseEditor {
   void on_actionZoomIn_triggered();
   void on_actionZoomOut_triggered();
   void on_actionZoom_triggered();
+  void updateCursorPositionLabel(const QPoint& pos);
 
  private:
   Ui::RoomEditor* ui;
+  QLabel *cursorPositionLabel, *assetNameLabel;
 
   bool eventFilter(QObject* obj, QEvent* event) override;
 };

--- a/Editors/RoomEditor.h
+++ b/Editors/RoomEditor.h
@@ -2,6 +2,10 @@
 #define ROOMEDITOR_H
 
 #include "BaseEditor.h"
+#include "Components/ArtManager.h"
+
+#include <QGraphicsScene>
+#include <QPainter>
 
 namespace Ui {
 class RoomEditor;
@@ -14,8 +18,18 @@ class RoomEditor : public BaseEditor {
   explicit RoomEditor(ProtoModel* model, QWidget* parent);
   ~RoomEditor();
 
+  void setZoom(qreal zoom);
+
+ private slots:
+  void on_actionZoomIn_triggered();
+  void on_actionZoomOut_triggered();
+  void on_actionZoom_triggered();
+
  private:
   Ui::RoomEditor* ui;
+  qreal zoom = 1.0;
+
+  bool eventFilter(QObject* obj, QEvent* event) override;
 };
 
 #endif  // ROOMEDITOR_H

--- a/Editors/RoomEditor.h
+++ b/Editors/RoomEditor.h
@@ -27,7 +27,6 @@ class RoomEditor : public BaseEditor {
 
  private:
   Ui::RoomEditor* ui;
-  qreal zoom = 1.0;
 
   bool eventFilter(QObject* obj, QEvent* event) override;
 };

--- a/Editors/RoomEditor.h
+++ b/Editors/RoomEditor.h
@@ -21,6 +21,9 @@ class RoomEditor : public BaseEditor {
 
   void setZoom(qreal zoom);
 
+ public slots:
+  void SelectedObjectChanged(QAction *action);
+
  private slots:
   void on_actionZoomIn_triggered();
   void on_actionZoomOut_triggered();

--- a/Editors/RoomEditor.ui
+++ b/Editors/RoomEditor.ui
@@ -111,7 +111,7 @@
             <enum>QAbstractItemView::ExtendedSelection</enum>
            </property>
           </widget>
-          <widget class="QWidget" name="">
+          <widget class="QWidget" name="layoutWidget">
            <layout class="QVBoxLayout" name="layersAssetsLayout">
             <property name="spacing">
              <number>4</number>
@@ -1277,54 +1277,46 @@
         </widget>
        </item>
        <item>
-        <widget class="QGraphicsView" name="graphicsView">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
+        <widget class="QScrollArea" name="roomPreview">
          <property name="autoFillBackground">
           <bool>false</bool>
          </property>
-         <property name="backgroundBrush">
-          <brush brushstyle="NoBrush">
-           <color alpha="255">
-            <red>136</red>
-            <green>136</green>
-            <blue>136</blue>
-           </color>
-          </brush>
+         <property name="widgetResizable">
+          <bool>true</bool>
          </property>
-         <property name="foregroundBrush">
-          <brush brushstyle="NoBrush">
-           <color alpha="255">
-            <red>0</red>
-            <green>0</green>
-            <blue>0</blue>
-           </color>
-          </brush>
-         </property>
-         <property name="sceneRect">
-          <rectf>
-           <x>0.000000000000000</x>
-           <y>0.000000000000000</y>
-           <width>800.000000000000000</width>
-           <height>600.000000000000000</height>
-          </rectf>
-         </property>
-         <property name="cacheMode">
-          <set>QGraphicsView::CacheNone</set>
-         </property>
-         <property name="transformationAnchor">
-          <enum>QGraphicsView::AnchorViewCenter</enum>
-         </property>
-         <property name="resizeAnchor">
-          <enum>QGraphicsView::NoAnchor</enum>
-         </property>
-         <property name="viewportUpdateMode">
-          <enum>QGraphicsView::FullViewportUpdate</enum>
-         </property>
+         <widget class="QWidget" name="scrollAreaWidgetContents">
+          <property name="geometry">
+           <rect>
+            <x>0</x>
+            <y>0</y>
+            <width>671</width>
+            <height>603</height>
+           </rect>
+          </property>
+          <property name="autoFillBackground">
+           <bool>true</bool>
+          </property>
+          <layout class="QVBoxLayout" name="verticalLayout_7">
+           <property name="spacing">
+            <number>0</number>
+           </property>
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
+           <item>
+            <widget class="RoomRenderer" name="roomRenderer" native="true"/>
+           </item>
+          </layout>
+         </widget>
         </widget>
        </item>
       </layout>
@@ -1459,6 +1451,14 @@
    </property>
   </action>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>RoomRenderer</class>
+   <extends>QWidget</extends>
+   <header>Widgets/RoomRenderer.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
  <resources>
   <include location="../images.qrc"/>
  </resources>

--- a/Editors/RoomEditor.ui
+++ b/Editors/RoomEditor.ui
@@ -10,6 +10,12 @@
     <height>651</height>
    </rect>
   </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
   <property name="windowTitle">
    <string>Room</string>
   </property>
@@ -17,7 +23,7 @@
    <iconset resource="../images.qrc">
     <normaloff>:/resources/room.png</normaloff>:/resources/room.png</iconset>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_7">
+  <layout class="QVBoxLayout" name="verticalLayout_6">
    <property name="spacing">
     <number>4</number>
    </property>
@@ -34,64 +40,71 @@
     <number>4</number>
    </property>
    <item>
-    <layout class="QHBoxLayout" name="contentLayout" stretch="0,1">
-     <property name="spacing">
-      <number>4</number>
+    <widget class="QSplitter" name="propertiesSceneSplitter">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
      </property>
-     <item>
-      <widget class="QTabWidget" name="propertiesTabWidget">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>320</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="tabShape">
-        <enum>QTabWidget::Rounded</enum>
-       </property>
-       <property name="currentIndex">
-        <number>0</number>
-       </property>
-       <property name="elideMode">
-        <enum>Qt::ElideNone</enum>
-       </property>
-       <property name="usesScrollButtons">
-        <bool>false</bool>
-       </property>
-       <property name="documentMode">
-        <bool>false</bool>
-       </property>
-       <property name="tabBarAutoHide">
-        <bool>false</bool>
-       </property>
-       <widget class="QWidget" name="layersTab">
-        <attribute name="title">
-         <string>Layers</string>
-        </attribute>
-        <layout class="QVBoxLayout" name="verticalLayout_6" stretch="1,1">
-         <property name="spacing">
-          <number>4</number>
-         </property>
-         <property name="leftMargin">
-          <number>4</number>
-         </property>
-         <property name="topMargin">
-          <number>4</number>
-         </property>
-         <property name="rightMargin">
-          <number>4</number>
-         </property>
-         <property name="bottomMargin">
-          <number>4</number>
-         </property>
-         <item>
-          <widget class="QTableView" name="layersTableView">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <widget class="QTabWidget" name="propertiesTabWidget">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="minimumSize">
+       <size>
+        <width>320</width>
+        <height>0</height>
+       </size>
+      </property>
+      <property name="tabShape">
+       <enum>QTabWidget::Rounded</enum>
+      </property>
+      <property name="currentIndex">
+       <number>0</number>
+      </property>
+      <property name="elideMode">
+       <enum>Qt::ElideNone</enum>
+      </property>
+      <property name="usesScrollButtons">
+       <bool>false</bool>
+      </property>
+      <property name="documentMode">
+       <bool>false</bool>
+      </property>
+      <property name="tabBarAutoHide">
+       <bool>false</bool>
+      </property>
+      <widget class="QWidget" name="layersTab">
+       <attribute name="title">
+        <string>Layers</string>
+       </attribute>
+       <layout class="QVBoxLayout" name="verticalLayout_2">
+        <property name="leftMargin">
+         <number>4</number>
+        </property>
+        <property name="topMargin">
+         <number>4</number>
+        </property>
+        <property name="rightMargin">
+         <number>4</number>
+        </property>
+        <property name="bottomMargin">
+         <number>4</number>
+        </property>
+        <item>
+         <widget class="QSplitter" name="splitter">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
+          <widget class="QListView" name="layersListView"/>
+          <widget class="QTableView" name="layersAssetsView">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
              <horstretch>0</horstretch>
@@ -108,8 +121,6 @@
             <bool>false</bool>
            </attribute>
           </widget>
-         </item>
-         <item>
           <widget class="QTableView" name="layersPropertiesView">
            <property name="editTriggers">
             <set>QAbstractItemView::AllEditTriggers</set>
@@ -124,123 +135,675 @@
             <bool>false</bool>
            </attribute>
           </widget>
-         </item>
-        </layout>
-       </widget>
-       <widget class="QWidget" name="settingsTab">
-        <attribute name="title">
-         <string>Settings</string>
-        </attribute>
-        <layout class="QVBoxLayout" name="verticalLayout_4" stretch="0,0,0,0,1">
-         <property name="spacing">
-          <number>4</number>
-         </property>
-         <property name="leftMargin">
-          <number>4</number>
-         </property>
-         <property name="topMargin">
-          <number>4</number>
-         </property>
-         <property name="rightMargin">
-          <number>4</number>
-         </property>
-         <property name="bottomMargin">
-          <number>4</number>
-         </property>
-         <item>
-          <layout class="QGridLayout" name="settingsGridLayout" columnstretch="0,1,0">
+         </widget>
+        </item>
+       </layout>
+      </widget>
+      <widget class="QWidget" name="settingsTab">
+       <attribute name="title">
+        <string>Settings</string>
+       </attribute>
+       <layout class="QVBoxLayout" name="verticalLayout_4" stretch="0,0,0,0,1">
+        <property name="spacing">
+         <number>4</number>
+        </property>
+        <property name="leftMargin">
+         <number>4</number>
+        </property>
+        <property name="topMargin">
+         <number>4</number>
+        </property>
+        <property name="rightMargin">
+         <number>4</number>
+        </property>
+        <property name="bottomMargin">
+         <number>4</number>
+        </property>
+        <item>
+         <layout class="QGridLayout" name="settingsGridLayout" columnstretch="0,1,0">
+          <property name="spacing">
+           <number>4</number>
+          </property>
+          <item row="2" column="0">
+           <widget class="QLabel" name="widthLabel">
+            <property name="toolTip">
+             <string>Width</string>
+            </property>
+            <property name="text">
+             <string>Width</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="2">
+           <widget class="QToolButton" name="creationToolButton">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="toolTip">
+             <string>Room Creation Code</string>
+            </property>
+            <property name="text">
+             <string>Creation</string>
+            </property>
+            <property name="icon">
+             <iconset resource="../images.qrc">
+              <normaloff>:/resources/script.png</normaloff>:/resources/script.png</iconset>
+            </property>
+            <property name="toolButtonStyle">
+             <enum>Qt::ToolButtonTextBesideIcon</enum>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QSpinBox" name="speedSpinBox">
+            <property name="toolTip">
+             <string>Frames per second</string>
+            </property>
+            <property name="value">
+             <number>30</number>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="heightLabel">
+            <property name="toolTip">
+             <string>Height</string>
+            </property>
+            <property name="text">
+             <string>Height</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="QSpinBox" name="heightSpinBox">
+            <property name="toolTip">
+             <string>Height</string>
+            </property>
+            <property name="maximum">
+             <number>99999</number>
+            </property>
+            <property name="value">
+             <number>480</number>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="2">
+           <widget class="QCheckBox" name="persistentCheckBox">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>Persistent</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="speedLabel">
+            <property name="text">
+             <string>Speed</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QSpinBox" name="widthSpinBox">
+            <property name="toolTip">
+             <string>Width</string>
+            </property>
+            <property name="maximum">
+             <number>99999</number>
+            </property>
+            <property name="value">
+             <number>640</number>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="2">
+           <widget class="QCheckBox" name="clearCheckBox">
+            <property name="toolTip">
+             <string>Clear Display Buffer</string>
+            </property>
+            <property name="text">
+             <string>Clear</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="0">
+           <widget class="QLabel" name="nameLabel">
+            <property name="text">
+             <string>Name</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1" colspan="2">
+           <widget class="QLineEdit" name="roomName"/>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <widget class="QGroupBox" name="captionGroupBox">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="title">
+           <string>Caption</string>
+          </property>
+          <property name="flat">
+           <bool>true</bool>
+          </property>
+          <layout class="QVBoxLayout" name="verticalLayout_5">
+           <property name="spacing">
+            <number>0</number>
+           </property>
+           <property name="leftMargin">
+            <number>4</number>
+           </property>
+           <property name="topMargin">
+            <number>4</number>
+           </property>
+           <property name="rightMargin">
+            <number>4</number>
+           </property>
+           <property name="bottomMargin">
+            <number>4</number>
+           </property>
+           <item>
+            <widget class="QLineEdit" name="captionLineEdit"/>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <item>
+         <widget class="QGroupBox" name="gridGroupBox">
+          <property name="title">
+           <string>Show Grid</string>
+          </property>
+          <property name="flat">
+           <bool>true</bool>
+          </property>
+          <property name="checkable">
+           <bool>true</bool>
+          </property>
+          <layout class="QVBoxLayout" name="verticalLayout_8">
            <property name="spacing">
             <number>4</number>
            </property>
-           <item row="2" column="0">
-            <widget class="QLabel" name="widthLabel">
-             <property name="toolTip">
-              <string>Width</string>
+           <property name="leftMargin">
+            <number>4</number>
+           </property>
+           <property name="topMargin">
+            <number>4</number>
+           </property>
+           <property name="rightMargin">
+            <number>4</number>
+           </property>
+           <property name="bottomMargin">
+            <number>4</number>
+           </property>
+           <item>
+            <layout class="QHBoxLayout" name="gridColorLayout">
+             <property name="spacing">
+              <number>4</number>
              </property>
+             <item>
+              <widget class="QLabel" name="colorLabel">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="text">
+                <string>Color</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QToolButton" name="gridColorButton">
+               <property name="toolTip">
+                <string>Choose Grid Color</string>
+               </property>
+               <property name="text">
+                <string>Choose Color</string>
+               </property>
+               <property name="icon">
+                <iconset resource="../images.qrc">
+                 <normaloff>:/actions/colorize.png</normaloff>:/actions/colorize.png</iconset>
+               </property>
+               <property name="popupMode">
+                <enum>QToolButton::MenuButtonPopup</enum>
+               </property>
+               <property name="toolButtonStyle">
+                <enum>Qt::ToolButtonIconOnly</enum>
+               </property>
+               <property name="arrowType">
+                <enum>Qt::NoArrow</enum>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QCheckBox" name="xorCheckBox">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="text">
+                <string>Xor</string>
+               </property>
+               <property name="checked">
+                <bool>true</bool>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QCheckBox" name="isometricCheckBox">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="text">
+                <string>Isometric</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+           <item>
+            <layout class="QGridLayout" name="gridDimensionsLayout" columnstretch="0,1,0,1">
+             <property name="spacing">
+              <number>4</number>
+             </property>
+             <item row="2" column="0">
+              <widget class="QLabel" name="gridYLabel">
+               <property name="toolTip">
+                <string>Y Offset</string>
+               </property>
+               <property name="text">
+                <string>Y</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+               </property>
+              </widget>
+             </item>
+             <item row="2" column="1">
+              <widget class="QSpinBox" name="gridYSpinBox">
+               <property name="toolTip">
+                <string>Y Offset</string>
+               </property>
+              </widget>
+             </item>
+             <item row="2" column="2">
+              <widget class="QLabel" name="gridHLabel">
+               <property name="toolTip">
+                <string>Cell Height</string>
+               </property>
+               <property name="text">
+                <string>H</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+               </property>
+              </widget>
+             </item>
+             <item row="2" column="3">
+              <widget class="QSpinBox" name="gridHSpinBox">
+               <property name="toolTip">
+                <string>Cell Height</string>
+               </property>
+               <property name="value">
+                <number>16</number>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="0">
+              <widget class="QLabel" name="gridXLabel">
+               <property name="toolTip">
+                <string>X Offset</string>
+               </property>
+               <property name="text">
+                <string>X</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="2">
+              <widget class="QLabel" name="gridWLabel">
+               <property name="toolTip">
+                <string>Cell Width</string>
+               </property>
+               <property name="text">
+                <string>W</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="1">
+              <widget class="QSpinBox" name="gridXSpinBox">
+               <property name="toolTip">
+                <string>X Offset</string>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="3">
+              <widget class="QSpinBox" name="gridWSpinBox">
+               <property name="toolTip">
+                <string>Cell Width</string>
+               </property>
+               <property name="value">
+                <number>16</number>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <item>
+         <widget class="QGroupBox" name="physicsGroupBox">
+          <property name="title">
+           <string>Physics World</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+          </property>
+          <property name="flat">
+           <bool>true</bool>
+          </property>
+          <property name="checkable">
+           <bool>true</bool>
+          </property>
+          <property name="checked">
+           <bool>false</bool>
+          </property>
+          <layout class="QFormLayout" name="formLayout_2">
+           <property name="labelAlignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+           <property name="horizontalSpacing">
+            <number>4</number>
+           </property>
+           <property name="verticalSpacing">
+            <number>4</number>
+           </property>
+           <property name="leftMargin">
+            <number>4</number>
+           </property>
+           <property name="topMargin">
+            <number>4</number>
+           </property>
+           <property name="rightMargin">
+            <number>4</number>
+           </property>
+           <property name="bottomMargin">
+            <number>4</number>
+           </property>
+           <item row="0" column="0">
+            <widget class="QLabel" name="pixelsPerMeterLabel">
              <property name="text">
-              <string>Width</string>
-             </property>
-             <property name="alignment">
-              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+              <string>Pixels per meter</string>
              </property>
             </widget>
            </item>
-           <item row="3" column="2">
-            <widget class="QToolButton" name="creationToolButton">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="toolTip">
-              <string>Room Creation Code</string>
-             </property>
+           <item row="0" column="1">
+            <widget class="QSpinBox" name="pixelsPerMeterSpinBox"/>
+           </item>
+           <item row="1" column="0">
+            <widget class="QLabel" name="gravityXLabel">
              <property name="text">
-              <string>Creation</string>
-             </property>
-             <property name="icon">
-              <iconset resource="../images.qrc">
-               <normaloff>:/resources/script.png</normaloff>:/resources/script.png</iconset>
-             </property>
-             <property name="toolButtonStyle">
-              <enum>Qt::ToolButtonTextBesideIcon</enum>
+              <string>Gravity X</string>
              </property>
             </widget>
            </item>
            <item row="1" column="1">
-            <widget class="QSpinBox" name="speedSpinBox">
-             <property name="toolTip">
-              <string>Frames per second</string>
-             </property>
-             <property name="value">
-              <number>30</number>
+            <widget class="QSpinBox" name="gravityXSpinBox"/>
+           </item>
+           <item row="2" column="0">
+            <widget class="QLabel" name="gravityYLabel">
+             <property name="text">
+              <string>Gravity Y</string>
              </property>
             </widget>
            </item>
-           <item row="3" column="0">
-            <widget class="QLabel" name="heightLabel">
-             <property name="toolTip">
-              <string>Height</string>
-             </property>
+           <item row="2" column="1">
+            <widget class="QSpinBox" name="gravityYSpinBox"/>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <item>
+         <spacer name="settingsVerticalSpacer">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>40</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </widget>
+      <widget class="QWidget" name="viewsTab">
+       <attribute name="title">
+        <string>Views</string>
+       </attribute>
+       <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0,0,0,0,0,0,1">
+        <property name="spacing">
+         <number>4</number>
+        </property>
+        <property name="leftMargin">
+         <number>4</number>
+        </property>
+        <property name="topMargin">
+         <number>4</number>
+        </property>
+        <property name="rightMargin">
+         <number>4</number>
+        </property>
+        <property name="bottomMargin">
+         <number>4</number>
+        </property>
+        <item>
+         <widget class="QCheckBox" name="enableViewsCheckBox">
+          <property name="text">
+           <string>Enable the use of views</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="clearViewportCheckBox">
+          <property name="text">
+           <string>Clear viewport background</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <layout class="QHBoxLayout" name="currentViewLayout">
+          <property name="spacing">
+           <number>4</number>
+          </property>
+          <item>
+           <widget class="QLabel" name="currentViewLabel">
+            <property name="text">
+             <string>Current</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QComboBox" name="currentViewComboBox">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>1</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="currentText">
+             <string>View 0</string>
+            </property>
+            <item>
              <property name="text">
-              <string>Height</string>
+              <string>View 0</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>View 1</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>View 2</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>View 3</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>View 4</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>View 5</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>View 6</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>View 7</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>View 8</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="viewVisibleCheckBox">
+          <property name="text">
+           <string>Visible when room starts</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QGroupBox" name="cameraGroupBox">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="title">
+           <string>Camera</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+          </property>
+          <property name="flat">
+           <bool>true</bool>
+          </property>
+          <property name="checkable">
+           <bool>false</bool>
+          </property>
+          <layout class="QGridLayout" name="gridLayout" columnstretch="0,1,0,1">
+           <property name="leftMargin">
+            <number>4</number>
+           </property>
+           <property name="topMargin">
+            <number>4</number>
+           </property>
+           <property name="rightMargin">
+            <number>4</number>
+           </property>
+           <property name="bottomMargin">
+            <number>4</number>
+           </property>
+           <property name="spacing">
+            <number>4</number>
+           </property>
+           <item row="1" column="0">
+            <widget class="QLabel" name="cameraXLabel">
+             <property name="text">
+              <string>X</string>
              </property>
              <property name="alignment">
               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
              </property>
             </widget>
            </item>
-           <item row="3" column="1">
-            <widget class="QSpinBox" name="heightSpinBox">
-             <property name="toolTip">
-              <string>Height</string>
+           <item row="2" column="0">
+            <widget class="QLabel" name="cameraYLabel">
+             <property name="text">
+              <string>Y</string>
              </property>
-             <property name="maximum">
-              <number>99999</number>
+             <property name="alignment">
+              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
              </property>
-             <property name="value">
-              <number>480</number>
+            </widget>
+           </item>
+           <item row="1" column="2">
+            <widget class="QLabel" name="cameraWidthLabel">
+             <property name="text">
+              <string>Width</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
              </property>
             </widget>
            </item>
            <item row="2" column="2">
-            <widget class="QCheckBox" name="persistentCheckBox">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
+            <widget class="QLabel" name="cameraHeightLabel">
              <property name="text">
-              <string>Persistent</string>
-             </property>
-            </widget>
-           </item>
-           <item row="1" column="0">
-            <widget class="QLabel" name="speedLabel">
-             <property name="text">
-              <string>Speed</string>
+              <string>Height</string>
              </property>
              <property name="alignment">
               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -248,860 +811,326 @@
             </widget>
            </item>
            <item row="2" column="1">
-            <widget class="QSpinBox" name="widthSpinBox">
-             <property name="toolTip">
-              <string>Width</string>
-             </property>
+            <widget class="QSpinBox" name="cameraYSpinBox"/>
+           </item>
+           <item row="1" column="1">
+            <widget class="QSpinBox" name="cameraXSpinBox"/>
+           </item>
+           <item row="1" column="3">
+            <widget class="QSpinBox" name="cameraWidthSpinBox">
              <property name="maximum">
-              <number>99999</number>
+              <number>10000</number>
              </property>
              <property name="value">
               <number>640</number>
              </property>
             </widget>
            </item>
-           <item row="1" column="2">
-            <widget class="QCheckBox" name="clearCheckBox">
-             <property name="toolTip">
-              <string>Clear Display Buffer</string>
+           <item row="2" column="3">
+            <widget class="QSpinBox" name="cameraHeightSpinBox">
+             <property name="maximum">
+              <number>10000</number>
              </property>
-             <property name="text">
-              <string>Clear</string>
-             </property>
-             <property name="checked">
-              <bool>true</bool>
+             <property name="value">
+              <number>480</number>
              </property>
             </widget>
            </item>
+          </layout>
+         </widget>
+        </item>
+        <item>
+         <widget class="QGroupBox" name="viewportGroupBox">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="title">
+           <string>Viewport</string>
+          </property>
+          <property name="flat">
+           <bool>true</bool>
+          </property>
+          <layout class="QGridLayout" name="gridLayout_2" columnstretch="0,1,0,1">
+           <property name="leftMargin">
+            <number>4</number>
+           </property>
+           <property name="topMargin">
+            <number>4</number>
+           </property>
+           <property name="rightMargin">
+            <number>4</number>
+           </property>
+           <property name="bottomMargin">
+            <number>4</number>
+           </property>
+           <property name="spacing">
+            <number>4</number>
+           </property>
            <item row="0" column="0">
-            <widget class="QLabel" name="nameLabel">
+            <widget class="QLabel" name="viewportXLabel">
              <property name="text">
-              <string>Name</string>
+              <string>X</string>
              </property>
              <property name="alignment">
               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
              </property>
             </widget>
            </item>
-           <item row="0" column="1" colspan="2">
-            <widget class="QLineEdit" name="roomName"/>
+           <item row="0" column="1">
+            <widget class="QSpinBox" name="viewportXSpinBox"/>
+           </item>
+           <item row="0" column="2">
+            <widget class="QLabel" name="viewportWidthLabel">
+             <property name="text">
+              <string>Width</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="3">
+            <widget class="QSpinBox" name="viewportWidthSpinBox">
+             <property name="maximum">
+              <number>100000</number>
+             </property>
+             <property name="value">
+              <number>640</number>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="0">
+            <widget class="QLabel" name="viewportYLabel">
+             <property name="text">
+              <string>Y</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="1">
+            <widget class="QSpinBox" name="viewportYSpinBox"/>
+           </item>
+           <item row="1" column="2">
+            <widget class="QLabel" name="viewportHeightLabel">
+             <property name="text">
+              <string>Height</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="3">
+            <widget class="QSpinBox" name="viewportHeightSpinBox">
+             <property name="maximum">
+              <number>1000000</number>
+             </property>
+             <property name="value">
+              <number>480</number>
+             </property>
+            </widget>
            </item>
           </layout>
-         </item>
-         <item>
-          <widget class="QGroupBox" name="captionGroupBox">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="title">
-            <string>Caption</string>
-           </property>
-           <property name="flat">
-            <bool>true</bool>
-           </property>
-           <layout class="QVBoxLayout" name="verticalLayout_5">
-            <property name="spacing">
-             <number>0</number>
-            </property>
-            <property name="leftMargin">
-             <number>4</number>
-            </property>
-            <property name="topMargin">
-             <number>4</number>
-            </property>
-            <property name="rightMargin">
-             <number>4</number>
-            </property>
-            <property name="bottomMargin">
-             <number>4</number>
-            </property>
-            <item>
-             <widget class="QLineEdit" name="captionLineEdit"/>
-            </item>
-           </layout>
-          </widget>
-         </item>
-         <item>
-          <widget class="QGroupBox" name="gridGroupBox">
-           <property name="title">
-            <string>Show Grid</string>
-           </property>
-           <property name="flat">
-            <bool>true</bool>
-           </property>
-           <property name="checkable">
-            <bool>true</bool>
-           </property>
-           <layout class="QVBoxLayout" name="verticalLayout_8">
-            <property name="spacing">
-             <number>4</number>
-            </property>
-            <property name="leftMargin">
-             <number>4</number>
-            </property>
-            <property name="topMargin">
-             <number>4</number>
-            </property>
-            <property name="rightMargin">
-             <number>4</number>
-            </property>
-            <property name="bottomMargin">
-             <number>4</number>
-            </property>
-            <item>
-             <layout class="QHBoxLayout" name="gridColorLayout">
-              <property name="spacing">
-               <number>4</number>
-              </property>
-              <item>
-               <widget class="QLabel" name="colorLabel">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="text">
-                 <string>Color</string>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QToolButton" name="gridColorButton">
-                <property name="toolTip">
-                 <string>Choose Grid Color</string>
-                </property>
-                <property name="text">
-                 <string>Choose Color</string>
-                </property>
-                <property name="icon">
-                 <iconset resource="../images.qrc">
-                  <normaloff>:/actions/colorize.png</normaloff>:/actions/colorize.png</iconset>
-                </property>
-                <property name="popupMode">
-                 <enum>QToolButton::MenuButtonPopup</enum>
-                </property>
-                <property name="toolButtonStyle">
-                 <enum>Qt::ToolButtonIconOnly</enum>
-                </property>
-                <property name="arrowType">
-                 <enum>Qt::NoArrow</enum>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QCheckBox" name="xorCheckBox">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="text">
-                 <string>Xor</string>
-                </property>
-                <property name="checked">
-                 <bool>true</bool>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QCheckBox" name="isometricCheckBox">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="text">
-                 <string>Isometric</string>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </item>
-            <item>
-             <layout class="QGridLayout" name="gridDimensionsLayout" columnstretch="0,1,0,1">
-              <property name="spacing">
-               <number>4</number>
-              </property>
-              <item row="2" column="0">
-               <widget class="QLabel" name="gridYLabel">
-                <property name="toolTip">
-                 <string>Y Offset</string>
-                </property>
-                <property name="text">
-                 <string>Y</string>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="1">
-               <widget class="QSpinBox" name="gridYSpinBox">
-                <property name="toolTip">
-                 <string>Y Offset</string>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="2">
-               <widget class="QLabel" name="gridHLabel">
-                <property name="toolTip">
-                 <string>Cell Height</string>
-                </property>
-                <property name="text">
-                 <string>H</string>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="3">
-               <widget class="QSpinBox" name="gridHSpinBox">
-                <property name="toolTip">
-                 <string>Cell Height</string>
-                </property>
-                <property name="value">
-                 <number>16</number>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="0">
-               <widget class="QLabel" name="gridXLabel">
-                <property name="toolTip">
-                 <string>X Offset</string>
-                </property>
-                <property name="text">
-                 <string>X</string>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="2">
-               <widget class="QLabel" name="gridWLabel">
-                <property name="toolTip">
-                 <string>Cell Width</string>
-                </property>
-                <property name="text">
-                 <string>W</string>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="1">
-               <widget class="QSpinBox" name="gridXSpinBox">
-                <property name="toolTip">
-                 <string>X Offset</string>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="3">
-               <widget class="QSpinBox" name="gridWSpinBox">
-                <property name="toolTip">
-                 <string>Cell Width</string>
-                </property>
-                <property name="value">
-                 <number>16</number>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </item>
-           </layout>
-          </widget>
-         </item>
-         <item>
-          <widget class="QGroupBox" name="physicsGroupBox">
-           <property name="title">
-            <string>Physics World</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-           </property>
-           <property name="flat">
-            <bool>true</bool>
-           </property>
-           <property name="checkable">
-            <bool>true</bool>
-           </property>
-           <property name="checked">
-            <bool>false</bool>
-           </property>
-           <layout class="QFormLayout" name="formLayout_2">
-            <property name="labelAlignment">
-             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-            </property>
-            <property name="horizontalSpacing">
-             <number>4</number>
-            </property>
-            <property name="verticalSpacing">
-             <number>4</number>
-            </property>
-            <property name="leftMargin">
-             <number>4</number>
-            </property>
-            <property name="topMargin">
-             <number>4</number>
-            </property>
-            <property name="rightMargin">
-             <number>4</number>
-            </property>
-            <property name="bottomMargin">
-             <number>4</number>
-            </property>
-            <item row="0" column="0">
-             <widget class="QLabel" name="pixelsPerMeterLabel">
-              <property name="text">
-               <string>Pixels per meter</string>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="1">
-             <widget class="QSpinBox" name="pixelsPerMeterSpinBox"/>
-            </item>
-            <item row="1" column="0">
-             <widget class="QLabel" name="gravityXLabel">
-              <property name="text">
-               <string>Gravity X</string>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="1">
-             <widget class="QSpinBox" name="gravityXSpinBox"/>
-            </item>
-            <item row="2" column="0">
-             <widget class="QLabel" name="gravityYLabel">
-              <property name="text">
-               <string>Gravity Y</string>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="1">
-             <widget class="QSpinBox" name="gravityYSpinBox"/>
-            </item>
-           </layout>
-          </widget>
-         </item>
-         <item>
-          <spacer name="settingsVerticalSpacer">
-           <property name="orientation">
-            <enum>Qt::Vertical</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>20</width>
-             <height>40</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-        </layout>
-       </widget>
-       <widget class="QWidget" name="viewsTab">
-        <attribute name="title">
-         <string>Views</string>
-        </attribute>
-        <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0,0,0,0,0,0,1">
-         <property name="spacing">
-          <number>4</number>
-         </property>
-         <property name="leftMargin">
-          <number>4</number>
-         </property>
-         <property name="topMargin">
-          <number>4</number>
-         </property>
-         <property name="rightMargin">
-          <number>4</number>
-         </property>
-         <property name="bottomMargin">
-          <number>4</number>
-         </property>
-         <item>
-          <widget class="QCheckBox" name="enableViewsCheckBox">
-           <property name="text">
-            <string>Enable the use of views</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QCheckBox" name="clearViewportCheckBox">
-           <property name="text">
-            <string>Clear viewport background</string>
-           </property>
-           <property name="checked">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <layout class="QHBoxLayout" name="currentViewLayout">
+         </widget>
+        </item>
+        <item>
+         <widget class="QGroupBox" name="followingGroupBox">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="title">
+           <string>Object Following</string>
+          </property>
+          <property name="flat">
+           <bool>true</bool>
+          </property>
+          <layout class="QVBoxLayout" name="verticalLayout_3">
            <property name="spacing">
             <number>4</number>
            </property>
+           <property name="leftMargin">
+            <number>4</number>
+           </property>
+           <property name="topMargin">
+            <number>4</number>
+           </property>
+           <property name="rightMargin">
+            <number>4</number>
+           </property>
+           <property name="bottomMargin">
+            <number>4</number>
+           </property>
            <item>
-            <widget class="QLabel" name="currentViewLabel">
-             <property name="text">
-              <string>Current</string>
+            <layout class="QHBoxLayout" name="followingHorizontalLayout">
+             <property name="spacing">
+              <number>4</number>
              </property>
-            </widget>
+             <item>
+              <widget class="QToolButton" name="followingToolButton">
+               <property name="text">
+                <string>Object</string>
+               </property>
+               <property name="icon">
+                <iconset resource="../images.qrc">
+                 <normaloff>:/actions/add.png</normaloff>:/actions/add.png</iconset>
+               </property>
+               <property name="toolButtonStyle">
+                <enum>Qt::ToolButtonTextBesideIcon</enum>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QComboBox" name="followingComboBox">
+               <item>
+                <property name="text">
+                 <string>&lt;no object&gt;</string>
+                </property>
+               </item>
+              </widget>
+             </item>
+            </layout>
            </item>
            <item>
-            <widget class="QComboBox" name="currentViewComboBox">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-               <horstretch>1</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
+            <layout class="QGridLayout" name="followingGridLayout" columnstretch="0,1,1">
+             <property name="spacing">
+              <number>4</number>
              </property>
-             <property name="currentText">
-              <string>View 0</string>
-             </property>
-             <item>
-              <property name="text">
-               <string>View 0</string>
-              </property>
+             <item row="2" column="0">
+              <widget class="QLabel" name="followingVLabel">
+               <property name="toolTip">
+                <string>Vertical</string>
+               </property>
+               <property name="text">
+                <string>V</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+               </property>
+              </widget>
              </item>
-             <item>
-              <property name="text">
-               <string>View 1</string>
-              </property>
+             <item row="2" column="1">
+              <widget class="QSpinBox" name="followingVBorderSpinBox">
+               <property name="value">
+                <number>32</number>
+               </property>
+              </widget>
              </item>
-             <item>
-              <property name="text">
-               <string>View 2</string>
-              </property>
+             <item row="1" column="0">
+              <widget class="QLabel" name="followingHLabel">
+               <property name="toolTip">
+                <string>Horizontal</string>
+               </property>
+               <property name="text">
+                <string>H</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+               </property>
+              </widget>
              </item>
-             <item>
-              <property name="text">
-               <string>View 3</string>
-              </property>
+             <item row="1" column="1">
+              <widget class="QSpinBox" name="followingHBorderSpinBox">
+               <property name="value">
+                <number>32</number>
+               </property>
+              </widget>
              </item>
-             <item>
-              <property name="text">
-               <string>View 4</string>
-              </property>
+             <item row="0" column="1">
+              <widget class="QLabel" name="followingBorderLabel">
+               <property name="toolTip">
+                <string>Border around the object</string>
+               </property>
+               <property name="text">
+                <string>Border</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignCenter</set>
+               </property>
+              </widget>
              </item>
-             <item>
-              <property name="text">
-               <string>View 5</string>
-              </property>
+             <item row="0" column="2">
+              <widget class="QLabel" name="followingSpeedLabel">
+               <property name="toolTip">
+                <string>Maximum speed</string>
+               </property>
+               <property name="text">
+                <string>Speed</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignCenter</set>
+               </property>
+              </widget>
              </item>
-             <item>
-              <property name="text">
-               <string>View 6</string>
-              </property>
+             <item row="1" column="2">
+              <widget class="QSpinBox" name="followingHSpeedSpinBox">
+               <property name="minimum">
+                <number>-99</number>
+               </property>
+               <property name="value">
+                <number>-1</number>
+               </property>
+              </widget>
              </item>
-             <item>
-              <property name="text">
-               <string>View 7</string>
-              </property>
+             <item row="2" column="2">
+              <widget class="QSpinBox" name="followingVSpeedSpinBox">
+               <property name="minimum">
+                <number>-99</number>
+               </property>
+               <property name="value">
+                <number>-1</number>
+               </property>
+              </widget>
              </item>
-             <item>
-              <property name="text">
-               <string>View 8</string>
-              </property>
-             </item>
-            </widget>
+            </layout>
            </item>
           </layout>
-         </item>
-         <item>
-          <widget class="QCheckBox" name="viewVisibleCheckBox">
-           <property name="text">
-            <string>Visible when room starts</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QGroupBox" name="cameraGroupBox">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="title">
-            <string>Camera</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-           </property>
-           <property name="flat">
-            <bool>true</bool>
-           </property>
-           <property name="checkable">
-            <bool>false</bool>
-           </property>
-           <layout class="QGridLayout" name="gridLayout" columnstretch="0,1,0,1">
-            <property name="leftMargin">
-             <number>4</number>
-            </property>
-            <property name="topMargin">
-             <number>4</number>
-            </property>
-            <property name="rightMargin">
-             <number>4</number>
-            </property>
-            <property name="bottomMargin">
-             <number>4</number>
-            </property>
-            <property name="spacing">
-             <number>4</number>
-            </property>
-            <item row="1" column="0">
-             <widget class="QLabel" name="cameraXLabel">
-              <property name="text">
-               <string>X</string>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="0">
-             <widget class="QLabel" name="cameraYLabel">
-              <property name="text">
-               <string>Y</string>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="2">
-             <widget class="QLabel" name="cameraWidthLabel">
-              <property name="text">
-               <string>Width</string>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="2">
-             <widget class="QLabel" name="cameraHeightLabel">
-              <property name="text">
-               <string>Height</string>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="1">
-             <widget class="QSpinBox" name="cameraYSpinBox"/>
-            </item>
-            <item row="1" column="1">
-             <widget class="QSpinBox" name="cameraXSpinBox"/>
-            </item>
-            <item row="1" column="3">
-             <widget class="QSpinBox" name="cameraWidthSpinBox">
-              <property name="maximum">
-               <number>10000</number>
-              </property>
-              <property name="value">
-               <number>640</number>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="3">
-             <widget class="QSpinBox" name="cameraHeightSpinBox">
-              <property name="maximum">
-               <number>10000</number>
-              </property>
-              <property name="value">
-               <number>480</number>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </widget>
-         </item>
-         <item>
-          <widget class="QGroupBox" name="viewportGroupBox">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="title">
-            <string>Viewport</string>
-           </property>
-           <property name="flat">
-            <bool>true</bool>
-           </property>
-           <layout class="QGridLayout" name="gridLayout_2" columnstretch="0,1,0,1">
-            <property name="leftMargin">
-             <number>4</number>
-            </property>
-            <property name="topMargin">
-             <number>4</number>
-            </property>
-            <property name="rightMargin">
-             <number>4</number>
-            </property>
-            <property name="bottomMargin">
-             <number>4</number>
-            </property>
-            <property name="spacing">
-             <number>4</number>
-            </property>
-            <item row="0" column="0">
-             <widget class="QLabel" name="viewportXLabel">
-              <property name="text">
-               <string>X</string>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="1">
-             <widget class="QSpinBox" name="viewportXSpinBox"/>
-            </item>
-            <item row="0" column="2">
-             <widget class="QLabel" name="viewportWidthLabel">
-              <property name="text">
-               <string>Width</string>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="3">
-             <widget class="QSpinBox" name="viewportWidthSpinBox">
-              <property name="maximum">
-               <number>100000</number>
-              </property>
-              <property name="value">
-               <number>640</number>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="0">
-             <widget class="QLabel" name="viewportYLabel">
-              <property name="text">
-               <string>Y</string>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="1">
-             <widget class="QSpinBox" name="viewportYSpinBox"/>
-            </item>
-            <item row="1" column="2">
-             <widget class="QLabel" name="viewportHeightLabel">
-              <property name="text">
-               <string>Height</string>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="3">
-             <widget class="QSpinBox" name="viewportHeightSpinBox">
-              <property name="maximum">
-               <number>1000000</number>
-              </property>
-              <property name="value">
-               <number>480</number>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </widget>
-         </item>
-         <item>
-          <widget class="QGroupBox" name="followingGroupBox">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="title">
-            <string>Object Following</string>
-           </property>
-           <property name="flat">
-            <bool>true</bool>
-           </property>
-           <layout class="QVBoxLayout" name="verticalLayout_3">
-            <property name="spacing">
-             <number>4</number>
-            </property>
-            <property name="leftMargin">
-             <number>4</number>
-            </property>
-            <property name="topMargin">
-             <number>4</number>
-            </property>
-            <property name="rightMargin">
-             <number>4</number>
-            </property>
-            <property name="bottomMargin">
-             <number>4</number>
-            </property>
-            <item>
-             <layout class="QHBoxLayout" name="followingHorizontalLayout">
-              <property name="spacing">
-               <number>4</number>
-              </property>
-              <item>
-               <widget class="QToolButton" name="followingToolButton">
-                <property name="text">
-                 <string>Object</string>
-                </property>
-                <property name="icon">
-                 <iconset resource="../images.qrc">
-                  <normaloff>:/actions/add.png</normaloff>:/actions/add.png</iconset>
-                </property>
-                <property name="toolButtonStyle">
-                 <enum>Qt::ToolButtonTextBesideIcon</enum>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QComboBox" name="followingComboBox">
-                <item>
-                 <property name="text">
-                  <string>&lt;no object&gt;</string>
-                 </property>
-                </item>
-               </widget>
-              </item>
-             </layout>
-            </item>
-            <item>
-             <layout class="QGridLayout" name="followingGridLayout" columnstretch="0,1,1">
-              <property name="spacing">
-               <number>4</number>
-              </property>
-              <item row="2" column="0">
-               <widget class="QLabel" name="followingVLabel">
-                <property name="toolTip">
-                 <string>Vertical</string>
-                </property>
-                <property name="text">
-                 <string>V</string>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="1">
-               <widget class="QSpinBox" name="followingVBorderSpinBox">
-                <property name="value">
-                 <number>32</number>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="0">
-               <widget class="QLabel" name="followingHLabel">
-                <property name="toolTip">
-                 <string>Horizontal</string>
-                </property>
-                <property name="text">
-                 <string>H</string>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="1">
-               <widget class="QSpinBox" name="followingHBorderSpinBox">
-                <property name="value">
-                 <number>32</number>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="1">
-               <widget class="QLabel" name="followingBorderLabel">
-                <property name="toolTip">
-                 <string>Border around the object</string>
-                </property>
-                <property name="text">
-                 <string>Border</string>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignCenter</set>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="2">
-               <widget class="QLabel" name="followingSpeedLabel">
-                <property name="toolTip">
-                 <string>Maximum speed</string>
-                </property>
-                <property name="text">
-                 <string>Speed</string>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignCenter</set>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="2">
-               <widget class="QSpinBox" name="followingHSpeedSpinBox">
-                <property name="minimum">
-                 <number>-99</number>
-                </property>
-                <property name="value">
-                 <number>-1</number>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="2">
-               <widget class="QSpinBox" name="followingVSpeedSpinBox">
-                <property name="minimum">
-                 <number>-99</number>
-                </property>
-                <property name="value">
-                 <number>-1</number>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </item>
-           </layout>
-          </widget>
-         </item>
-         <item>
-          <spacer name="viewsVerticalSpacer">
-           <property name="orientation">
-            <enum>Qt::Vertical</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>20</width>
-             <height>40</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-        </layout>
-       </widget>
+         </widget>
+        </item>
+        <item>
+         <spacer name="viewsVerticalSpacer">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>40</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
       </widget>
-     </item>
-     <item>
+     </widget>
+     <widget class="QWidget" name="sceneWidget" native="true">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+        <horstretch>1</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
       <layout class="QVBoxLayout" name="sceneLayout">
        <property name="spacing">
+        <number>4</number>
+       </property>
+       <property name="leftMargin">
+        <number>4</number>
+       </property>
+       <property name="topMargin">
+        <number>4</number>
+       </property>
+       <property name="rightMargin">
+        <number>4</number>
+       </property>
+       <property name="bottomMargin">
         <number>4</number>
        </property>
        <item>
@@ -1190,8 +1219,8 @@
         </widget>
        </item>
       </layout>
-     </item>
-    </layout>
+     </widget>
+    </widget>
    </item>
   </layout>
   <action name="actionSave">

--- a/Editors/RoomEditor.ui
+++ b/Editors/RoomEditor.ui
@@ -47,7 +47,7 @@
         </sizepolicy>
        </property>
        <property name="currentIndex">
-        <number>2</number>
+        <number>1</number>
        </property>
        <property name="elideMode">
         <enum>Qt::ElideNone</enum>
@@ -1241,8 +1241,11 @@
            <verstretch>0</verstretch>
           </sizepolicy>
          </property>
+         <property name="autoFillBackground">
+          <bool>false</bool>
+         </property>
          <property name="backgroundBrush">
-          <brush brushstyle="SolidPattern">
+          <brush brushstyle="NoBrush">
            <color alpha="255">
             <red>136</red>
             <green>136</green>
@@ -1258,6 +1261,26 @@
             <blue>0</blue>
            </color>
           </brush>
+         </property>
+         <property name="sceneRect">
+          <rectf>
+           <x>0.000000000000000</x>
+           <y>0.000000000000000</y>
+           <width>800.000000000000000</width>
+           <height>600.000000000000000</height>
+          </rectf>
+         </property>
+         <property name="cacheMode">
+          <set>QGraphicsView::CacheNone</set>
+         </property>
+         <property name="transformationAnchor">
+          <enum>QGraphicsView::AnchorViewCenter</enum>
+         </property>
+         <property name="resizeAnchor">
+          <enum>QGraphicsView::NoAnchor</enum>
+         </property>
+         <property name="viewportUpdateMode">
+          <enum>QGraphicsView::FullViewportUpdate</enum>
          </property>
         </widget>
        </item>

--- a/Editors/RoomEditor.ui
+++ b/Editors/RoomEditor.ui
@@ -46,8 +46,11 @@
          <verstretch>0</verstretch>
         </sizepolicy>
        </property>
+       <property name="tabShape">
+        <enum>QTabWidget::Rounded</enum>
+       </property>
        <property name="currentIndex">
-        <number>1</number>
+        <number>0</number>
        </property>
        <property name="elideMode">
         <enum>Qt::ElideNone</enum>
@@ -82,136 +85,13 @@
           <number>4</number>
          </property>
          <item>
-          <widget class="QTreeWidget" name="layersTreeWidget">
+          <widget class="QTableView" name="layersTableView">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
              <horstretch>0</horstretch>
              <verstretch>1</verstretch>
             </sizepolicy>
            </property>
-           <attribute name="headerVisible">
-            <bool>false</bool>
-           </attribute>
-           <column>
-            <property name="text">
-             <string>Name</string>
-            </property>
-           </column>
-           <item>
-            <property name="text">
-             <string>Background 0</string>
-            </property>
-           </item>
-           <item>
-            <property name="text">
-             <string>Background 1</string>
-            </property>
-           </item>
-           <item>
-            <property name="text">
-             <string>NPC</string>
-            </property>
-            <item>
-             <property name="text">
-              <string>Enemy 1</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Enemy 2</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>New Item</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>New Item</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>New Item</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>New Item</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>New Item</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>New Item</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>New Item</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>New Item</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>New Item</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>New Item</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>New Item</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>New Item</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>New Item</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>New Item</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>New Item</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>New Item</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>New Item</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>New Item</string>
-             </property>
-            </item>
-           </item>
           </widget>
          </item>
          <item>

--- a/Editors/RoomEditor.ui
+++ b/Editors/RoomEditor.ui
@@ -1166,16 +1166,16 @@
         <number>4</number>
        </property>
        <property name="leftMargin">
-        <number>4</number>
+        <number>0</number>
        </property>
        <property name="topMargin">
-        <number>4</number>
+        <number>0</number>
        </property>
        <property name="rightMargin">
-        <number>4</number>
+        <number>0</number>
        </property>
        <property name="bottomMargin">
-        <number>4</number>
+        <number>0</number>
        </property>
        <item>
         <widget class="QToolBar" name="mainToolBar">

--- a/Editors/RoomEditor.ui
+++ b/Editors/RoomEditor.ui
@@ -74,7 +74,7 @@
         <attribute name="title">
          <string>Layers</string>
         </attribute>
-        <layout class="QVBoxLayout" name="verticalLayout_6">
+        <layout class="QVBoxLayout" name="verticalLayout_6" stretch="1,1">
          <property name="spacing">
           <number>4</number>
          </property>
@@ -104,12 +104,25 @@
              <height>0</height>
             </size>
            </property>
+           <attribute name="verticalHeaderVisible">
+            <bool>false</bool>
+           </attribute>
           </widget>
          </item>
          <item>
-          <widget class="QStackedWidget" name="layerPropertiesStackWidget">
-           <widget class="QWidget" name="page"/>
-           <widget class="QWidget" name="page_2"/>
+          <widget class="QTableView" name="layersPropertiesView">
+           <property name="editTriggers">
+            <set>QAbstractItemView::AllEditTriggers</set>
+           </property>
+           <property name="alternatingRowColors">
+            <bool>true</bool>
+           </property>
+           <attribute name="horizontalHeaderVisible">
+            <bool>false</bool>
+           </attribute>
+           <attribute name="verticalHeaderCascadingSectionResizes">
+            <bool>false</bool>
+           </attribute>
           </widget>
          </item>
         </layout>

--- a/Editors/RoomEditor.ui
+++ b/Editors/RoomEditor.ui
@@ -46,6 +46,12 @@
          <verstretch>0</verstretch>
         </sizepolicy>
        </property>
+       <property name="minimumSize">
+        <size>
+         <width>320</width>
+         <height>0</height>
+        </size>
+       </property>
        <property name="tabShape">
         <enum>QTabWidget::Rounded</enum>
        </property>
@@ -91,6 +97,12 @@
              <horstretch>0</horstretch>
              <verstretch>1</verstretch>
             </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>259</width>
+             <height>0</height>
+            </size>
            </property>
           </widget>
          </item>

--- a/Editors/RoomEditor.ui
+++ b/Editors/RoomEditor.ui
@@ -150,35 +150,30 @@
                <number>4</number>
               </property>
               <item>
-               <widget class="QToolButton" name="addAssetButton">
+               <widget class="QLineEdit" name="currentObject">
                 <property name="text">
-                 <string>Object</string>
-                </property>
-                <property name="icon">
-                 <iconset resource="../images.qrc">
-                  <normaloff>:/actions/add.png</normaloff>:/actions/add.png</iconset>
-                </property>
-                <property name="popupMode">
-                 <enum>QToolButton::MenuButtonPopup</enum>
-                </property>
-                <property name="toolButtonStyle">
-                 <enum>Qt::ToolButtonTextBesideIcon</enum>
+                 <string>&lt;no object&gt;</string>
                 </property>
                </widget>
               </item>
               <item>
-               <widget class="QComboBox" name="addAssetCombo">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
+               <widget class="QToolButton" name="objectSelectButton">
+                <property name="minimumSize">
+                 <size>
+                  <width>32</width>
+                  <height>0</height>
+                 </size>
                 </property>
-                <item>
-                 <property name="text">
-                  <string>&lt;no object&gt;</string>
-                 </property>
-                </item>
+                <property name="text">
+                 <string/>
+                </property>
+                <property name="icon">
+                 <iconset resource="../images.qrc">
+                  <normaloff>:/resources/object.png</normaloff>:/resources/object.png</iconset>
+                </property>
+                <property name="popupMode">
+                 <enum>QToolButton::MenuButtonPopup</enum>
+                </property>
                </widget>
               </item>
               <item>
@@ -1290,8 +1285,8 @@
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>671</width>
-            <height>569</height>
+            <width>670</width>
+            <height>570</height>
            </rect>
           </property>
           <property name="autoFillBackground">

--- a/Editors/RoomEditor.ui
+++ b/Editors/RoomEditor.ui
@@ -52,14 +52,14 @@
      </property>
      <widget class="QTabWidget" name="propertiesTabWidget">
       <property name="sizePolicy">
-       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <sizepolicy hsizetype="Ignored" vsizetype="Expanding">
         <horstretch>0</horstretch>
         <verstretch>0</verstretch>
        </sizepolicy>
       </property>
       <property name="minimumSize">
        <size>
-        <width>320</width>
+        <width>0</width>
         <height>0</height>
        </size>
       </property>
@@ -67,13 +67,13 @@
        <enum>QTabWidget::Rounded</enum>
       </property>
       <property name="currentIndex">
-       <number>0</number>
+       <number>1</number>
       </property>
       <property name="elideMode">
        <enum>Qt::ElideNone</enum>
       </property>
       <property name="usesScrollButtons">
-       <bool>false</bool>
+       <bool>true</bool>
       </property>
       <property name="documentMode">
        <bool>false</bool>
@@ -395,7 +395,7 @@
             <number>4</number>
            </property>
            <item>
-            <layout class="QHBoxLayout" name="gridColorLayout">
+            <layout class="QHBoxLayout" name="gridColorLayout" stretch="0,0,0,0,1">
              <property name="spacing">
               <number>4</number>
              </property>
@@ -463,6 +463,19 @@
                 <string>Isometric</string>
                </property>
               </widget>
+             </item>
+             <item>
+              <spacer name="horizontalSpacer">
+               <property name="orientation">
+                <enum>Qt::Horizontal</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>40</width>
+                 <height>20</height>
+                </size>
+               </property>
+              </spacer>
              </item>
             </layout>
            </item>

--- a/Editors/RoomEditor.ui
+++ b/Editors/RoomEditor.ui
@@ -1281,8 +1281,14 @@
          <property name="autoFillBackground">
           <bool>false</bool>
          </property>
+         <property name="sizeAdjustPolicy">
+          <enum>QAbstractScrollArea::AdjustIgnored</enum>
+         </property>
          <property name="widgetResizable">
           <bool>true</bool>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
          </property>
          <widget class="QWidget" name="scrollAreaWidgetContents">
           <property name="geometry">
@@ -1296,9 +1302,9 @@
           <property name="autoFillBackground">
            <bool>true</bool>
           </property>
-          <layout class="QVBoxLayout" name="verticalLayout_7">
-           <property name="spacing">
-            <number>0</number>
+          <layout class="QGridLayout" name="gridLayout_3">
+           <property name="sizeConstraint">
+            <enum>QLayout::SetDefaultConstraint</enum>
            </property>
            <property name="leftMargin">
             <number>0</number>
@@ -1312,7 +1318,10 @@
            <property name="bottomMargin">
             <number>0</number>
            </property>
-           <item>
+           <property name="spacing">
+            <number>0</number>
+           </property>
+           <item row="0" column="0">
             <widget class="RoomRenderer" name="roomRenderer" native="true"/>
            </item>
           </layout>

--- a/Editors/RoomEditor.ui
+++ b/Editors/RoomEditor.ui
@@ -827,11 +827,6 @@
               <string>View 7</string>
              </property>
             </item>
-            <item>
-             <property name="text">
-              <string>View 8</string>
-             </property>
-            </item>
            </widget>
           </item>
          </layout>

--- a/Editors/RoomEditor.ui
+++ b/Editors/RoomEditor.ui
@@ -1296,7 +1296,7 @@
             <x>0</x>
             <y>0</y>
             <width>671</width>
-            <height>603</height>
+            <height>569</height>
            </rect>
           </property>
           <property name="autoFillBackground">
@@ -1327,6 +1327,9 @@
           </layout>
          </widget>
         </widget>
+       </item>
+       <item>
+        <widget class="QStatusBar" name="statusBar"/>
        </item>
       </layout>
      </widget>

--- a/Editors/RoomEditor.ui
+++ b/Editors/RoomEditor.ui
@@ -67,7 +67,7 @@
        <enum>QTabWidget::Rounded</enum>
       </property>
       <property name="currentIndex">
-       <number>1</number>
+       <number>0</number>
       </property>
       <property name="elideMode">
        <enum>Qt::ElideNone</enum>
@@ -86,6 +86,9 @@
         <string>Layers</string>
        </attribute>
        <layout class="QVBoxLayout" name="verticalLayout_2">
+        <property name="spacing">
+         <number>4</number>
+        </property>
         <property name="leftMargin">
          <number>4</number>
         </property>
@@ -108,31 +111,93 @@
             <enum>QAbstractItemView::ExtendedSelection</enum>
            </property>
           </widget>
-          <widget class="QTreeView" name="layersAssetsView">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-             <horstretch>0</horstretch>
-             <verstretch>1</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="minimumSize">
-            <size>
-             <width>259</width>
-             <height>0</height>
-            </size>
-           </property>
-           <property name="selectionMode">
-            <enum>QAbstractItemView::ExtendedSelection</enum>
-           </property>
-           <property name="selectionBehavior">
-            <enum>QAbstractItemView::SelectRows</enum>
-           </property>
-           <property name="rootIsDecorated">
-            <bool>false</bool>
-           </property>
-           <property name="uniformRowHeights">
-            <bool>true</bool>
-           </property>
+          <widget class="QWidget" name="">
+           <layout class="QVBoxLayout" name="layersAssetsLayout">
+            <property name="spacing">
+             <number>4</number>
+            </property>
+            <item>
+             <widget class="QTreeView" name="layersAssetsView">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                <horstretch>0</horstretch>
+                <verstretch>1</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>259</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="selectionMode">
+               <enum>QAbstractItemView::ExtendedSelection</enum>
+              </property>
+              <property name="selectionBehavior">
+               <enum>QAbstractItemView::SelectRows</enum>
+              </property>
+              <property name="rootIsDecorated">
+               <bool>false</bool>
+              </property>
+              <property name="uniformRowHeights">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <layout class="QHBoxLayout" name="layersAssetsTools">
+              <property name="spacing">
+               <number>4</number>
+              </property>
+              <item>
+               <widget class="QToolButton" name="addAssetButton">
+                <property name="text">
+                 <string>Object</string>
+                </property>
+                <property name="icon">
+                 <iconset resource="../images.qrc">
+                  <normaloff>:/actions/add.png</normaloff>:/actions/add.png</iconset>
+                </property>
+                <property name="popupMode">
+                 <enum>QToolButton::MenuButtonPopup</enum>
+                </property>
+                <property name="toolButtonStyle">
+                 <enum>Qt::ToolButtonTextBesideIcon</enum>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QComboBox" name="addAssetCombo">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <item>
+                 <property name="text">
+                  <string>&lt;no object&gt;</string>
+                 </property>
+                </item>
+               </widget>
+              </item>
+              <item>
+               <widget class="QToolButton" name="deleteAssetButton">
+                <property name="toolTip">
+                 <string>Delete Assets</string>
+                </property>
+                <property name="text">
+                 <string>Delete Assets</string>
+                </property>
+                <property name="icon">
+                 <iconset resource="../images.qrc">
+                  <normaloff>:/actions/delete.png</normaloff>:/actions/delete.png</iconset>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+           </layout>
           </widget>
           <widget class="QTableView" name="layersPropertiesView">
            <property name="editTriggers">

--- a/Editors/RoomEditor.ui
+++ b/Editors/RoomEditor.ui
@@ -103,8 +103,12 @@
           <property name="orientation">
            <enum>Qt::Vertical</enum>
           </property>
-          <widget class="QListView" name="layersListView"/>
-          <widget class="QTableView" name="layersAssetsView">
+          <widget class="QListView" name="layersListView">
+           <property name="selectionMode">
+            <enum>QAbstractItemView::ExtendedSelection</enum>
+           </property>
+          </widget>
+          <widget class="QTreeView" name="layersAssetsView">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
              <horstretch>0</horstretch>
@@ -117,9 +121,18 @@
              <height>0</height>
             </size>
            </property>
-           <attribute name="verticalHeaderVisible">
+           <property name="selectionMode">
+            <enum>QAbstractItemView::ExtendedSelection</enum>
+           </property>
+           <property name="selectionBehavior">
+            <enum>QAbstractItemView::SelectRows</enum>
+           </property>
+           <property name="rootIsDecorated">
             <bool>false</bool>
-           </attribute>
+           </property>
+           <property name="uniformRowHeights">
+            <bool>true</bool>
+           </property>
           </widget>
           <widget class="QTableView" name="layersPropertiesView">
            <property name="editTriggers">
@@ -131,8 +144,26 @@
            <attribute name="horizontalHeaderVisible">
             <bool>false</bool>
            </attribute>
+           <attribute name="horizontalHeaderCascadingSectionResizes">
+            <bool>true</bool>
+           </attribute>
+           <attribute name="horizontalHeaderDefaultSectionSize">
+            <number>24</number>
+           </attribute>
+           <attribute name="horizontalHeaderMinimumSectionSize">
+            <number>24</number>
+           </attribute>
+           <attribute name="horizontalHeaderStretchLastSection">
+            <bool>true</bool>
+           </attribute>
            <attribute name="verticalHeaderCascadingSectionResizes">
-            <bool>false</bool>
+            <bool>true</bool>
+           </attribute>
+           <attribute name="verticalHeaderDefaultSectionSize">
+            <number>24</number>
+           </attribute>
+           <attribute name="verticalHeaderMinimumSectionSize">
+            <number>24</number>
            </attribute>
           </widget>
          </widget>

--- a/Editors/RoomEditor.ui
+++ b/Editors/RoomEditor.ui
@@ -379,7 +379,7 @@
             </widget>
            </item>
            <item row="0" column="1" colspan="2">
-            <widget class="QLineEdit" name="lineEdit"/>
+            <widget class="QLineEdit" name="roomName"/>
            </item>
           </layout>
          </item>

--- a/Editors/SpriteEditor.cpp
+++ b/Editors/SpriteEditor.cpp
@@ -8,7 +8,7 @@ SpriteEditor::SpriteEditor(ProtoModel* model, QWidget* parent) : BaseEditor(mode
   ui->setupUi(this);
 
   spriteModel =
-      new SpriteModel(static_cast<buffers::resources::Sprite*>(model->GetBuffer())->mutable_subimages(), this);
+      new SpriteModel(static_cast<buffers::resources::Sprite*>(model->GetSubModel(TreeNode::kSpriteFieldNumber)->GetBuffer())->mutable_subimages(), this);
 
   connect(spriteModel, &SpriteModel::MismatchedImageSize, this, &SpriteEditor::LoadedMismatchedImage);
   ui->subImageList->setModel(spriteModel);

--- a/Editors/SpriteEditor.ui
+++ b/Editors/SpriteEditor.ui
@@ -94,13 +94,6 @@
         </widget>
        </item>
        <item>
-        <widget class="QCheckBox" name="transparentCheckBox">
-         <property name="text">
-          <string>&amp;Transparent</string>
-         </property>
-        </widget>
-       </item>
-       <item>
         <widget class="QCheckBox" name="preloadCheckBox">
          <property name="text">
           <string>Pre&amp;load texture</string>

--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -90,7 +90,7 @@ void MainWindow::openSubWindow(buffers::TreeNode *item) {
   using namespace google::protobuf;
 
   using TypeCase = buffers::TreeNode::TypeCase;
-  using FactoryMap = std::unordered_map<TypeCase, std::function<BaseEditor*(ProtoModel* model, QWidget* parent)>>;
+  using FactoryMap = std::unordered_map<TypeCase, std::function<BaseEditor*(ProtoModel* m, QWidget* p)>>;
 
   static FactoryMap factoryMap({
     { TypeCase::kSprite,     EditorFactory<SpriteEditor>     },
@@ -109,7 +109,7 @@ void MainWindow::openSubWindow(buffers::TreeNode *item) {
     if (factoryFunction == factoryMap.end()) return;  // no registered editor
 
     ProtoModel* res = resourceMap->GetResourceByName(item->type_case(), item->name());
-    QWidget *editor = factoryFunction->second(res, nullptr);
+    QWidget *editor = factoryFunction->second(res, this);
 
     subWindow = subWindows[item] = ui->mdiArea->addSubWindow(editor);
     subWindow->resize(subWindow->frameSize().expandedTo(editor->size()));

--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -31,6 +31,7 @@
 #undef GetMessage
 
 ResourceModelMap *MainWindow::resourceMap = nullptr;
+TreeModel *MainWindow::treeModel = nullptr;
 
 MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWindow) {
   ArtManager::Init();

--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -108,7 +108,10 @@ void MainWindow::openSubWindow(buffers::TreeNode *item) {
     if (factoryFunction == factoryMap.end()) return;  // no registered editor
 
     ProtoModel *res = resourceMap->GetResourceByName(item->type_case(), item->name());
-    QWidget *editor = factoryFunction->second(res, this);
+    BaseEditor *editor = factoryFunction->second(res, this);
+
+    connect(editor, &BaseEditor::ResourceRenamed, resourceMap, &ResourceModelMap::ResourceRenamed);
+    connect(editor, &BaseEditor::ResourceRenamed, [=]() { treeModel->dataChanged(QModelIndex(), QModelIndex()); });
 
     subWindow = subWindows[item] = ui->mdiArea->addSubWindow(editor);
     subWindow->resize(subWindow->frameSize().expandedTo(editor->size()));

--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -114,18 +114,20 @@ void MainWindow::openSubWindow(buffers::TreeNode *item) {
     auto factoryFunction = factoryMap.find(item->type_case());
     if (factoryFunction == factoryMap.end()) return;  // no registered editor
 
-    if (!resourceModels.contains(item)) resourceModels[item] = new ProtoModel(typeMessage, nullptr);
-    auto resourceModel = resourceModels[item];
+    //if (!resourceModels.contains(item)) resourceModels[item] = new ProtoModel(typeMessage, nullptr);
+    //auto resourceModel = resourceModels[item];
 
-    QWidget *editor = factoryFunction->second(resourceModel, nullptr);
-    resourceModel->setParent(editor);
+    QVariant res = resourceMap->GetResourceByName(item->type_case(), item->name())->data(buffers::TreeNode::kBackground);
+    ProtoModel* resModel = static_cast<ProtoModel*>(res.value<void*>());
+    QWidget *editor = factoryFunction->second(resModel, nullptr);
+    //resourceModel->setParent(editor);
 
     subWindow = subWindows[item] = ui->mdiArea->addSubWindow(editor);
     subWindow->resize(subWindow->frameSize().expandedTo(editor->size()));
     editor->setParent(subWindow);
 
     subWindow->connect(subWindow, &QObject::destroyed, [=]() {
-      resourceModels.remove(item);
+      //resourceModels.remove(item);
       subWindows.remove(item);
     });
     subWindow->setWindowIcon(subWindow->widget()->windowIcon());
@@ -157,6 +159,7 @@ void MainWindow::openFile(QString fName) {
   MainWindow::setWindowTitle(fileInfo.fileName() + " - ENIGMA");
   recentFiles->prependFile(fName);
 
+  resourceMap = new ResourceModelMap(project->mutable_game()->mutable_root());
   treeModel = new TreeModel(project->mutable_game()->mutable_root(), this);
   ui->treeView->setModel(treeModel);
   treeModel->connect(treeModel, &QAbstractItemModel::dataChanged,

--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -100,34 +100,21 @@ void MainWindow::openSubWindow(buffers::TreeNode *item) {
                                 {TypeCase::kObject, EditorFactory<ObjectEditor>},
                                 {TypeCase::kRoom, EditorFactory<RoomEditor>}});
 
-  const Descriptor *desc = item->GetDescriptor();
-  const Reflection *refl = item->GetReflection();
-
-  const OneofDescriptor *typeOneof = desc->FindOneofByName("type");
-  const FieldDescriptor *typeField = refl->GetOneofFieldDescriptor(*item, typeOneof);
-  // might not be set or it's not a message
-  if (!typeField || typeField->cpp_type() != FieldDescriptor::CppType::CPPTYPE_MESSAGE) return;
-  Message *typeMessage = refl->MutableMessage(item, typeField);
-
   auto subWindow = subWindows[item];
   if (!subWindows.contains(item) || subWindow == nullptr) {
     auto factoryFunction = factoryMap.find(item->type_case());
     if (factoryFunction == factoryMap.end()) return;  // no registered editor
 
-    //if (!resourceModels.contains(item)) resourceModels[item] = new ProtoModel(typeMessage, nullptr);
-    //auto resourceModel = resourceModels[item];
-
     ProtoModel* treeNode = resourceMap->GetResourceByName(item->type_case(), item->name());
     ProtoModel* resModel = static_cast<ProtoModel*>(treeNode->data(buffers::TreeNode::kBackgroundFieldNumber).value<void*>());
     QWidget *editor = factoryFunction->second(resModel, nullptr);
-    //resourceModel->setParent(editor);
+    resModel->setParent(editor);
 
     subWindow = subWindows[item] = ui->mdiArea->addSubWindow(editor);
     subWindow->resize(subWindow->frameSize().expandedTo(editor->size()));
     editor->setParent(subWindow);
 
     subWindow->connect(subWindow, &QObject::destroyed, [=]() {
-      //resourceModels.remove(item);
       subWindows.remove(item);
     });
     subWindow->setWindowIcon(subWindow->widget()->windowIcon());

--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -117,8 +117,8 @@ void MainWindow::openSubWindow(buffers::TreeNode *item) {
     //if (!resourceModels.contains(item)) resourceModels[item] = new ProtoModel(typeMessage, nullptr);
     //auto resourceModel = resourceModels[item];
 
-    QVariant res = resourceMap->GetResourceByName(item->type_case(), item->name())->data(buffers::TreeNode::kBackground);
-    ProtoModel* resModel = static_cast<ProtoModel*>(res.value<void*>());
+    ProtoModel* treeNode = resourceMap->GetResourceByName(item->type_case(), item->name());
+    ProtoModel* resModel = static_cast<ProtoModel*>(treeNode->data(buffers::TreeNode::kBackgroundFieldNumber).value<void*>());
     QWidget *editor = factoryFunction->second(resModel, nullptr);
     //resourceModel->setParent(editor);
 

--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -115,9 +115,6 @@ void MainWindow::openSubWindow(buffers::TreeNode *item) {
     subWindow->resize(subWindow->frameSize().expandedTo(editor->size()));
     editor->setParent(subWindow);
 
-    subWindow->connect(subWindow, &QObject::destroyed, [=]() {
-      subWindows.remove(item);
-    });
     subWindow->setWindowIcon(subWindow->widget()->windowIcon());
     subWindow->setWindowTitle(QString::fromStdString(item->name()));
   }
@@ -147,8 +144,9 @@ void MainWindow::openFile(QString fName) {
   MainWindow::setWindowTitle(fileInfo.fileName() + " - ENIGMA");
   recentFiles->prependFile(fName);
 
-  resourceMap = new ResourceModelMap(project->mutable_game()->mutable_root());
-  treeModel = new TreeModel(project->mutable_game()->mutable_root(), this);
+  resourceMap = new ResourceModelMap(project->mutable_game()->mutable_root(), this);
+  treeModel = new TreeModel(project->mutable_game()->mutable_root(), resourceMap
+                            );
   ui->treeView->setModel(treeModel);
   treeModel->connect(treeModel, &QAbstractItemModel::dataChanged,
                      [=](const QModelIndex &topLeft, const QModelIndex &bottomRight) {

--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -191,6 +191,7 @@ void MainWindow::openFile(QString fName) {
                          }
                        }
                      });
+  ArtManager::clearCache();
 }
 
 void MainWindow::on_actionOpen_triggered() {

--- a/MainWindow.h
+++ b/MainWindow.h
@@ -3,6 +3,7 @@
 
 #include "Models/ProtoModel.h"
 #include "Models/TreeModel.h"
+#include "Models/ResourceModelMap.h"
 
 class MainWindow;
 #include "Components/RecentFiles.h"
@@ -58,7 +59,7 @@ class MainWindow : public QMainWindow {
   void on_actionClearRecentMenu_triggered();
 
  private:
-  QHash<buffers::TreeNode *, ProtoModel *> resourceModels;
+  ResourceModelMap* resourceMap;
   QHash<buffers::TreeNode *, QMdiSubWindow *> subWindows;
 
   TreeModel *treeModel;

--- a/MainWindow.h
+++ b/MainWindow.h
@@ -26,7 +26,7 @@ class MainWindow : public QMainWindow {
   explicit MainWindow(QWidget *parent);
   ~MainWindow();
   void closeEvent(QCloseEvent *event);
-
+  static ResourceModelMap* resourceMap;
   buffers::Game *Game() const { return this->project->mutable_game(); }
 
  public slots:
@@ -59,7 +59,6 @@ class MainWindow : public QMainWindow {
   void on_actionClearRecentMenu_triggered();
 
  private:
-  ResourceModelMap* resourceMap;
   QHash<buffers::TreeNode *, QMdiSubWindow *> subWindows;
 
   TreeModel *treeModel;

--- a/MainWindow.h
+++ b/MainWindow.h
@@ -27,6 +27,7 @@ class MainWindow : public QMainWindow {
   ~MainWindow();
   void closeEvent(QCloseEvent *event);
   static ResourceModelMap* resourceMap;
+  static TreeModel *treeModel;
   buffers::Game *Game() const { return this->project->mutable_game(); }
 
  public slots:
@@ -62,7 +63,6 @@ class MainWindow : public QMainWindow {
  private:
   QHash<buffers::TreeNode *, QMdiSubWindow *> subWindows;
 
-  TreeModel *treeModel;
   Ui::MainWindow *ui;
 
   buffers::Project *project;

--- a/Models/ModelMapper.cpp
+++ b/Models/ModelMapper.cpp
@@ -37,7 +37,7 @@ bool ModelMapper::setData(const QModelIndex &index, const QVariant &value, int r
   return model->setData(index, value, role);
 }
 
-QVariant ModelMapper::data(int index) const { return model->data(index); }
+QVariant ModelMapper::data(int row, int column) const { return model->data(row, column); }
 
 QVariant ModelMapper::data(const QModelIndex &index, int role) const { return model->data(index, role); }
 

--- a/Models/ModelMapper.cpp
+++ b/Models/ModelMapper.cpp
@@ -41,6 +41,8 @@ QVariant ModelMapper::data(int row, int column) const { return model->data(row, 
 
 QVariant ModelMapper::data(const QModelIndex &index, int role) const { return model->data(index, role); }
 
+RepeatedProtoModel* ModelMapper::GetRepeatedSubModel(int fieldNum) { return model->GetRepeatedSubModel(fieldNum); }
+
 ProtoModel *ModelMapper::GetSubModel(int fieldNum) { return model->GetSubModel(fieldNum); }
 
 QString ModelMapper::GetString(int fieldNum, int index) { return model->GetString(fieldNum, index); }

--- a/Models/ModelMapper.cpp
+++ b/Models/ModelMapper.cpp
@@ -1,0 +1,86 @@
+#include "Models/ModelMapper.h"
+
+#include "Editors/BaseEditor.h"
+
+ModelMapper::ModelMapper(ProtoModel* model, BaseEditor* parent) : model(model) {
+  mapper = new ImmediateDataWidgetMapper(parent);
+  mapper->setOrientation(Qt::Vertical);
+  mapper->setModel(model);
+  parent->connect(model, &ProtoModel::dataChanged, parent, &BaseEditor::dataChanged);
+}
+
+// mapper
+
+void ModelMapper::addMapping(QWidget * widget, int section) {
+  mapper->addMapping(widget, section);
+}
+
+void ModelMapper::clearMapping() {
+  mapper->clearMapping();
+}
+
+void ModelMapper::toFirst() {
+  mapper->toFirst();
+}
+
+// model
+
+void ModelMapper::RestoreBuffer() {
+  model->RestoreBuffer();
+}
+
+void ModelMapper::ReplaceBuffer(google::protobuf::Message *buffer) {
+  model->ReplaceBuffer(buffer);
+}
+
+void ModelMapper::SetDirty(bool dirty) {
+  model->SetDirty(dirty);
+}
+
+bool ModelMapper::IsDirty() {
+  return model->IsDirty();
+}
+
+int ModelMapper::rowCount(const QModelIndex &parent) const {
+  return model->rowCount(parent);
+}
+
+int ModelMapper::columnCount(const QModelIndex &parent) const {
+  return model->columnCount(parent);
+}
+
+bool ModelMapper::setData(const QModelIndex &index, const QVariant &value, int role) {
+  return model->setData(index, value, role);
+}
+
+QVariant ModelMapper::data(int index) const {
+  return model->data(index);
+}
+
+QVariant ModelMapper::data(const QModelIndex &index, int role) const {
+  return model->data(index, role);
+}
+
+ProtoModel* ModelMapper::GetSubModel(int fieldNum) {
+  return model->GetSubModel(fieldNum);
+}
+
+QString ModelMapper::GetString(int fieldNum, int index) {
+  return model->GetString(fieldNum, index);
+}
+
+QModelIndex ModelMapper::parent(const QModelIndex &index) const {
+  return model->parent(index);
+}
+
+QVariant ModelMapper::headerData(int section, Qt::Orientation orientation, int role) const {
+  return model->headerData(section, orientation, role);
+}
+
+QModelIndex ModelMapper::index(int row, int column, const QModelIndex &parent) const {
+  return model->index(row, column, parent);
+}
+
+Qt::ItemFlags ModelMapper::flags(const QModelIndex &index) const {
+  return model->flags(index);
+}

--- a/Models/ModelMapper.cpp
+++ b/Models/ModelMapper.cpp
@@ -2,7 +2,7 @@
 
 #include "Editors/BaseEditor.h"
 
-ModelMapper::ModelMapper(ProtoModel* model, BaseEditor* parent) : model(model) {
+ModelMapper::ModelMapper(ProtoModel *model, BaseEditor *parent) : model(model) {
   mapper = new ImmediateDataWidgetMapper(parent);
   mapper->setOrientation(Qt::Vertical);
   mapper->setModel(model);
@@ -11,71 +11,41 @@ ModelMapper::ModelMapper(ProtoModel* model, BaseEditor* parent) : model(model) {
 
 // mapper
 
-ProtoModel* ModelMapper::GetModel() {
-  return model;
-}
+ProtoModel *ModelMapper::GetModel() { return model; }
 
-void ModelMapper::addMapping(QWidget * widget, int section) {
-  mapper->addMapping(widget, section);
-}
+void ModelMapper::addMapping(QWidget *widget, int section) { mapper->addMapping(widget, section); }
 
-void ModelMapper::clearMapping() {
-  mapper->clearMapping();
-}
+void ModelMapper::clearMapping() { mapper->clearMapping(); }
 
-void ModelMapper::toFirst() {
-  mapper->toFirst();
-}
+void ModelMapper::toFirst() { mapper->toFirst(); }
 
 // model
 
-void ModelMapper::RestoreBuffer() {
-  model->RestoreBuffer();
-}
+void ModelMapper::RestoreBuffer() { model->RestoreBuffer(); }
 
-void ModelMapper::ReplaceBuffer(google::protobuf::Message *buffer) {
-  model->ReplaceBuffer(buffer);
-}
+void ModelMapper::ReplaceBuffer(google::protobuf::Message *buffer) { model->ReplaceBuffer(buffer); }
 
-void ModelMapper::SetDirty(bool dirty) {
-  model->SetDirty(dirty);
-}
+void ModelMapper::SetDirty(bool dirty) { model->SetDirty(dirty); }
 
-bool ModelMapper::IsDirty() {
-  return model->IsDirty();
-}
+bool ModelMapper::IsDirty() { return model->IsDirty(); }
 
-int ModelMapper::rowCount(const QModelIndex &parent) const {
-  return model->rowCount(parent);
-}
+int ModelMapper::rowCount(const QModelIndex &parent) const { return model->rowCount(parent); }
 
-int ModelMapper::columnCount(const QModelIndex &parent) const {
-  return model->columnCount(parent);
-}
+int ModelMapper::columnCount(const QModelIndex &parent) const { return model->columnCount(parent); }
 
 bool ModelMapper::setData(const QModelIndex &index, const QVariant &value, int role) {
   return model->setData(index, value, role);
 }
 
-QVariant ModelMapper::data(int index) const {
-  return model->data(index);
-}
+QVariant ModelMapper::data(int index) const { return model->data(index); }
 
-QVariant ModelMapper::data(const QModelIndex &index, int role) const {
-  return model->data(index, role);
-}
+QVariant ModelMapper::data(const QModelIndex &index, int role) const { return model->data(index, role); }
 
-ProtoModel* ModelMapper::GetSubModel(int fieldNum) {
-  return model->GetSubModel(fieldNum);
-}
+ProtoModel *ModelMapper::GetSubModel(int fieldNum) { return model->GetSubModel(fieldNum); }
 
-QString ModelMapper::GetString(int fieldNum, int index) {
-  return model->GetString(fieldNum, index);
-}
+QString ModelMapper::GetString(int fieldNum, int index) { return model->GetString(fieldNum, index); }
 
-QModelIndex ModelMapper::parent(const QModelIndex &index) const {
-  return model->parent(index);
-}
+QModelIndex ModelMapper::parent(const QModelIndex &index) const { return model->parent(index); }
 
 QVariant ModelMapper::headerData(int section, Qt::Orientation orientation, int role) const {
   return model->headerData(section, orientation, role);
@@ -85,6 +55,4 @@ QModelIndex ModelMapper::index(int row, int column, const QModelIndex &parent) c
   return model->index(row, column, parent);
 }
 
-Qt::ItemFlags ModelMapper::flags(const QModelIndex &index) const {
-  return model->flags(index);
-}
+Qt::ItemFlags ModelMapper::flags(const QModelIndex &index) const { return model->flags(index); }

--- a/Models/ModelMapper.cpp
+++ b/Models/ModelMapper.cpp
@@ -11,6 +11,10 @@ ModelMapper::ModelMapper(ProtoModel* model, BaseEditor* parent) : model(model) {
 
 // mapper
 
+ProtoModel* ModelMapper::GetModel() {
+  return model;
+}
+
 void ModelMapper::addMapping(QWidget * widget, int section) {
   mapper->addMapping(widget, section);
 }

--- a/Models/ModelMapper.h
+++ b/Models/ModelMapper.h
@@ -1,0 +1,42 @@
+#ifndef MODELMAPPER_H
+#define MODELMAPPER_H
+
+#include "Models/ProtoModel.h"
+#include "Models/ImmediateMapper.h"
+
+#include <google/protobuf/message.h>
+
+class BaseEditor;
+
+class ModelMapper {
+public:
+  ModelMapper(ProtoModel *model, BaseEditor* parent);
+
+  // mapper
+  void addMapping(QWidget * widget, int section);
+  void clearMapping();
+  void toFirst();
+
+  // model
+  void RestoreBuffer();
+  void ReplaceBuffer(google::protobuf::Message *buffer);
+  void SetDirty(bool dirty);
+  bool IsDirty();
+  int rowCount(const QModelIndex &parent = QModelIndex()) const;
+  int columnCount(const QModelIndex &parent = QModelIndex()) const;
+  bool setData(const QModelIndex &index, const QVariant &value, int role);
+  QVariant data(int index) const;
+  QVariant data(const QModelIndex &index, int role) const;
+  ProtoModel* GetSubModel(int fieldNum);
+  QString GetString(int fieldNum, int index);
+  QModelIndex parent(const QModelIndex &index) const;
+  QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const;
+  QModelIndex index(int row, int column = 0, const QModelIndex &parent = QModelIndex()) const;
+  Qt::ItemFlags flags(const QModelIndex &index) const;
+
+protected:
+  ProtoModel *model;
+  ImmediateDataWidgetMapper *mapper;
+};
+
+#endif // MODELMAPPER_H

--- a/Models/ModelMapper.h
+++ b/Models/ModelMapper.h
@@ -26,7 +26,7 @@ public:
   int rowCount(const QModelIndex &parent = QModelIndex()) const;
   int columnCount(const QModelIndex &parent = QModelIndex()) const;
   bool setData(const QModelIndex &index, const QVariant &value, int role);
-  QVariant data(int index) const;
+  QVariant data(int row, int column=0) const;
   QVariant data(const QModelIndex &index, int role) const;
   ProtoModel* GetSubModel(int fieldNum);
   QString GetString(int fieldNum, int index);

--- a/Models/ModelMapper.h
+++ b/Models/ModelMapper.h
@@ -28,6 +28,7 @@ public:
   bool setData(const QModelIndex &index, const QVariant &value, int role);
   QVariant data(int row, int column=0) const;
   QVariant data(const QModelIndex &index, int role) const;
+  RepeatedProtoModel* GetRepeatedSubModel(int fieldNum);
   ProtoModel* GetSubModel(int fieldNum);
   QString GetString(int fieldNum, int index);
   QModelIndex parent(const QModelIndex &index) const;

--- a/Models/ModelMapper.h
+++ b/Models/ModelMapper.h
@@ -18,6 +18,7 @@ public:
   void toFirst();
 
   // model
+  ProtoModel* GetModel();
   void RestoreBuffer();
   void ReplaceBuffer(google::protobuf::Message *buffer);
   void SetDirty(bool dirty);

--- a/Models/ProtoModel.cpp
+++ b/Models/ProtoModel.cpp
@@ -176,9 +176,9 @@ QString ProtoModel::GetString(int fieldNum, int index) const {
     return "";
 }
 
-QModelIndex ProtoModel::parent(const QModelIndex &index) const { return QModelIndex(); }
+QModelIndex ProtoModel::parent(const QModelIndex & /*index*/) const { return QModelIndex(); }
 
-QVariant ProtoModel::headerData(int section, Qt::Orientation orientation, int role) const {
+QVariant ProtoModel::headerData(int section, Qt::Orientation /*orientation*/, int role) const {
   if (role != Qt::DisplayRole) return QVariant();
   if (section == 0) return tr("Property");
 

--- a/Models/ProtoModel.cpp
+++ b/Models/ProtoModel.cpp
@@ -169,7 +169,7 @@ ProtoModel *ProtoModel::GetSubModel(int fieldNum, int index) {
   return static_cast<ProtoModel *>(repeatedMessages[fieldNum][index].value<void *>());
 }
 
-QString ProtoModel::GetString(int fieldNum, int index) {
+QString ProtoModel::GetString(int fieldNum, int index) const {
   if (repeatedMessages.contains(fieldNum) && repeatedMessages[fieldNum].size() > index)
     return repeatedMessages[fieldNum][index].toString();
   else

--- a/Models/ProtoModel.cpp
+++ b/Models/ProtoModel.cpp
@@ -180,7 +180,7 @@ QModelIndex ProtoModel::parent(const QModelIndex &index) const { return QModelIn
 
 QVariant ProtoModel::headerData(int section, Qt::Orientation orientation, int role) const {
   if (role != Qt::DisplayRole) return QVariant();
-  if (section == 0) return "Property";
+  if (section == 0) return tr("Property");
 
   const Descriptor *desc = protobuf->GetDescriptor();
   const FieldDescriptor *field = desc->FindFieldByNumber(section);
@@ -196,5 +196,7 @@ QModelIndex ProtoModel::index(int row, int column, const QModelIndex & /*parent*
 
 Qt::ItemFlags ProtoModel::flags(const QModelIndex &index) const {
   if (!index.isValid()) return nullptr;
-  return QAbstractItemModel::flags(index) | Qt::ItemIsEditable;
+  auto flags = QAbstractItemModel::flags(index);
+  if (index.row() > 0) flags |= Qt::ItemIsEditable;
+  return flags;
 }

--- a/Models/ProtoModel.cpp
+++ b/Models/ProtoModel.cpp
@@ -153,10 +153,9 @@ ProtoModel* ProtoModel::GetSubModel(int fieldNum) {
 }
 
 QString ProtoModel::GetString(int fieldNum, int index) {
-    std::cout << "wut: " << fieldNum << std::endl;
-    std::cout << "wut2: " << repeatedMessages.empty() << std::endl;
-  //std::cout << repeatedMessages[fieldNum].size() << std::endl;
-  return "";//repeatedMessages[fieldNum][index].toString();
+  if (repeatedMessages.contains(fieldNum) && repeatedMessages[fieldNum].size() > index)
+    return repeatedMessages[fieldNum][index].toString();
+  else return "";
 }
 
 QModelIndex ProtoModel::parent(const QModelIndex & /*index*/) const { return QModelIndex(); }

--- a/Models/ProtoModel.cpp
+++ b/Models/ProtoModel.cpp
@@ -113,7 +113,7 @@ bool ProtoModel::setData(const QModelIndex &index, const QVariant &value, int ro
   return true;
 }
 
-QVariant ProtoModel::data(int index) const { return data(this->index(index, 0, QModelIndex()), Qt::DisplayRole); }
+QVariant ProtoModel::data(int row, int column) const { return data(this->index(row, column, QModelIndex()), Qt::DisplayRole); }
 
 QVariant ProtoModel::data(const QModelIndex &index, int role) const {
   if (role != Qt::DisplayRole && role != Qt::EditRole) return QVariant();
@@ -126,7 +126,7 @@ QVariant ProtoModel::data(const QModelIndex &index, int role) const {
   switch (field->cpp_type()) {
     case CppType::CPPTYPE_MESSAGE:
       if (field->is_repeated())
-        return repeatedMessages[index.row()];
+        return repeatedMessages[index.row()][index.column()];
       else
         return messages[index.row()];
     case CppType::CPPTYPE_INT32:

--- a/Models/ProtoModel.cpp
+++ b/Models/ProtoModel.cpp
@@ -177,8 +177,8 @@ QModelIndex ProtoModel::parent(const QModelIndex& index) const {
   return QModelIndex();
 }
 
-QVariant ProtoModel::headerData(int section, Qt::Orientation /*orientation*/, int role) const {
-  if (role != Qt::DisplayRole) return QVariant();
+QVariant ProtoModel::headerData(int section, Qt::Orientation orientation, int role) const {
+  if (role != Qt::DisplayRole || orientation != Qt::Orientation::Horizontal) return QVariant();
   const Descriptor *desc = protobuf->GetDescriptor();
   const FieldDescriptor *field = desc->FindFieldByNumber(section);
 

--- a/Models/ProtoModel.cpp
+++ b/Models/ProtoModel.cpp
@@ -166,7 +166,7 @@ QVariant ProtoModel::headerData(int /*section*/, Qt::Orientation /*orientation*/
 }
 
 QModelIndex ProtoModel::index(int row, int column, const QModelIndex & /*parent*/) const {
-  return this->createIndex(row, column);
+  return this->createIndex(row, column, static_cast<void*>(protobuf));
 }
 
 Qt::ItemFlags ProtoModel::flags(const QModelIndex &index) const {

--- a/Models/ProtoModel.cpp
+++ b/Models/ProtoModel.cpp
@@ -63,7 +63,9 @@ void ProtoModel::SetDirty(bool dirty) { this->dirty = dirty; }
 
 bool ProtoModel::IsDirty() { return dirty; }
 
-int ProtoModel::columnCount(const QModelIndex & /*parent*/) const { return 1; }
+int ProtoModel::columnCount(const QModelIndex & /*parent*/) const {
+  return 1;
+}
 
 bool ProtoModel::setData(const QModelIndex &index, const QVariant &value, int role) {
   const Descriptor *desc = protobuf->GetDescriptor();
@@ -161,11 +163,19 @@ QString ProtoModel::GetString(int fieldNum, int index) {
     return "";
 }
 
-QModelIndex ProtoModel::parent(const QModelIndex & /*index*/) const { return QModelIndex(); }
+QModelIndex ProtoModel::parent(const QModelIndex& index) const {
+  return QModelIndex();
+}
 
-QVariant ProtoModel::headerData(int /*section*/, Qt::Orientation /*orientation*/, int role) const {
+QVariant ProtoModel::headerData(int section, Qt::Orientation /*orientation*/, int role) const {
   if (role != Qt::DisplayRole) return QVariant();
-  return tr("Field");
+  const Descriptor *desc = protobuf->GetDescriptor();
+  const FieldDescriptor *field = desc->FindFieldByNumber(section);
+
+  if (field != nullptr)
+    return QString::fromStdString(field->name());
+
+  return "";
 }
 
 QModelIndex ProtoModel::index(int row, int column, const QModelIndex & /*parent*/) const {

--- a/Models/ProtoModel.cpp
+++ b/Models/ProtoModel.cpp
@@ -22,6 +22,11 @@ ProtoModel::ProtoModel(Message *protobuf, QObject *parent)
             repeatedMessages[i].append(QVariant::fromValue(static_cast<void*>(subModel)));
           }
         } else {
+          const google::protobuf::OneofDescriptor *oneof = field->containing_oneof();
+          if (oneof && refl->HasOneof(*protobuf, oneof)) {
+            field = refl->GetOneofFieldDescriptor(*protobuf, oneof);
+            if (field->cpp_type() != CppType::CPPTYPE_MESSAGE) continue; // is prolly folder
+          }
           ProtoModel* subModel = new ProtoModel(refl->MutableMessage(protobuf, field), nullptr);
           messages[i] = QVariant::fromValue(static_cast<void*>(subModel));
         }

--- a/Models/ProtoModel.cpp
+++ b/Models/ProtoModel.cpp
@@ -18,7 +18,7 @@ ProtoModel::ProtoModel(Message *protobuf, QObject *parent)
     if (field->cpp_type() == CppType::CPPTYPE_MESSAGE) {
         if (field->is_repeated()) {
           for (int j=0; j < refl->FieldSize(*protobuf, field); j++) {
-            ProtoModel* subModel = new ProtoModel(refl->MutableRepeatedMessage(protobuf, field, j), nullptr);
+            ProtoModel* subModel = new ProtoModel(refl->MutableRepeatedMessage(protobuf, field, j), this);
             repeatedMessages[i].append(QVariant::fromValue(static_cast<void*>(subModel)));
           }
         } else {
@@ -27,7 +27,7 @@ ProtoModel::ProtoModel(Message *protobuf, QObject *parent)
             field = refl->GetOneofFieldDescriptor(*protobuf, oneof);
             if (field->cpp_type() != CppType::CPPTYPE_MESSAGE) continue; // is prolly folder
           }
-          ProtoModel* subModel = new ProtoModel(refl->MutableMessage(protobuf, field), nullptr);
+          ProtoModel* subModel = new ProtoModel(refl->MutableMessage(protobuf, field), this);
           messages[i] = QVariant::fromValue(static_cast<void*>(subModel));
         }
     }

--- a/Models/ProtoModel.cpp
+++ b/Models/ProtoModel.cpp
@@ -16,22 +16,22 @@ ProtoModel::ProtoModel(Message *protobuf, QObject *parent)
     const google::protobuf::FieldDescriptor *field = desc->field(i);
 
     if (field->cpp_type() == CppType::CPPTYPE_MESSAGE) {
-        if (field->is_repeated()) {
-          for (int j=0; j < refl->FieldSize(*protobuf, field); j++) {
-            ProtoModel* subModel = new ProtoModel(refl->MutableRepeatedMessage(protobuf, field, j), this);
-            repeatedMessages[field->number()].append(QVariant::fromValue(static_cast<void*>(subModel)));
-          }
-        } else {
-          const google::protobuf::OneofDescriptor *oneof = field->containing_oneof();
-          if (oneof && refl->HasOneof(*protobuf, oneof)) {
-            field = refl->GetOneofFieldDescriptor(*protobuf, oneof);
-            if (field->cpp_type() != CppType::CPPTYPE_MESSAGE) continue; // is prolly folder
-          }
-          ProtoModel* subModel = new ProtoModel(refl->MutableMessage(protobuf, field), this);
-          messages[field->number()] = QVariant::fromValue(static_cast<void*>(subModel));
+      if (field->is_repeated()) {
+        for (int j = 0; j < refl->FieldSize(*protobuf, field); j++) {
+          ProtoModel *subModel = new ProtoModel(refl->MutableRepeatedMessage(protobuf, field, j), this);
+          repeatedMessages[field->number()].append(QVariant::fromValue(static_cast<void *>(subModel)));
         }
+      } else {
+        const google::protobuf::OneofDescriptor *oneof = field->containing_oneof();
+        if (oneof && refl->HasOneof(*protobuf, oneof)) {
+          field = refl->GetOneofFieldDescriptor(*protobuf, oneof);
+          if (field->cpp_type() != CppType::CPPTYPE_MESSAGE) continue;  // is prolly folder
+        }
+        ProtoModel *subModel = new ProtoModel(refl->MutableMessage(protobuf, field), this);
+        messages[field->number()] = QVariant::fromValue(static_cast<void *>(subModel));
+      }
     } else if (field->cpp_type() == CppType::CPPTYPE_STRING && field->is_repeated()) {
-      for (int j=0; j < refl->FieldSize(*protobuf, field); j++) {
+      for (int j = 0; j < refl->FieldSize(*protobuf, field); j++) {
         repeatedMessages[field->number()].append(QString::fromStdString(refl->GetRepeatedString(*protobuf, field, j)));
       }
     }
@@ -65,11 +65,13 @@ bool ProtoModel::IsDirty() { return dirty; }
 
 int ProtoModel::columnCount(const QModelIndex & /*parent*/) const { return 1; }
 
-bool ProtoModel::setData(const QModelIndex &index, const QVariant &value, int /*role*/) {
+bool ProtoModel::setData(const QModelIndex &index, const QVariant &value, int role) {
   const Descriptor *desc = protobuf->GetDescriptor();
   const Reflection *refl = protobuf->GetReflection();
   const FieldDescriptor *field = desc->FindFieldByNumber(index.row());
   if (!field) return false;
+
+  const QVariant oldValue = this->data(index, role);
 
   switch (field->cpp_type()) {
     case CppType::CPPTYPE_MESSAGE: {
@@ -105,7 +107,7 @@ bool ProtoModel::setData(const QModelIndex &index, const QVariant &value, int /*
   }
 
   SetDirty(true);
-  emit dataChanged(index, index);
+  emit dataChanged(index, index, oldValue);
   return true;
 }
 
@@ -148,14 +150,15 @@ QVariant ProtoModel::data(const QModelIndex &index, int role) const {
   return QVariant();
 }
 
-ProtoModel* ProtoModel::GetSubModel(int fieldNum) {
- return static_cast<ProtoModel*>(this->data(fieldNum).value<void*>());
+ProtoModel *ProtoModel::GetSubModel(int fieldNum) {
+  return static_cast<ProtoModel *>(this->data(fieldNum).value<void *>());
 }
 
 QString ProtoModel::GetString(int fieldNum, int index) {
   if (repeatedMessages.contains(fieldNum) && repeatedMessages[fieldNum].size() > index)
     return repeatedMessages[fieldNum][index].toString();
-  else return "";
+  else
+    return "";
 }
 
 QModelIndex ProtoModel::parent(const QModelIndex & /*index*/) const { return QModelIndex(); }
@@ -166,7 +169,7 @@ QVariant ProtoModel::headerData(int /*section*/, Qt::Orientation /*orientation*/
 }
 
 QModelIndex ProtoModel::index(int row, int column, const QModelIndex & /*parent*/) const {
-  return this->createIndex(row, column, static_cast<void*>(protobuf));
+  return this->createIndex(row, column, static_cast<void *>(protobuf));
 }
 
 Qt::ItemFlags ProtoModel::flags(const QModelIndex &index) const {

--- a/Models/ProtoModel.h
+++ b/Models/ProtoModel.h
@@ -7,6 +7,19 @@
 
 #include <google/protobuf/message.h>
 
+#include "codegen/treenode.pb.h"
+
+using TypeCase = buffers::TreeNode::TypeCase;
+using TreeNode = buffers::TreeNode;
+using Background = buffers::resources::Background;
+using Font =  buffers::resources::Font;
+using Object = buffers::resources::Object;
+using Path = buffers::resources::Path;
+using Room = buffers::resources::Room;
+using Sound = buffers::resources::Sound;
+using Sprite = buffers::resources::Sprite;
+using Timeline = buffers::resources::Timeline;
+
 class ProtoModel : public QAbstractItemModel {
   Q_OBJECT
 

--- a/Models/ProtoModel.h
+++ b/Models/ProtoModel.h
@@ -24,6 +24,8 @@ class ProtoModel : public QAbstractItemModel {
   bool setData(const QModelIndex &index, const QVariant &value, int role) override;
   QVariant data(int index) const;
   QVariant data(const QModelIndex &index, int role) const override;
+  ProtoModel* GetSubModel(int fieldNum);
+  QString GetString(int fieldNum, int index);
   QModelIndex parent(const QModelIndex &index) const override;
   QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
   QModelIndex index(int row, int column = 0, const QModelIndex &parent = QModelIndex()) const override;

--- a/Models/ProtoModel.h
+++ b/Models/ProtoModel.h
@@ -39,7 +39,7 @@ class ProtoModel : public QAbstractItemModel {
   RepeatedProtoModel* GetRepeatedSubModel(int fieldNum);
   ProtoModel *GetSubModel(int fieldNum);
   ProtoModel *GetSubModel(int fieldNum, int index);
-  QString GetString(int fieldNum, int index);
+  QString GetString(int fieldNum, int index) const;
   QModelIndex parent(const QModelIndex &index) const override;
   QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
   QModelIndex index(int row, int column = 0, const QModelIndex &parent = QModelIndex()) const override;

--- a/Models/ProtoModel.h
+++ b/Models/ProtoModel.h
@@ -35,7 +35,7 @@ class ProtoModel : public QAbstractItemModel {
   int rowCount(const QModelIndex &parent = QModelIndex()) const override;
   int columnCount(const QModelIndex &parent = QModelIndex()) const override;
   bool setData(const QModelIndex &index, const QVariant &value, int role) override;
-  QVariant data(int index) const;
+  QVariant data(int row, int column=0) const;
   QVariant data(const QModelIndex &index, int role) const override;
   ProtoModel *GetSubModel(int fieldNum);
   QString GetString(int fieldNum, int index);

--- a/Models/ProtoModel.h
+++ b/Models/ProtoModel.h
@@ -1,13 +1,12 @@
 #ifndef RESOURCEMODEL_H
 #define RESOURCEMODEL_H
 
-#include <QAbstractItemModel>
+#include "codegen/treenode.pb.h"
+
+#include "RepeatedProtoModel.h"
+
 #include <QHash>
 #include <QList>
-
-#include <google/protobuf/message.h>
-
-#include "codegen/treenode.pb.h"
 
 using TypeCase = buffers::TreeNode::TypeCase;
 using TreeNode = buffers::TreeNode;
@@ -37,7 +36,9 @@ class ProtoModel : public QAbstractItemModel {
   bool setData(const QModelIndex &index, const QVariant &value, int role) override;
   QVariant data(int row, int column=0) const;
   QVariant data(const QModelIndex &index, int role) const override;
+  RepeatedProtoModel* GetRepeatedSubModel(int fieldNum);
   ProtoModel *GetSubModel(int fieldNum);
+  ProtoModel *GetSubModel(int fieldNum, int index);
   QString GetString(int fieldNum, int index);
   QModelIndex parent(const QModelIndex &index) const override;
   QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
@@ -45,12 +46,13 @@ class ProtoModel : public QAbstractItemModel {
   Qt::ItemFlags flags(const QModelIndex &index) const override;
 
  signals:
-  virtual void dataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight,
+  void dataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight,
                            const QVariant &oldValue = QVariant(0), const QVector<int> &roles = QVector<int>());
 
  private:
   QHash<int, QVariant> messages;  //where QVariant is ProtoModel*
   QHash<int, QList<QVariant>> repeatedMessages;
+  QHash<int, RepeatedProtoModel*> repeatedModels;
   bool dirty;
   google::protobuf::Message *protobuf;
   google::protobuf::Message *protobufBackup;

--- a/Models/ProtoModel.h
+++ b/Models/ProtoModel.h
@@ -12,7 +12,7 @@
 using TypeCase = buffers::TreeNode::TypeCase;
 using TreeNode = buffers::TreeNode;
 using Background = buffers::resources::Background;
-using Font =  buffers::resources::Font;
+using Font = buffers::resources::Font;
 using Object = buffers::resources::Object;
 using Path = buffers::resources::Path;
 using Room = buffers::resources::Room;
@@ -37,15 +37,19 @@ class ProtoModel : public QAbstractItemModel {
   bool setData(const QModelIndex &index, const QVariant &value, int role) override;
   QVariant data(int index) const;
   QVariant data(const QModelIndex &index, int role) const override;
-  ProtoModel* GetSubModel(int fieldNum);
+  ProtoModel *GetSubModel(int fieldNum);
   QString GetString(int fieldNum, int index);
   QModelIndex parent(const QModelIndex &index) const override;
   QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
   QModelIndex index(int row, int column = 0, const QModelIndex &parent = QModelIndex()) const override;
   Qt::ItemFlags flags(const QModelIndex &index) const override;
 
+ signals:
+  virtual void dataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight,
+                           const QVariant &oldValue = QVariant(0), const QVector<int> &roles = QVector<int>());
+
  private:
-  QHash<int, QVariant> messages; //where QVariant is ProtoModel*
+  QHash<int, QVariant> messages;  //where QVariant is ProtoModel*
   QHash<int, QList<QVariant>> repeatedMessages;
   bool dirty;
   google::protobuf::Message *protobuf;

--- a/Models/ProtoModel.h
+++ b/Models/ProtoModel.h
@@ -2,6 +2,8 @@
 #define RESOURCEMODEL_H
 
 #include <QAbstractItemModel>
+#include <QHash>
+#include <QList>
 
 #include <google/protobuf/message.h>
 
@@ -28,6 +30,8 @@ class ProtoModel : public QAbstractItemModel {
   Qt::ItemFlags flags(const QModelIndex &index) const override;
 
  private:
+  QHash<int, ProtoModel*> messages;
+  QHash<int, QList<QVariant>> repeatedMessages;
   bool dirty;
   google::protobuf::Message *protobuf;
   google::protobuf::Message *protobufBackup;

--- a/Models/ProtoModel.h
+++ b/Models/ProtoModel.h
@@ -30,7 +30,7 @@ class ProtoModel : public QAbstractItemModel {
   Qt::ItemFlags flags(const QModelIndex &index) const override;
 
  private:
-  QHash<int, ProtoModel*> messages;
+  QHash<int, QVariant> messages; //where QVariant is ProtoModel*
   QHash<int, QList<QVariant>> repeatedMessages;
   bool dirty;
   google::protobuf::Message *protobuf;

--- a/Models/RepeatedProtoModel.cpp
+++ b/Models/RepeatedProtoModel.cpp
@@ -12,6 +12,8 @@ int RepeatedProtoModel::rowCount(const QModelIndex & /*parent*/) const {
   return refl->FieldSize(*protobuf, field);
 }
 
+bool RepeatedProtoModel::empty() const { return this->rowCount() <= 0; }
+
 int RepeatedProtoModel::columnCount(const QModelIndex & /*parent*/) const {
   const Descriptor *desc = protobuf->GetDescriptor();
   return desc->field_count();
@@ -52,7 +54,7 @@ QVariant RepeatedProtoModel::data(const QModelIndex &index, int role) const {
 QModelIndex RepeatedProtoModel::parent(const QModelIndex &index) const { return QModelIndex(); }
 
 QVariant RepeatedProtoModel::headerData(int section, Qt::Orientation orientation, int role) const {
-  if (role != Qt::DisplayRole || orientation != Qt::Orientation::Horizontal) return QVariant();
+  if (this->empty() || role != Qt::DisplayRole || orientation != Qt::Orientation::Horizontal) return QVariant();
   ProtoModel *m = static_cast<ProtoModel *>(QObject::parent())->GetSubModel(field->number(), 0);
   return m->headerData(section, orientation, role);
 }

--- a/Models/RepeatedProtoModel.cpp
+++ b/Models/RepeatedProtoModel.cpp
@@ -31,7 +31,8 @@ QModelIndex RepeatedProtoModel::parent(const QModelIndex& index) const {
 }
 
 QVariant RepeatedProtoModel::headerData(int section, Qt::Orientation orientation, int role) const {
-  return "";
+  ProtoModel* m = static_cast<ProtoModel*>(QObject::parent())->GetSubModel(field->number(), 0);
+  return m->headerData(section, orientation, role);
 }
 
 QModelIndex RepeatedProtoModel::index(int row, int column, const QModelIndex &parent) const {

--- a/Models/RepeatedProtoModel.cpp
+++ b/Models/RepeatedProtoModel.cpp
@@ -1,18 +1,18 @@
 #include "RepeatedProtoModel.h"
-#include "ProtoModel.h"
 #include "Components/ArtManager.h"
-#include "ResourceModelMap.h"
 #include "MainWindow.h"
+#include "ProtoModel.h"
+#include "ResourceModelMap.h"
 
-RepeatedProtoModel::RepeatedProtoModel(Message *protobuf, const FieldDescriptor *field, ProtoModel *parent) :
-   QAbstractItemModel(parent), protobuf(protobuf), field(field) {}
+RepeatedProtoModel::RepeatedProtoModel(Message *protobuf, const FieldDescriptor *field, ProtoModel *parent)
+    : QAbstractItemModel(parent), protobuf(protobuf), field(field) {}
 
-int RepeatedProtoModel::rowCount(const QModelIndex& /*parent*/) const {
+int RepeatedProtoModel::rowCount(const QModelIndex & /*parent*/) const {
   const Reflection *refl = protobuf->GetReflection();
   return refl->FieldSize(*protobuf, field);
 }
 
-int RepeatedProtoModel::columnCount(const QModelIndex& /*parent*/) const {
+int RepeatedProtoModel::columnCount(const QModelIndex & /*parent*/) const {
   const Descriptor *desc = protobuf->GetDescriptor();
   return desc->field_count();
 }
@@ -24,28 +24,31 @@ QVariant RepeatedProtoModel::data(int row, int column) const {
 }
 
 QVariant RepeatedProtoModel::data(const QModelIndex &index, int role) const {
-  ProtoModel* m = static_cast<ProtoModel*>(QObject::parent())->GetSubModel(field->number(), index.row());
+  ProtoModel *m = static_cast<ProtoModel *>(QObject::parent())->GetSubModel(field->number(), index.row());
   QVariant data = m->data(index.column());
-  if (role == Qt::DecorationRole && field->name() == "instances" && index.column() == Room::Instance::kObjectTypeFieldNumber) {
+  if (role == Qt::DecorationRole && field->name() == "instances" &&
+      index.column() == Room::Instance::kObjectTypeFieldNumber) {
     auto obj = MainWindow::resourceMap->GetResourceByName(TreeNode::kObject, data.toString());
     if (obj != nullptr) {
       obj = obj->GetSubModel(TreeNode::kObjectFieldNumber);
-      ProtoModel* spr = MainWindow::resourceMap->GetResourceByName(TreeNode::kSprite, obj->data(Object::kSpriteNameFieldNumber).toString());
+      ProtoModel *spr = MainWindow::resourceMap->GetResourceByName(
+          TreeNode::kSprite, obj->data(Object::kSpriteNameFieldNumber).toString());
       if (spr != nullptr) {
         spr = spr->GetSubModel(TreeNode::kSpriteFieldNumber);
         return ArtManager::GetIcon(spr->GetString(Sprite::kSubimagesFieldNumber, 0));
       }
     }
-  } else if (role != Qt::DisplayRole && role != Qt::EditRole) return QVariant();
-  else return data;
+  } else if (role != Qt::DisplayRole && role != Qt::EditRole)
+    return QVariant();
+  else
+    return data;
 }
 
-QModelIndex RepeatedProtoModel::parent(const QModelIndex& index) const {
-  return QModelIndex();
-}
+QModelIndex RepeatedProtoModel::parent(const QModelIndex &index) const { return QModelIndex(); }
 
 QVariant RepeatedProtoModel::headerData(int section, Qt::Orientation orientation, int role) const {
-  ProtoModel* m = static_cast<ProtoModel*>(QObject::parent())->GetSubModel(field->number(), 0);
+  if (role != Qt::DisplayRole || orientation != Qt::Orientation::Horizontal) return QVariant();
+  ProtoModel *m = static_cast<ProtoModel *>(QObject::parent())->GetSubModel(field->number(), 0);
   return m->headerData(section, orientation, role);
 }
 

--- a/Models/RepeatedProtoModel.cpp
+++ b/Models/RepeatedProtoModel.cpp
@@ -33,15 +33,20 @@ QVariant RepeatedProtoModel::data(const QModelIndex &index, int role) const {
       obj = obj->GetSubModel(TreeNode::kObjectFieldNumber);
       ProtoModel *spr = MainWindow::resourceMap->GetResourceByName(
           TreeNode::kSprite, obj->data(Object::kSpriteNameFieldNumber).toString());
+      static const QSize pixmapSize(18, 18);
       if (spr != nullptr) {
         spr = spr->GetSubModel(TreeNode::kSpriteFieldNumber);
-        return ArtManager::GetIcon(spr->GetString(Sprite::kSubimagesFieldNumber, 0));
+        return ArtManager::GetIcon(spr->GetString(Sprite::kSubimagesFieldNumber, 0)).pixmap(pixmapSize);
+      } else {
+        return QIcon(":/actions/help.png").pixmap(pixmapSize);
       }
     }
   } else if (role != Qt::DisplayRole && role != Qt::EditRole)
     return QVariant();
   else
     return data;
+
+  return QVariant();
 }
 
 QModelIndex RepeatedProtoModel::parent(const QModelIndex &index) const { return QModelIndex(); }

--- a/Models/RepeatedProtoModel.cpp
+++ b/Models/RepeatedProtoModel.cpp
@@ -51,7 +51,7 @@ QVariant RepeatedProtoModel::data(const QModelIndex &index, int role) const {
   return QVariant();
 }
 
-QModelIndex RepeatedProtoModel::parent(const QModelIndex &index) const { return QModelIndex(); }
+QModelIndex RepeatedProtoModel::parent(const QModelIndex & /*index*/) const { return QModelIndex(); }
 
 QVariant RepeatedProtoModel::headerData(int section, Qt::Orientation orientation, int role) const {
   if (this->empty() || role != Qt::DisplayRole || orientation != Qt::Orientation::Horizontal) return QVariant();
@@ -59,7 +59,7 @@ QVariant RepeatedProtoModel::headerData(int section, Qt::Orientation orientation
   return m->headerData(section, orientation, role);
 }
 
-QModelIndex RepeatedProtoModel::index(int row, int column, const QModelIndex &parent) const {
+QModelIndex RepeatedProtoModel::index(int row, int column, const QModelIndex & /*parent*/) const {
   return createIndex(row, column);
 }
 

--- a/Models/RepeatedProtoModel.cpp
+++ b/Models/RepeatedProtoModel.cpp
@@ -1,0 +1,44 @@
+#include "RepeatedProtoModel.h"
+#include "ProtoModel.h"
+
+RepeatedProtoModel::RepeatedProtoModel(Message *protobuf, const FieldDescriptor *field, ProtoModel *parent) :
+   QAbstractItemModel(parent), protobuf(protobuf), field(field) {}
+
+int RepeatedProtoModel::rowCount(const QModelIndex& /*parent*/) const {
+  const Reflection *refl = protobuf->GetReflection();
+  return refl->FieldSize(*protobuf, field);
+}
+
+int RepeatedProtoModel::columnCount(const QModelIndex& /*parent*/) const {
+  const Descriptor *desc = protobuf->GetDescriptor();
+  return desc->field_count();
+}
+
+//bool RepeatedProtoModel::setData(const QModelIndex &index, const QVariant &value, int role) {}
+
+QVariant RepeatedProtoModel::data(int row, int column) const {
+  return data(this->index(row, column, QModelIndex()), Qt::DisplayRole);
+}
+
+QVariant RepeatedProtoModel::data(const QModelIndex &index, int role) const {
+  if (role != Qt::DisplayRole && role != Qt::EditRole) return QVariant();
+  ProtoModel* m = static_cast<ProtoModel*>(QObject::parent())->GetSubModel(field->number(), index.row());
+  return m->data(index.column());
+}
+
+QModelIndex RepeatedProtoModel::parent(const QModelIndex& index) const {
+  return QModelIndex();
+}
+
+QVariant RepeatedProtoModel::headerData(int section, Qt::Orientation orientation, int role) const {
+  return "";
+}
+
+QModelIndex RepeatedProtoModel::index(int row, int column, const QModelIndex &parent) const {
+  return createIndex(row, column);
+}
+
+Qt::ItemFlags RepeatedProtoModel::flags(const QModelIndex &index) const {
+  if (!index.isValid()) return nullptr;
+  return QAbstractItemModel::flags(index);
+}

--- a/Models/RepeatedProtoModel.h
+++ b/Models/RepeatedProtoModel.h
@@ -1,0 +1,36 @@
+#ifndef REPEATEDPROTOMODEL_H
+#define REPEATEDPROTOMODEL_H
+
+#include <QAbstractItemModel>
+
+#include <google/protobuf/message.h>
+
+using namespace google::protobuf;
+using CppType = FieldDescriptor::CppType;
+
+class ProtoModel;
+
+class RepeatedProtoModel : public QAbstractItemModel {
+  Q_OBJECT
+public:
+  RepeatedProtoModel(Message *protobuf, const FieldDescriptor *field, ProtoModel *parent);
+  int rowCount(const QModelIndex &parent = QModelIndex()) const override;
+  int columnCount(const QModelIndex &parent = QModelIndex()) const override;
+  //bool setData(const QModelIndex &index, const QVariant &value, int role) override;
+  QVariant data(int row, int column=0) const;
+  QVariant data(const QModelIndex &index, int role) const override;
+  QModelIndex parent(const QModelIndex &index) const override;
+  QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
+  QModelIndex index(int row, int column = 0, const QModelIndex &parent = QModelIndex()) const override;
+  Qt::ItemFlags flags(const QModelIndex &index) const override;
+
+ signals:
+  void dataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight,
+                           const QVariant &oldValue = QVariant(0), const QVector<int> &roles = QVector<int>());
+
+protected:
+  Message *protobuf;
+  const FieldDescriptor *field;
+};
+
+#endif // REPEATEDPROTOMODEL_H

--- a/Models/RepeatedProtoModel.h
+++ b/Models/RepeatedProtoModel.h
@@ -12,12 +12,13 @@ class ProtoModel;
 
 class RepeatedProtoModel : public QAbstractItemModel {
   Q_OBJECT
-public:
+ public:
   RepeatedProtoModel(Message *protobuf, const FieldDescriptor *field, ProtoModel *parent);
   int rowCount(const QModelIndex &parent = QModelIndex()) const override;
+  bool empty() const;
   int columnCount(const QModelIndex &parent = QModelIndex()) const override;
   //bool setData(const QModelIndex &index, const QVariant &value, int role) override;
-  QVariant data(int row, int column=0) const;
+  QVariant data(int row, int column = 0) const;
   QVariant data(const QModelIndex &index, int role) const override;
   QModelIndex parent(const QModelIndex &index) const override;
   QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
@@ -25,12 +26,12 @@ public:
   Qt::ItemFlags flags(const QModelIndex &index) const override;
 
  signals:
-  void dataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight,
-                           const QVariant &oldValue = QVariant(0), const QVector<int> &roles = QVector<int>());
+  void dataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight, const QVariant &oldValue = QVariant(0),
+                   const QVector<int> &roles = QVector<int>());
 
-protected:
+ protected:
   Message *protobuf;
   const FieldDescriptor *field;
 };
 
-#endif // REPEATEDPROTOMODEL_H
+#endif  // REPEATEDPROTOMODEL_H

--- a/Models/ResourceModelMap.cpp
+++ b/Models/ResourceModelMap.cpp
@@ -1,9 +1,11 @@
 #include "Models/ResourceModelMap.h"
+
 ResourceModelMap::ResourceModelMap(buffers::TreeNode *root) {
   recursiveBindRes(root);
 }
 
 void ResourceModelMap::recursiveBindRes(buffers::TreeNode *node) {
+
     for (int i=0; i < node->child_size(); ++i) {
       buffers::TreeNode* child = node->mutable_child(i);
       if (child->folder()) {

--- a/Models/ResourceModelMap.cpp
+++ b/Models/ResourceModelMap.cpp
@@ -1,5 +1,17 @@
 #include "Models/ResourceModelMap.h"
 
+using TypeCase = buffers::TreeNode::TypeCase;
+QHash<int, int> ResourceModelMap::_resTypeFields = {
+    { TypeCase::kSprite,     buffers::TreeNode::kSpriteFieldNumber     },
+    { TypeCase::kSound,      buffers::TreeNode::kSoundFieldNumber      },
+    { TypeCase::kBackground, buffers::TreeNode::kBackgroundFieldNumber },
+    { TypeCase::kPath,       buffers::TreeNode::kPathFieldNumber       },
+    { TypeCase::kFont,       buffers::TreeNode::kFontFieldNumber       },
+    { TypeCase::kTimeline,   buffers::TreeNode::kTimelineFieldNumber   },
+    { TypeCase::kObject,     buffers::TreeNode::kObjectFieldNumber     },
+    { TypeCase::kRoom,       buffers::TreeNode::kRoomFieldNumber       }
+};
+
 ResourceModelMap::ResourceModelMap(buffers::TreeNode *root) {
   recursiveBindRes(root);
 }
@@ -18,7 +30,9 @@ void ResourceModelMap::recursiveBindRes(buffers::TreeNode *node) {
 }
 
 ProtoModel* ResourceModelMap::GetResourceByName(int type, const QString& name) {
-  return _resources[type][name];
+  if (_resources[type].contains(name))
+    return _resources[type][name]->GetSubModel(_resTypeFields[type]);
+  else return nullptr;
 }
 
 ProtoModel* ResourceModelMap::GetResourceByName(int type, const std::string& name) {

--- a/Models/ResourceModelMap.cpp
+++ b/Models/ResourceModelMap.cpp
@@ -1,0 +1,24 @@
+#include "Models/ResourceModelMap.h"
+ResourceModelMap::ResourceModelMap(buffers::TreeNode *root) {
+  recursiveBindRes(root);
+}
+
+void ResourceModelMap::recursiveBindRes(buffers::TreeNode *node) {
+    for (int i=0; i < node->child_size(); ++i) {
+      buffers::TreeNode* child = node->mutable_child(i);
+      if (child->folder()) {
+        recursiveBindRes(child);
+        continue;
+      }
+
+      _resources[child->type_case()][QString::fromStdString(child->name())] = new ProtoModel(child, nullptr);
+    }
+}
+
+ProtoModel* ResourceModelMap::GetResourceByName(int type, const QString& name) {
+  return _resources[type][name];
+}
+
+ProtoModel* ResourceModelMap::GetResourceByName(int type, const std::string& name) {
+  return GetResourceByName(type, QString::fromStdString(name));
+}

--- a/Models/ResourceModelMap.cpp
+++ b/Models/ResourceModelMap.cpp
@@ -1,17 +1,5 @@
 #include "Models/ResourceModelMap.h"
 
-using TypeCase = buffers::TreeNode::TypeCase;
-QHash<int, int> ResourceModelMap::_resTypeFields = {
-    { TypeCase::kSprite,     buffers::TreeNode::kSpriteFieldNumber     },
-    { TypeCase::kSound,      buffers::TreeNode::kSoundFieldNumber      },
-    { TypeCase::kBackground, buffers::TreeNode::kBackgroundFieldNumber },
-    { TypeCase::kPath,       buffers::TreeNode::kPathFieldNumber       },
-    { TypeCase::kFont,       buffers::TreeNode::kFontFieldNumber       },
-    { TypeCase::kTimeline,   buffers::TreeNode::kTimelineFieldNumber   },
-    { TypeCase::kObject,     buffers::TreeNode::kObjectFieldNumber     },
-    { TypeCase::kRoom,       buffers::TreeNode::kRoomFieldNumber       }
-};
-
 ResourceModelMap::ResourceModelMap(buffers::TreeNode *root) {
   recursiveBindRes(root);
 }
@@ -31,7 +19,7 @@ void ResourceModelMap::recursiveBindRes(buffers::TreeNode *node) {
 
 ProtoModel* ResourceModelMap::GetResourceByName(int type, const QString& name) {
   if (_resources[type].contains(name))
-    return _resources[type][name]->GetSubModel(_resTypeFields[type]);
+    return _resources[type][name];
   else return nullptr;
 }
 

--- a/Models/ResourceModelMap.cpp
+++ b/Models/ResourceModelMap.cpp
@@ -1,4 +1,5 @@
 #include "Models/ResourceModelMap.h"
+#include "MainWindow.h"
 
 ResourceModelMap::ResourceModelMap(buffers::TreeNode *root, QObject* parent) : QObject(parent) {
   recursiveBindRes(root, this);
@@ -30,4 +31,19 @@ ProtoModel* ResourceModelMap::GetResourceByName(int type, const std::string& nam
 void ResourceModelMap::ResourceRenamed(TypeCase type, const QString& oldName, const QString& newName) {
   _resources[type][newName] = _resources[type][oldName];
   _resources[type][oldName] = nullptr;
+}
+
+const ProtoModel* GetObjectSprite(const std::string& objName) {
+  return GetObjectSprite(QString::fromStdString(objName));
+}
+
+const ProtoModel* GetObjectSprite(const QString& objName) {
+  ProtoModel* obj = MainWindow::resourceMap->GetResourceByName(TreeNode::kObject, objName);
+  if (!obj) return nullptr;
+  obj = obj->GetSubModel(TreeNode::kObjectFieldNumber);
+  if (!obj) return nullptr;
+  const QString spriteName = obj->data(Object::kSpriteNameFieldNumber).toString();
+  ProtoModel* spr = MainWindow::resourceMap->GetResourceByName(TreeNode::kSprite, spriteName);
+  if (spr) return spr->GetSubModel(TreeNode::kSpriteFieldNumber);
+  return nullptr;
 }

--- a/Models/ResourceModelMap.cpp
+++ b/Models/ResourceModelMap.cpp
@@ -1,19 +1,19 @@
 #include "Models/ResourceModelMap.h"
 
-ResourceModelMap::ResourceModelMap(buffers::TreeNode *root) {
-  recursiveBindRes(root);
+ResourceModelMap::ResourceModelMap(buffers::TreeNode *root, QObject* parent) : QObject(parent) {
+  recursiveBindRes(root, this);
 }
 
-void ResourceModelMap::recursiveBindRes(buffers::TreeNode *node) {
+void ResourceModelMap::recursiveBindRes(buffers::TreeNode *node, QObject* parent) {
 
     for (int i=0; i < node->child_size(); ++i) {
       buffers::TreeNode* child = node->mutable_child(i);
       if (child->folder()) {
-        recursiveBindRes(child);
+        recursiveBindRes(child, parent);
         continue;
       }
 
-      _resources[child->type_case()][QString::fromStdString(child->name())] = new ProtoModel(child, nullptr);
+      _resources[child->type_case()][QString::fromStdString(child->name())] = new ProtoModel(child, parent);
     }
 }
 
@@ -25,4 +25,9 @@ ProtoModel* ResourceModelMap::GetResourceByName(int type, const QString& name) {
 
 ProtoModel* ResourceModelMap::GetResourceByName(int type, const std::string& name) {
   return GetResourceByName(type, QString::fromStdString(name));
+}
+
+void ResourceModelMap::ResourceRenamed(TypeCase type, const QString& oldName, const QString& newName) {
+  _resources[type][newName] = _resources[type][oldName];
+  _resources[type][oldName] = nullptr;
 }

--- a/Models/ResourceModelMap.h
+++ b/Models/ResourceModelMap.h
@@ -16,7 +16,6 @@ public:
   ProtoModel* GetResourceByName(int type, const std::string& name);
 protected:
   void recursiveBindRes(buffers::TreeNode *node);
-  static QHash<int, int> _resTypeFields;
   QHash<int, QHash<QString, ProtoModel*>> _resources;
 };
 

--- a/Models/ResourceModelMap.h
+++ b/Models/ResourceModelMap.h
@@ -16,6 +16,7 @@ public:
   ProtoModel* GetResourceByName(int type, const std::string& name);
 protected:
   void recursiveBindRes(buffers::TreeNode *node);
+  static QHash<int, int> _resTypeFields;
   QHash<int, QHash<QString, ProtoModel*>> _resources;
 };
 

--- a/Models/ResourceModelMap.h
+++ b/Models/ResourceModelMap.h
@@ -22,4 +22,7 @@ protected:
   QHash<int, QHash<QString, ProtoModel*>> _resources;
 };
 
+const ProtoModel* GetObjectSprite(const std::string& objName);
+const ProtoModel* GetObjectSprite(const QString& objName);
+
 #endif // MODELMAP_H

--- a/Models/ResourceModelMap.h
+++ b/Models/ResourceModelMap.h
@@ -1,0 +1,22 @@
+#ifndef MODELMAP_H
+#define MODELMAP_H
+
+#include "ProtoModel.h"
+
+#include "codegen/treenode.pb.h"
+
+#include <QHash>
+#include <QVector>
+#include <string>
+
+class ResourceModelMap {
+public:
+  ResourceModelMap(buffers::TreeNode *root);
+  ProtoModel* GetResourceByName(int type, const QString& name);
+  ProtoModel* GetResourceByName(int type, const std::string& name);
+protected:
+  void recursiveBindRes(buffers::TreeNode *node);
+  QHash<int, QHash<QString, ProtoModel*>> _resources;
+};
+
+#endif // MODELMAP_H

--- a/Models/ResourceModelMap.h
+++ b/Models/ResourceModelMap.h
@@ -3,19 +3,22 @@
 
 #include "ProtoModel.h"
 
-#include "codegen/treenode.pb.h"
-
 #include <QHash>
 #include <QVector>
 #include <string>
 
-class ResourceModelMap {
+class ResourceModelMap : public QObject {
+  Q_OBJECT
 public:
-  ResourceModelMap(buffers::TreeNode *root);
+  ResourceModelMap(buffers::TreeNode *root, QObject* parent);
   ProtoModel* GetResourceByName(int type, const QString& name);
   ProtoModel* GetResourceByName(int type, const std::string& name);
+
+public slots:
+  void ResourceRenamed(TypeCase type, const QString& oldName, const QString& newName);
+
 protected:
-  void recursiveBindRes(buffers::TreeNode *node);
+  void recursiveBindRes(buffers::TreeNode *node, QObject* parent);
   QHash<int, QHash<QString, ProtoModel*>> _resources;
 };
 

--- a/Models/TreeModel.cpp
+++ b/Models/TreeModel.cpp
@@ -1,6 +1,7 @@
 #include "TreeModel.h"
 
 #include "Components/ArtManager.h"
+#include "Models/ResourceModelMap.h"
 
 #include <unordered_map>
 
@@ -48,6 +49,25 @@ QVariant TreeModel::data(const QModelIndex &index, int role) const {
 
     auto it = iconMap.find(item->type_case());
     if (it == iconMap.end()) return ArtManager::GetIcon("info");
+
+    if (item->type_case() == TypeCase::kSprite) {
+      QString spr = QString::fromStdString(item->sprite().subimages(0));
+      if (!spr.isEmpty()) return ArtManager::GetIcon(spr);
+    }
+
+    if (item->type_case() == TypeCase::kBackground) {
+      QString bkg = QString::fromStdString(item->background().image());
+      if (!bkg.isEmpty()) return ArtManager::GetIcon(bkg);
+    }
+
+    if (item->type_case() == TypeCase::kObject) {
+      const ProtoModel* sprModel = GetObjectSprite(item->name());
+      if (sprModel != nullptr) {
+        QString spr = sprModel->GetString(Sprite::kSubimagesFieldNumber, 0);
+        if (!spr.isEmpty()) return ArtManager::GetIcon(spr);
+      }
+    }
+
     const QIcon &icon = it->second;
     if (item->type_case() == TypeCase::kFolder && item->child_size() <= 0) {
       return icon.pixmap(icon.availableSizes().first(), QIcon::Disabled);

--- a/Models/TreeSortFilterProxyModel.cpp
+++ b/Models/TreeSortFilterProxyModel.cpp
@@ -1,0 +1,31 @@
+#include "TreeSortFilterProxyModel.h"
+#include "ProtoModel.h"
+
+TreeSortFilterProxyModel::TreeSortFilterProxyModel(QObject *parent) : QSortFilterProxyModel(parent) {}
+
+
+void TreeSortFilterProxyModel::SetFilterType(TreeNode::TypeCase type) {
+  filterType = type;
+}
+
+inline bool recHasType(TreeNode& n, TreeNode::TypeCase type) {
+  for (auto child : n.child()) {
+    if (child.type_case() == TreeNode::kFolder) return recHasType(child, type);
+    if (child.type_case() == type) return true;
+  }
+  return false;
+}
+
+bool TreeSortFilterProxyModel::filterAcceptsRow(int sourceRow, const QModelIndex &sourceParent) const {
+
+  if (filterType == TreeNode::TYPE_NOT_SET) return true;
+
+  QModelIndex idx = sourceModel()->index(sourceRow, 0, sourceParent);
+  buffers::TreeNode *item = static_cast<buffers::TreeNode *>(idx.internalPointer());
+
+  if (item->folder() && item->child_size() > 0) {
+    return recHasType(*item, filterType);
+  }
+
+  return item->type_case() == filterType;
+}

--- a/Models/TreeSortFilterProxyModel.h
+++ b/Models/TreeSortFilterProxyModel.h
@@ -1,0 +1,19 @@
+#ifndef TREESORTFILTERPROXYMODEL_H
+#define TREESORTFILTERPROXYMODEL_H
+
+#include "Models/ProtoModel.h"
+
+#include <QSortFilterProxyModel>
+
+class TreeSortFilterProxyModel : public QSortFilterProxyModel
+{
+public:
+  TreeSortFilterProxyModel(QObject *parent = nullptr);
+  void SetFilterType(TreeNode::TypeCase type);
+
+protected:
+  TreeNode::TypeCase filterType = TreeNode::TypeCase::TYPE_NOT_SET;
+  bool filterAcceptsRow(int sourceRow, const QModelIndex &sourceParent) const override;
+};
+
+#endif // TREESORTFILTERPROXYMODEL_H

--- a/Plugins/ServerPlugin.cpp
+++ b/Plugins/ServerPlugin.cpp
@@ -18,6 +18,8 @@
 using namespace grpc;
 using namespace buffers;
 
+using CompileMode = CompileRequest::CompileMode;
+
 class CompilerClient {
  public:
   explicit CompilerClient(std::shared_ptr<Channel> channel) : stub(Compiler::NewStub(channel)) {}
@@ -33,7 +35,7 @@ class CompilerClient {
     std::unique_ptr<ClientReader<CompileReply> > reader(stub->CompileBuffer(&context, request));
     CompileReply reply;
     while (reader->Read(&reply)) {
-      qDebug() << reply.message().c_str() << reply.progress();
+      //qDebug() << reply.message().c_str() << reply.progress();
     }
     Status status = reader->Finish();
   }
@@ -108,15 +110,15 @@ ServerPlugin::~ServerPlugin() {
   process->waitForFinished();
 }
 
-void ServerPlugin::Run() { compilerClient->CompileBuffer(mainWindow.Game(), CompileMode::RUN); };
+void ServerPlugin::Run() { compilerClient->CompileBuffer(mainWindow.Game(), CompileRequest::RUN); };
 
-void ServerPlugin::Debug() { compilerClient->CompileBuffer(mainWindow.Game(), CompileMode::DEBUG); };
+void ServerPlugin::Debug() { compilerClient->CompileBuffer(mainWindow.Game(), CompileRequest::DEBUG); };
 
 void ServerPlugin::CreateExecutable() {
   const QString& fileName =
       QFileDialog::getSaveFileName(&mainWindow, tr("Create Executable"), "", tr("Executable (*.exe);;All Files (*)"));
   if (!fileName.isEmpty())
-    compilerClient->CompileBuffer(mainWindow.Game(), CompileMode::COMPILE, fileName.toStdString());
+    compilerClient->CompileBuffer(mainWindow.Game(), CompileRequest::COMPILE, fileName.toStdString());
 };
 
 void ServerPlugin::HandleOutput() { emit OutputRead(process->readAllStandardOutput()); }

--- a/RadialGM.pro
+++ b/RadialGM.pro
@@ -83,7 +83,9 @@ SOURCES += \
     Models/ResourceModelMap.cpp \
     Models/ModelMapper.cpp \
     Models/RepeatedProtoModel.cpp \
-    Widgets/RoomRenderer.cpp
+    Widgets/RoomRenderer.cpp \
+    Components/QMenuView.cpp \
+    Models/TreeSortFilterProxyModel.cpp
 
 HEADERS += \
     MainWindow.h \
@@ -115,7 +117,10 @@ HEADERS += \
     Models/ResourceModelMap.h \
     Models/ModelMapper.h \
     Models/RepeatedProtoModel.h \
-    Widgets/RoomRenderer.h
+    Widgets/RoomRenderer.h \
+    Components/QMenuView.h \
+    Components/QMenuView_p.h \
+    Models/TreeSortFilterProxyModel.h
 
 FORMS += \
     MainWindow.ui \

--- a/RadialGM.pro
+++ b/RadialGM.pro
@@ -76,7 +76,8 @@ SOURCES += \
     Components/Utility.cpp \
     Plugins/RGMPlugin.cpp \
     Plugins/ServerPlugin.cpp \
-    Components/RecentFiles.cpp
+    Components/RecentFiles.cpp \
+    Models/ResourceModelMap.cpp
 
 HEADERS += \
     MainWindow.h \
@@ -102,7 +103,8 @@ HEADERS += \
     Widgets/CodeWidget.h \
     Components/RecentFiles.h \
     main.h \
-    Dialogs/PreferencesKeys.h
+    Dialogs/PreferencesKeys.h \
+    Models/ResourceModelMap.h
 
 FORMS += \
     MainWindow.ui \

--- a/RadialGM.pro
+++ b/RadialGM.pro
@@ -77,7 +77,8 @@ SOURCES += \
     Plugins/RGMPlugin.cpp \
     Plugins/ServerPlugin.cpp \
     Components/RecentFiles.cpp \
-    Models/ResourceModelMap.cpp
+    Models/ResourceModelMap.cpp \
+    Models/ModelMapper.cpp
 
 HEADERS += \
     MainWindow.h \
@@ -104,7 +105,8 @@ HEADERS += \
     Components/RecentFiles.h \
     main.h \
     Dialogs/PreferencesKeys.h \
-    Models/ResourceModelMap.h
+    Models/ResourceModelMap.h \
+    Models/ModelMapper.h
 
 FORMS += \
     MainWindow.ui \

--- a/RadialGM.pro
+++ b/RadialGM.pro
@@ -82,7 +82,8 @@ SOURCES += \
     Editors/ScriptEditor.cpp \
     Models/ResourceModelMap.cpp \
     Models/ModelMapper.cpp \
-    Models/RepeatedProtoModel.cpp
+    Models/RepeatedProtoModel.cpp \
+    Widgets/RoomRenderer.cpp
 
 HEADERS += \
     MainWindow.h \
@@ -113,7 +114,8 @@ HEADERS += \
     Editors/ScriptEditor.h \
     Models/ResourceModelMap.h \
     Models/ModelMapper.h \
-    Models/RepeatedProtoModel.h
+    Models/RepeatedProtoModel.h \
+    Widgets/RoomRenderer.h
 
 FORMS += \
     MainWindow.ui \

--- a/RadialGM.pro
+++ b/RadialGM.pro
@@ -78,7 +78,8 @@ SOURCES += \
     Plugins/ServerPlugin.cpp \
     Components/RecentFiles.cpp \
     Models/ResourceModelMap.cpp \
-    Models/ModelMapper.cpp
+    Models/ModelMapper.cpp \
+    Models/RepeatedProtoModel.cpp
 
 HEADERS += \
     MainWindow.h \
@@ -106,7 +107,8 @@ HEADERS += \
     main.h \
     Dialogs/PreferencesKeys.h \
     Models/ResourceModelMap.h \
-    Models/ModelMapper.h
+    Models/ModelMapper.h \
+    Models/RepeatedProtoModel.h
 
 FORMS += \
     MainWindow.ui \

--- a/Widgets/BackgroundRenderer.cpp
+++ b/Widgets/BackgroundRenderer.cpp
@@ -99,7 +99,7 @@ void BackgroundRenderer::paintEvent(QPaintEvent * /* event */) {
     }
 
     if (gridVertSpacing == 0) {
-      for (int y = gridVertOff; y <= pixmap.width(); y += gridHeight) painter.drawLine(0, y, pixmap.width(), y);
+      for (int y = gridVertOff; y <= pixmap.height(); y += gridHeight) painter.drawLine(0, y, pixmap.width(), y);
     }
   }
 }

--- a/Widgets/BackgroundRenderer.cpp
+++ b/Widgets/BackgroundRenderer.cpp
@@ -55,10 +55,10 @@ void BackgroundRenderer::WriteImage(QString fName, QString type) {
 QSize BackgroundRenderer::sizeHint() const { return QSize(pixmap.width(), pixmap.height()); }
 
 void BackgroundRenderer::SetZoom(qreal zoom) {
+  if (zoom > 3200) zoom = 3200;
+  if (zoom < 0.0625) zoom = 0.0625;
   this->zoom = zoom;
-  if (this->zoom > 3200) this->zoom = 3200;
-  if (this->zoom < 0.0625) this->zoom = 0.0625;
-  setFixedSize(static_cast<int>(pixmap.width() * this->zoom) + 1, static_cast<int>(pixmap.height() * this->zoom) + 1);
+  setFixedSize(static_cast<int>(pixmap.width() * zoom) + 1, static_cast<int>(pixmap.height() * zoom) + 1);
 }
 
 const qreal &BackgroundRenderer::GetZoom() const { return zoom; }

--- a/Widgets/BackgroundRenderer.cpp
+++ b/Widgets/BackgroundRenderer.cpp
@@ -71,7 +71,7 @@ void BackgroundRenderer::paintEvent(QPaintEvent * /* event */) {
   painter.fillRect(QRectF(0, 0, pixmap.width() * zoom, pixmap.height() * zoom), ArtManager::GetTransparenyBrush());
 
   painter.scale(zoom, zoom);
-  bool transparent = model->data(Background::kTransparentFieldNumber).toBool();
+  bool transparent = false;
   painter.drawPixmap(0, 0, (transparent) ? transparentPixmap : pixmap);
 
   bool gridVisible = model->data(Background::kUseAsTilesetFieldNumber).toBool();

--- a/Widgets/BackgroundRenderer.cpp
+++ b/Widgets/BackgroundRenderer.cpp
@@ -39,7 +39,7 @@ bool BackgroundRenderer::SetImage(QPixmap image) {
 }
 
 bool BackgroundRenderer::SetImage(QString fName) {
-  if (!SetImage(QPixmap(fName))) {
+  if (!SetImage(ArtManager::GetCachedPixmap(fName))) {
     QMessageBox::critical(this, tr("Failed to load image"), tr("Error opening: ") + fName, QMessageBox::Ok);
     return false;
   }

--- a/Widgets/BackgroundRenderer.cpp
+++ b/Widgets/BackgroundRenderer.cpp
@@ -64,42 +64,42 @@ void BackgroundRenderer::SetZoom(qreal zoom) {
 const qreal &BackgroundRenderer::GetZoom() const { return zoom; }
 
 void BackgroundRenderer::paintEvent(QPaintEvent * /* event */) {
-  if (model != nullptr) {
-    QPainter painter(this);
+  if (!model) return;
 
-    painter.fillRect(QRectF(0, 0, pixmap.width() * zoom, pixmap.height() * zoom), ArtManager::GetTransparenyBrush());
+  QPainter painter(this);
 
-    painter.scale(zoom, zoom);
-    bool transparent = model->data(Background::kTransparentFieldNumber).toBool();
-    painter.drawPixmap(0, 0, (transparent) ? transparentPixmap : pixmap);
+  painter.fillRect(QRectF(0, 0, pixmap.width() * zoom, pixmap.height() * zoom), ArtManager::GetTransparenyBrush());
 
-    bool gridVisible = model->data(Background::kUseAsTilesetFieldNumber).toBool();
-    int gridHorSpacing = model->data(Background::kHorizontalSpacingFieldNumber).toInt();
-    int gridVertSpacing = model->data(Background::kVerticalSpacingFieldNumber).toInt();
-    int gridHorOff = model->data(Background::kHorizontalOffsetFieldNumber).toInt();
-    int gridVertOff = model->data(Background::kVerticalOffsetFieldNumber).toInt();
-    int gridWidth = model->data(Background::kTileWidthFieldNumber).toInt();
-    int gridHeight = model->data(Background::kTileHeightFieldNumber).toInt();
+  painter.scale(zoom, zoom);
+  bool transparent = model->data(Background::kTransparentFieldNumber).toBool();
+  painter.drawPixmap(0, 0, (transparent) ? transparentPixmap : pixmap);
 
-    if (gridVisible) {
-      painter.setCompositionMode(QPainter::RasterOp_SourceXorDestination);
-      painter.setPen(QColor(0xff, 0xff, 0xff));
+  bool gridVisible = model->data(Background::kUseAsTilesetFieldNumber).toBool();
+  int gridHorSpacing = model->data(Background::kHorizontalSpacingFieldNumber).toInt();
+  int gridVertSpacing = model->data(Background::kVerticalSpacingFieldNumber).toInt();
+  int gridHorOff = model->data(Background::kHorizontalOffsetFieldNumber).toInt();
+  int gridVertOff = model->data(Background::kVerticalOffsetFieldNumber).toInt();
+  int gridWidth = model->data(Background::kTileWidthFieldNumber).toInt();
+  int gridHeight = model->data(Background::kTileHeightFieldNumber).toInt();
 
-      if (gridHorSpacing != 0 || gridVertSpacing != 0) {
-        for (int x = gridHorOff; x < pixmap.width(); x += gridWidth + gridHorSpacing) {
-          for (int y = gridVertOff; y < pixmap.height(); y += gridHeight + gridVertSpacing) {
-            painter.drawRect(x, y, gridWidth, gridHeight);
-          }
+  if (gridVisible) {
+    painter.setCompositionMode(QPainter::RasterOp_SourceXorDestination);
+    painter.setPen(QColor(0xff, 0xff, 0xff));
+
+    if (gridHorSpacing != 0 || gridVertSpacing != 0) {
+      for (int x = gridHorOff; x < pixmap.width(); x += gridWidth + gridHorSpacing) {
+        for (int y = gridVertOff; y < pixmap.height(); y += gridHeight + gridVertSpacing) {
+          painter.drawRect(x, y, gridWidth, gridHeight);
         }
       }
+    }
 
-      if (gridHorSpacing == 0) {
-        for (int x = gridHorOff; x <= pixmap.width(); x += gridWidth) painter.drawLine(x, 0, x, pixmap.height());
-      }
+    if (gridHorSpacing == 0) {
+      for (int x = gridHorOff; x <= pixmap.width(); x += gridWidth) painter.drawLine(x, 0, x, pixmap.height());
+    }
 
-      if (gridVertSpacing == 0) {
-        for (int y = gridVertOff; y <= pixmap.width(); y += gridHeight) painter.drawLine(0, y, pixmap.width(), y);
-      }
+    if (gridVertSpacing == 0) {
+      for (int y = gridVertOff; y <= pixmap.width(); y += gridHeight) painter.drawLine(0, y, pixmap.width(), y);
     }
   }
 }

--- a/Widgets/RoomRenderer.cpp
+++ b/Widgets/RoomRenderer.cpp
@@ -62,12 +62,13 @@ void RoomRenderer::paintTiles(QPainter& painter, Room* room) {
     if (!bkg) continue;
     bkg = bkg->GetSubModel(TreeNode::kBackgroundFieldNumber);
     if (!bkg) continue;
-
-    QString imgFile = bkg->data(Background::kImageFieldNumber).toString();
     int w = static_cast<int>(tile.width());
     int h = static_cast<int>(tile.height());
 
-    QPixmap pixmap(imgFile);
+    QString imgFile = bkg->data(Background::kImageFieldNumber).toString();
+    QPixmap pixmap = ArtManager::GetCachedPixmap(imgFile);
+    if (pixmap.isNull()) continue;
+
     QRect dest(tile.x(), tile.y(), w, h);
     QRect src(tile.xoffset(), tile.yoffset(), w, h);
     const QTransform transform = painter.transform();
@@ -84,11 +85,13 @@ void RoomRenderer::paintBackgrounds(QPainter& painter, Room* room, bool foregrou
     if (!bkgRes) continue;
     bkgRes = bkgRes->GetSubModel(TreeNode::kBackgroundFieldNumber);
     if (!bkgRes) continue;
-
-    QString imgFile = bkgRes->data(Background::kImageFieldNumber).toString();
     int w = bkgRes->data(Background::kWidthFieldNumber).toInt();
     int h = bkgRes->data(Background::kHeightFieldNumber).toInt();
-    QPixmap pixmap(imgFile);
+
+    QString imgFile = bkgRes->data(Background::kImageFieldNumber).toString();
+    QPixmap pixmap = ArtManager::GetCachedPixmap(imgFile);
+    if (pixmap.isNull()) continue;
+
     QRect dest(bkg.x(), bkg.y(), w, h);
     QRect src(0, 0, w, h);
     const QTransform transform = painter.transform();
@@ -148,8 +151,9 @@ void RoomRenderer::paintInstances(QPainter& painter, Room* room) {
     }
 
     if (imgFile.isEmpty()) imgFile = "object";
+    QPixmap pixmap = ArtManager::GetCachedPixmap(imgFile);
+    if (pixmap.isNull()) continue;
 
-    QPixmap pixmap(imgFile);
     QRect dest(inst.x(), inst.y(), w, h);
     const QTransform transform = painter.transform();
     painter.translate(-xoff, -yoff);

--- a/Widgets/RoomRenderer.cpp
+++ b/Widgets/RoomRenderer.cpp
@@ -63,13 +63,14 @@ void RoomRenderer::paintTiles(QPainter& painter, Room* room) {
     QString imgFile = bkg->data(Background::kImageFieldNumber).toString();
     int w = static_cast<int>(tile.width());
     int h = static_cast<int>(tile.height());
-    /*
-                                     auto item = scene->addPixmap(ArtManager::GetIcon(imgFile).pixmap(w, h));
-                                     item->setPos(tile.x(), tile.y());
-                                     item->setOffset(-tile.xoffset(), -tile.yoffset());
-                                     qreal xscale = (tile.has_xscale()) ? tile.xscale() : 1;
-                                     qreal yscale = (tile.has_yscale()) ? tile.yscale() : 1;
-                                     item->setTransform(item->transform().scale(xscale, yscale));*/
+
+    QPixmap pixmap(imgFile);
+    QRect dest(tile.x(), tile.y(), w, h);
+    QRect src(tile.xoffset(), tile.yoffset(), w, h);
+    const QTransform transform = painter.transform();
+    painter.scale(tile.has_xscale() ? tile.xscale() : 1, tile.has_yscale() ? tile.yscale() : 1);
+    painter.drawPixmap(dest, pixmap, src);
+    painter.setTransform(transform);
   }
 }
 
@@ -151,15 +152,14 @@ void RoomRenderer::paintInstances(QPainter& painter, Room* room) {
 
     if (imgFile.isEmpty()) imgFile = "object";
 
-    /*
-                                         auto item = scene->addPixmap();
-                                         item->setPos(inst.x(), inst.y());
-                                         item->setOffset(-xoff, -yoff);
-                                         item->setRotation(inst.rotation());
-                                         item->setTransform(item->transform().scale(inst.xscale(), inst.yscale()));*/
-    QPixmap pixmap = ArtManager::GetIcon(imgFile).pixmap(w, h);
-    QRect dest(inst.x() - xoff, inst.y() - yoff, w * inst.xscale(), h * inst.yscale());
+    QPixmap pixmap(imgFile);
+    QRect dest(inst.x(), inst.y(), w, h);
+    const QTransform transform = painter.transform();
+    painter.translate(-xoff, -yoff);
+    painter.rotate(inst.rotation());
+    painter.scale(inst.xscale(), inst.yscale());
     painter.drawPixmap(dest, pixmap);
+    painter.setTransform(transform);
   }
 }
 

--- a/Widgets/RoomRenderer.cpp
+++ b/Widgets/RoomRenderer.cpp
@@ -69,8 +69,8 @@ void RoomRenderer::paintTiles(QPainter& painter, Room* room) {
     QPixmap pixmap = ArtManager::GetCachedPixmap(imgFile);
     if (pixmap.isNull()) continue;
 
-    QRect dest(tile.x(), tile.y(), w, h);
-    QRect src(tile.xoffset(), tile.yoffset(), w, h);
+    QRectF dest(tile.x(), tile.y(), w, h);
+    QRectF src(tile.xoffset(), tile.yoffset(), w, h);
     const QTransform transform = painter.transform();
     painter.scale(tile.has_xscale() ? tile.xscale() : 1, tile.has_yscale() ? tile.yscale() : 1);
     painter.drawPixmap(dest, pixmap, src);
@@ -92,20 +92,20 @@ void RoomRenderer::paintBackgrounds(QPainter& painter, Room* room, bool foregrou
     QPixmap pixmap = ArtManager::GetCachedPixmap(imgFile);
     if (pixmap.isNull()) continue;
 
-    QRect dest(bkg.x(), bkg.y(), w, h);
-    QRect src(0, 0, w, h);
+    QRectF dest(bkg.x(), bkg.y(), w, h);
+    QRectF src(0, 0, w, h);
     const QTransform transform = painter.transform();
     if (bkg.stretch()) {
       painter.scale(room->width() / qreal(w), room->height() / qreal(h));
     }
     if (bkg.htiled()) {
       dest.setX(0);
-      dest.setWidth(room->width());
+      dest.setWidth(static_cast<int>(room->width()));
       src.setX(bkg.x());
     }
     if (bkg.vtiled()) {
       dest.setY(0);
-      dest.setHeight(room->height());
+      dest.setHeight(static_cast<int>(room->height()));
       src.setY(bkg.y());
     }
     painter.fillRect(dest, QBrush(pixmap));
@@ -154,12 +154,13 @@ void RoomRenderer::paintInstances(QPainter& painter, Room* room) {
     QPixmap pixmap = ArtManager::GetCachedPixmap(imgFile);
     if (pixmap.isNull()) continue;
 
-    QRect dest(inst.x(), inst.y(), w, h);
+    QRectF dest(inst.x(), inst.y(), w, h);
+    QRectF src(0, 0, w, h);
     const QTransform transform = painter.transform();
     painter.translate(-xoff, -yoff);
     painter.rotate(inst.rotation());
     painter.scale(inst.xscale(), inst.yscale());
-    painter.drawPixmap(dest, pixmap);
+    painter.drawPixmap(dest, pixmap, src);
     painter.setTransform(transform);
   }
 }
@@ -173,7 +174,7 @@ void RoomRenderer::paintGrid(QPainter& painter, Room* room) {
   int gridWidth = 16;
   int gridHeight = 16;
 
-  unsigned roomWidth = room->width(), roomHeight = room->height();
+  int roomWidth = static_cast<int>(room->width()), roomHeight = static_cast<int>(room->height());
 
   if (gridVisible) {
     painter.setCompositionMode(QPainter::RasterOp_SourceXorDestination);
@@ -192,7 +193,7 @@ void RoomRenderer::paintGrid(QPainter& painter, Room* room) {
     }
 
     if (gridVertSpacing == 0) {
-      for (int y = gridVertOff; y <= roomWidth; y += gridHeight) painter.drawLine(0, y, roomWidth, y);
+      for (int y = gridVertOff; y <= roomHeight; y += gridHeight) painter.drawLine(0, y, roomWidth, y);
     }
   }
 }

--- a/Widgets/RoomRenderer.cpp
+++ b/Widgets/RoomRenderer.cpp
@@ -133,24 +133,16 @@ void RoomRenderer::paintInstances(QPainter& painter, Room* room) {
     int xoff = 0;
     int yoff = 0;
 
-    ProtoModel* obj = MainWindow::resourceMap->GetResourceByName(TreeNode::kObject, inst.object_type());
-    if (!obj) continue;
-    obj = obj->GetSubModel(TreeNode::kObjectFieldNumber);
-    if (!obj) continue;
-    const QString spriteName = obj->data(Object::kSpriteNameFieldNumber).toString();
-    ProtoModel* spr = MainWindow::resourceMap->GetResourceByName(TreeNode::kSprite, spriteName);
-    if (spr) {
-      spr = spr->GetSubModel(TreeNode::kSpriteFieldNumber);
-      if (spr) {
-        imgFile = spr->GetString(Sprite::kSubimagesFieldNumber, 0);
-        w = spr->data(Sprite::kWidthFieldNumber).toInt();
-        h = spr->data(Sprite::kHeightFieldNumber).toInt();
-        xoff = spr->data(Sprite::kOriginXFieldNumber).toInt();
-        yoff = spr->data(Sprite::kOriginYFieldNumber).toInt();
-      }
+    const ProtoModel* spr = GetObjectSprite(inst.object_type());
+    if (spr == nullptr) imgFile = "object";
+    else {
+      imgFile = spr->GetString(Sprite::kSubimagesFieldNumber, 0);
+      w = spr->data(Sprite::kWidthFieldNumber).toInt();
+      h = spr->data(Sprite::kHeightFieldNumber).toInt();
+      xoff = spr->data(Sprite::kOriginXFieldNumber).toInt();
+      yoff = spr->data(Sprite::kOriginYFieldNumber).toInt();
     }
 
-    if (imgFile.isEmpty()) imgFile = "object";
     QPixmap pixmap = ArtManager::GetCachedPixmap(imgFile);
     if (pixmap.isNull()) continue;
 

--- a/Widgets/RoomRenderer.cpp
+++ b/Widgets/RoomRenderer.cpp
@@ -120,9 +120,9 @@ void RoomRenderer::paintInstances(QPainter& painter, Room* room) {
     return false;
   });
   for (auto inst : sortedInstances) {
-    QString imgFile;
-    int w = 18;
-    int h = 18;
+    QString imgFile = ":/actions/help.png";
+    int w = 16;
+    int h = 16;
     int xoff = 0;
     int yoff = 0;
 
@@ -132,14 +132,16 @@ void RoomRenderer::paintInstances(QPainter& painter, Room* room) {
     if (!obj) continue;
     ProtoModel* spr = MainWindow::resourceMap->GetResourceByName(TreeNode::kSprite,
                                                                  obj->data(Object::kSpriteNameFieldNumber).toString());
-    if (!spr) continue;
-    spr = spr->GetSubModel(TreeNode::kSpriteFieldNumber);
-    if (!spr) continue;
-    imgFile = spr->GetString(Sprite::kSubimagesFieldNumber, 0);
-    w = spr->data(Sprite::kWidthFieldNumber).toInt();
-    h = spr->data(Sprite::kHeightFieldNumber).toInt();
-    xoff = spr->data(Sprite::kOriginXFieldNumber).toInt();
-    yoff = spr->data(Sprite::kOriginYFieldNumber).toInt();
+    if (spr) {
+      spr = spr->GetSubModel(TreeNode::kSpriteFieldNumber);
+      if (spr) {
+        imgFile = spr->GetString(Sprite::kSubimagesFieldNumber, 0);
+        w = spr->data(Sprite::kWidthFieldNumber).toInt();
+        h = spr->data(Sprite::kHeightFieldNumber).toInt();
+        xoff = spr->data(Sprite::kOriginXFieldNumber).toInt();
+        yoff = spr->data(Sprite::kOriginYFieldNumber).toInt();
+      }
+    }
 
     if (imgFile.isEmpty()) imgFile = "object";
 

--- a/Widgets/RoomRenderer.cpp
+++ b/Widgets/RoomRenderer.cpp
@@ -58,9 +58,11 @@ void RoomRenderer::paintTiles(QPainter& painter, Room* room) {
   std::sort(sortedTiles.begin(), sortedTiles.end(),
             [](const Room::Tile& a, const Room::Tile& b) { return a.depth() > b.depth(); });
   for (auto tile : sortedTiles) {
-    ProtoModel* bkg = MainWindow::resourceMap->GetResourceByName(TreeNode::kBackground, tile.background_name())
-                          ->GetSubModel(TreeNode::kBackgroundFieldNumber);
+    ProtoModel* bkg = MainWindow::resourceMap->GetResourceByName(TreeNode::kBackground, tile.background_name());
     if (!bkg) continue;
+    bkg = bkg->GetSubModel(TreeNode::kBackgroundFieldNumber);
+    if (!bkg) continue;
+
     QString imgFile = bkg->data(Background::kImageFieldNumber).toString();
     int w = static_cast<int>(tile.width());
     int h = static_cast<int>(tile.height());
@@ -78,9 +80,11 @@ void RoomRenderer::paintTiles(QPainter& painter, Room* room) {
 void RoomRenderer::paintBackgrounds(QPainter& painter, Room* room, bool foregrounds) {
   for (auto bkg : room->backgrounds()) {  //TODO: need to draw last if foreground
     if (!bkg.visible() || bkg.foreground() != foregrounds) continue;
-    ProtoModel* bkgRes = MainWindow::resourceMap->GetResourceByName(TreeNode::kBackground, bkg.background_name())
-                             ->GetSubModel(TreeNode::kBackgroundFieldNumber);
+    ProtoModel* bkgRes = MainWindow::resourceMap->GetResourceByName(TreeNode::kBackground, bkg.background_name());
     if (!bkgRes) continue;
+    bkgRes = bkgRes->GetSubModel(TreeNode::kBackgroundFieldNumber);
+    if (!bkgRes) continue;
+
     QString imgFile = bkgRes->data(Background::kImageFieldNumber).toString();
     int w = bkgRes->data(Background::kWidthFieldNumber).toInt();
     int h = bkgRes->data(Background::kHeightFieldNumber).toInt();
@@ -130,8 +134,8 @@ void RoomRenderer::paintInstances(QPainter& painter, Room* room) {
     if (!obj) continue;
     obj = obj->GetSubModel(TreeNode::kObjectFieldNumber);
     if (!obj) continue;
-    ProtoModel* spr = MainWindow::resourceMap->GetResourceByName(TreeNode::kSprite,
-                                                                 obj->data(Object::kSpriteNameFieldNumber).toString());
+    const QString spriteName = obj->data(Object::kSpriteNameFieldNumber).toString();
+    ProtoModel* spr = MainWindow::resourceMap->GetResourceByName(TreeNode::kSprite, spriteName);
     if (spr) {
       spr = spr->GetSubModel(TreeNode::kSpriteFieldNumber);
       if (spr) {

--- a/Widgets/RoomRenderer.cpp
+++ b/Widgets/RoomRenderer.cpp
@@ -1,0 +1,180 @@
+#include "RoomRenderer.h"
+#include "Components/ArtManager.h"
+#include "MainWindow.h"
+
+#include <QPainter>
+
+RoomRenderer::RoomRenderer(QWidget* parent) : QWidget(parent), model(nullptr), zoom(1) {}
+
+void RoomRenderer::SetResourceModel(ProtoModel* model) { this->model = model; }
+
+QSize RoomRenderer::sizeHint() const {
+  if (!model) return QSize();
+  unsigned roomWidth = model->data(Room::kWidthFieldNumber).toUInt(),
+           roomHeight = model->data(Room::kHeightFieldNumber).toUInt();
+  return QSize(roomWidth, roomHeight);
+}
+
+void RoomRenderer::SetZoom(qreal zoom) {
+  if (zoom > 3200) zoom = 3200;
+  if (zoom < 0.0625) zoom = 0.0625;
+  this->zoom = zoom;
+  unsigned roomWidth = model->data(Room::kWidthFieldNumber).toUInt(),
+           roomHeight = model->data(Room::kHeightFieldNumber).toUInt();
+  setFixedSize(static_cast<unsigned>(roomWidth * zoom) + 1, static_cast<unsigned>(roomHeight * zoom) + 1);
+}
+
+const qreal& RoomRenderer::GetZoom() const { return zoom; }
+
+void RoomRenderer::paintEvent(QPaintEvent* /* event */) {
+  if (!model) return;
+  QPainter painter(this);
+  unsigned roomWidth = model->data(Room::kWidthFieldNumber).toUInt(),
+           roomHeight = model->data(Room::kHeightFieldNumber).toUInt();
+
+  painter.scale(4, 4);
+  painter.fillRect(this->rect(), ArtManager::GetTransparenyBrush());
+  painter.scale(0.25, 0.25);
+
+  painter.scale(zoom, zoom);
+
+  Room* room = static_cast<Room*>(model->GetBuffer());
+  QColor roomColor = Qt::transparent;
+  if (room->show_color()) roomColor = room->color();
+  painter.fillRect(QRectF(0, 0, room->width() * zoom, room->height() * zoom), QBrush(roomColor));
+
+  for (auto bkg : room->backgrounds()) {  //TODO: need to draw last if foreground
+    if (bkg.visible()) {
+      ProtoModel* bkgRes = MainWindow::resourceMap->GetResourceByName(TreeNode::kBackground, bkg.background_name())
+                               ->GetSubModel(TreeNode::kBackgroundFieldNumber);
+      if (!bkgRes) continue;
+      QString imgFile = bkgRes->data(Background::kImageFieldNumber).toString();
+      int w = bkgRes->data(Background::kWidthFieldNumber).toInt();
+      int h = bkgRes->data(Background::kHeightFieldNumber).toInt();
+      /*
+      auto item = scene->addPixmap(ArtManager::GetIcon(imgFile).pixmap(w, h));
+      item->setPos(bkg.x(), bkg.y());
+      if (bkg.stretch()) {
+        item->setTransform(item->transform().scale(room->width() / qreal(w), room->height() / qreal(h)));
+      } else {
+        if (bkg.htiled() && bkg.vtiled()) {
+          for (int i = 0; i < static_cast<int>(room->width()); i += w) {
+            for (int j = 0; j < static_cast<int>(room->height()); j += h) {
+              auto b = scene->addPixmap(ArtManager::GetIcon(imgFile).pixmap(w, h));
+              b->setPos(i, j);
+            }
+          }
+        } else {
+          if (bkg.htiled()) {
+            for (int i = w; i < static_cast<int>(room->width()); i += w) {
+              auto b = scene->addPixmap(ArtManager::GetIcon(imgFile).pixmap(w, h));
+              b->setPos(i, 0);
+            }
+          }
+          if (bkg.vtiled()) {
+            for (int i = h; i < static_cast<int>(room->height()); i += h) {
+              auto b = scene->addPixmap(ArtManager::GetIcon(imgFile).pixmap(w, h));
+              b->setPos(0, i);
+            }
+          }
+        }
+      }*/
+    }
+  }
+
+  google::protobuf::RepeatedField<Room::Tile> sortedTiles(room->mutable_tiles()->begin(), room->mutable_tiles()->end());
+
+  std::sort(sortedTiles.begin(), sortedTiles.end(),
+            [](const Room::Tile& a, const Room::Tile& b) { return a.depth() > b.depth(); });
+  for (auto tile : sortedTiles) {
+    ProtoModel* bkg = MainWindow::resourceMap->GetResourceByName(TreeNode::kBackground, tile.background_name())
+                          ->GetSubModel(TreeNode::kBackgroundFieldNumber);
+    if (!bkg) continue;
+    QString imgFile = bkg->data(Background::kImageFieldNumber).toString();
+    int w = static_cast<int>(tile.width());
+    int h = static_cast<int>(tile.height());
+    /*
+    auto item = scene->addPixmap(ArtManager::GetIcon(imgFile).pixmap(w, h));
+    item->setPos(tile.x(), tile.y());
+    item->setOffset(-tile.xoffset(), -tile.yoffset());
+    qreal xscale = (tile.has_xscale()) ? tile.xscale() : 1;
+    qreal yscale = (tile.has_yscale()) ? tile.yscale() : 1;
+    item->setTransform(item->transform().scale(xscale, yscale));*/
+  }
+
+  google::protobuf::RepeatedField<Room::Instance> sortedInstances(room->mutable_instances()->begin(),
+                                                                  room->mutable_instances()->end());
+
+  std::sort(sortedInstances.begin(), sortedInstances.end(), [](const Room::Instance& a, const Room::Instance& b) {
+    ProtoModel* objA = MainWindow::resourceMap->GetResourceByName(TreeNode::kObject, a.object_type())
+                           ->GetSubModel(TreeNode::kObjectFieldNumber);
+    ProtoModel* objB = MainWindow::resourceMap->GetResourceByName(TreeNode::kObject, b.object_type())
+                           ->GetSubModel(TreeNode::kObjectFieldNumber);
+    if (objA != nullptr && objB != nullptr)
+      return objA->data(Object::kDepthFieldNumber) > objB->data(Object::kDepthFieldNumber);
+    return false;
+  });
+  for (auto inst : sortedInstances) {
+    QString imgFile;
+    int w = 18;
+    int h = 18;
+    int xoff = 0;
+    int yoff = 0;
+
+    ProtoModel* obj = MainWindow::resourceMap->GetResourceByName(TreeNode::kObject, inst.object_type());
+    if (!obj) continue;
+    obj = obj->GetSubModel(TreeNode::kObjectFieldNumber);
+    if (!obj) continue;
+    ProtoModel* spr = MainWindow::resourceMap->GetResourceByName(TreeNode::kSprite,
+                                                                 obj->data(Object::kSpriteNameFieldNumber).toString());
+    if (!spr) continue;
+    spr = spr->GetSubModel(TreeNode::kSpriteFieldNumber);
+    if (!spr) continue;
+    imgFile = spr->GetString(Sprite::kSubimagesFieldNumber, 0);
+    w = spr->data(Sprite::kWidthFieldNumber).toInt();
+    h = spr->data(Sprite::kHeightFieldNumber).toInt();
+    xoff = spr->data(Sprite::kOriginXFieldNumber).toInt();
+    yoff = spr->data(Sprite::kOriginYFieldNumber).toInt();
+
+    if (imgFile.isEmpty()) imgFile = "object";
+
+    /*
+    auto item = scene->addPixmap();
+    item->setPos(inst.x(), inst.y());
+    item->setOffset(-xoff, -yoff);
+    item->setRotation(inst.rotation());
+    item->setTransform(item->transform().scale(inst.xscale(), inst.yscale()));*/
+    QPixmap pixmap = ArtManager::GetIcon(imgFile).pixmap(w, h);
+    QRect dest(inst.x() - xoff, inst.y() - yoff, w * inst.xscale(), h * inst.yscale());
+    painter.drawPixmap(dest, pixmap);
+  }
+
+  bool gridVisible = true;
+  int gridHorSpacing = 0;
+  int gridVertSpacing = 0;
+  int gridHorOff = 0;
+  int gridVertOff = 0;
+  int gridWidth = 16;
+  int gridHeight = 16;
+
+  if (gridVisible) {
+    painter.setCompositionMode(QPainter::RasterOp_SourceXorDestination);
+    painter.setPen(QColor(0xff, 0xff, 0xff));
+
+    if (gridHorSpacing != 0 || gridVertSpacing != 0) {
+      for (int x = gridHorOff; x < roomWidth; x += gridWidth + gridHorSpacing) {
+        for (int y = gridVertOff; y < roomHeight; y += gridHeight + gridVertSpacing) {
+          painter.drawRect(x, y, gridWidth, gridHeight);
+        }
+      }
+    }
+
+    if (gridHorSpacing == 0) {
+      for (int x = gridHorOff; x <= roomWidth; x += gridWidth) painter.drawLine(x, 0, x, roomHeight);
+    }
+
+    if (gridVertSpacing == 0) {
+      for (int y = gridVertOff; y <= roomWidth; y += gridHeight) painter.drawLine(0, y, roomWidth, y);
+    }
+  }
+}

--- a/Widgets/RoomRenderer.cpp
+++ b/Widgets/RoomRenderer.cpp
@@ -32,10 +32,6 @@ void RoomRenderer::paintEvent(QPaintEvent* /* event */) {
   unsigned roomWidth = model->data(Room::kWidthFieldNumber).toUInt(),
            roomHeight = model->data(Room::kHeightFieldNumber).toUInt();
 
-  painter.scale(4, 4);
-  painter.fillRect(this->rect(), ArtManager::GetTransparenyBrush());
-  painter.scale(0.25, 0.25);
-
   painter.scale(zoom, zoom);
 
   Room* room = static_cast<Room*>(model->GetBuffer());

--- a/Widgets/RoomRenderer.h
+++ b/Widgets/RoomRenderer.h
@@ -23,6 +23,11 @@ class RoomRenderer : public QWidget {
   ProtoModel *model;
   QPixmap transparentPixmap;
   qreal zoom;
+
+  void paintTiles(QPainter &painter, Room *room);
+  void paintBackgrounds(QPainter &painter, Room *room);
+  void paintInstances(QPainter &painter, Room *room);
+  void paintGrid(QPainter &painter, Room *room);
 };
 
 #endif  // ROOMRENDERER_H

--- a/Widgets/RoomRenderer.h
+++ b/Widgets/RoomRenderer.h
@@ -1,0 +1,28 @@
+#ifndef ROOMRENDERER_H
+#define ROOMRENDERER_H
+
+#include "Models/ProtoModel.h"
+
+#include <QObject>
+#include <QWidget>
+
+class RoomRenderer : public QWidget {
+  Q_OBJECT
+
+ public:
+  explicit RoomRenderer(QWidget *parent);
+  QSize sizeHint() const override;
+  void SetResourceModel(ProtoModel *model);
+  void SetZoom(qreal zoom);
+  const qreal &GetZoom() const;
+
+ protected:
+  void paintEvent(QPaintEvent *event) override;
+
+ private:
+  ProtoModel *model;
+  QPixmap transparentPixmap;
+  qreal zoom;
+};
+
+#endif  // ROOMRENDERER_H

--- a/Widgets/RoomRenderer.h
+++ b/Widgets/RoomRenderer.h
@@ -25,7 +25,7 @@ class RoomRenderer : public QWidget {
   qreal zoom;
 
   void paintTiles(QPainter &painter, Room *room);
-  void paintBackgrounds(QPainter &painter, Room *room);
+  void paintBackgrounds(QPainter &painter, Room *room, bool foregrounds = false);
   void paintInstances(QPainter &painter, Room *room);
   void paintGrid(QPainter &painter, Room *room);
 };


### PR DESCRIPTION
Alright so the goal here was to make it possible to map to submodels easily and this was used to implement some basic room editor functionality.

### Summary of Changes
* Added a 500mb pixmap cache to the `ArtManager` class for caching large images used by the background, sprite, and room renderering widgets. That way they don't each load their own copy. Later it can be expanded with a file change monitor to automatically reload the pixmaps when they are changed on disk.
* Changed ArtManager::GetIcon to load more icons that have not yet been loaded.
* Used `QMenuView` widget by Ulrich Van Den Hekke to implement resource picker.
* Changed `BackgroundEditor` and `ScriptEditor` to use the renamed default mapper of `BaseEditor` which distinguishes it from the mapper used for mapping the resource's name in the tree model.
* Changed `BackgroundEditor::dataChanged` to forward itself to the `BaseEditor` base event.
* Made the `BackgroundEditor` save button mutate the dirty state of the default resource mapper and not the dirty state of its model.
* Changed the `BaseEditor` close event to check the dirty state of the default resource mapper and not the dirty state of its model. When not saving changes it also now clears the mappings to its tree node mapper. Finally, it will otherwise mark its mapper as not dirty now instead of its model.
* Added a map of resource type cases to to tree node field numbers to `BaseEditor.h` to facilitate looking up the submodel of a tree node.
* Added a `ResourceRenamed` signal to `BaseEditor` that is emitted when the tree node of the resource is renamed.
* Used the tree node mapper of `BaseEditor` in the room editor to map the name field on the settings tab.
* Used the resource mapper of `BaseEditor` in the room editor to map the rest of the settings that are fields of the root room resource proto.
* Added a new mapper in the room editor to map the view settings on the views tab.
* Made the current view combo box change the currently mapped view resource on the views tab.
* Tied the selection of assets in the assets list to the model shown in the asset properties view. Later this same selection model needs to be shared with the RoomRenderer as well.
* Added a status bar just under the room renderer that tracks the mouse position.
* Used an event filter to paint the transparency checkerboard pattern on the background of the room preview scroll area viewport.
* Added zooming to the room editor and room renderer.
* Put the room preview and the room property tabs into a horizontal splitter so more screen space can be used when designing levels.
* Because we decided to deprecate the transparent field from GM6 in libEGM when I fixed GMK, I removed the transparent checkbox from the sprite and background editors as well as the logic from both renderers.
* Changed the close event of the main window to close all the subwindows which triggers their save changes dialog. More work needs to be done to this to make it perfect. Even if you decline the individual dialog for each editor, there should still be a final overruling dialog that's shown if the tree model itself is dirty. That is how GM5 behaved though it could be improved upon with "Yes to All" or "No to All".
* Changed the `BaseEditor` constructor to accept the tree node instead of its subresource so editors can map the name field.
* Created the composite `ModelMapper` class that combines `ImmediateDataWidgetMapper` together with `ProtoModel` using traditional class composition. Fundies argued that since everywhere we use a model, we also want a mapper, it ultimately will save redundant code.
* Changed the `ProtoModel` to deal with recursive submodels from nested protobuf messages.
* Added the `RepeatedProtoModel` class for use with repeated submodels, such as instances that are a repeated field in the Room proto.
* Added the `TreeSortFilterProxyModel` class for filtering the main tree by resource type. It is used in conjunction with QMenuView to implement the resource picker which needs to filter by type.
* Added the `RoomRenderer` widget that uses the submodels of the Room proto to render the room layers, views, assets, grid, etc.
* Added the `ResourceModelMap` class that facilitates in finding resources by name as well as getting an object/sprite preview for the tree.
* Fixed a typo in the background renderer's grid painting algorithm. The mistake was that fundies put width where he meant height for the number of horizontal lines.

### Example Rooms
![Functional Room Editor](https://user-images.githubusercontent.com/3212801/47529957-49765600-d877-11e8-9fa1-1a0433671b08.png)
![SONIGMA Level0](https://user-images.githubusercontent.com/3212801/47530025-7460aa00-d877-11e8-803f-d06f2f4a46dd.png)
![Game Of Life room0](https://user-images.githubusercontent.com/3212801/47530055-8f331e80-d877-11e8-993f-6f6a0c41e8f5.png)
![Key to Success Levels](https://user-images.githubusercontent.com/3212801/47530112-b2f66480-d877-11e8-9da7-7fc21df17b85.png)
![DragonRise3](https://user-images.githubusercontent.com/3212801/47530174-d1f4f680-d877-11e8-91d5-af3b2787514c.png)

