### PR TITLE
GRPC & Compiler Related Features

### DIFF
--- a/CmakeLists.txt
+++ b/CmakeLists.txt
@@ -162,6 +162,8 @@ find_library(LIB_PROTO NAMES Protocols PATHS ${ENIGMA_DIR})
 target_link_libraries(${EXE} PRIVATE "$<IF:$<CONFIG:Debug>,${LIB_PROTO_D},${LIB_PROTO}>")
 
 # Find GRPC
+find_package(GRPC REQUIRED)
+include_directories(${GRPC_INCLUDE_DIRS})
 find_library(LIB_GRPC_UNSECURE NAMES grpc++_unsecure)
 find_library(LIB_GRPC NAMES grpc)
 find_library(LIB_GPR NAMES gpr)

--- a/CmakeLists.txt
+++ b/CmakeLists.txt
@@ -162,8 +162,6 @@ find_library(LIB_PROTO NAMES Protocols PATHS ${ENIGMA_DIR})
 target_link_libraries(${EXE} PRIVATE "$<IF:$<CONFIG:Debug>,${LIB_PROTO_D},${LIB_PROTO}>")
 
 # Find GRPC
-find_package(GRPC REQUIRED)
-include_directories(${GRPC_INCLUDE_DIRS})
 find_library(LIB_GRPC_UNSECURE NAMES grpc++_unsecure)
 find_library(LIB_GRPC NAMES grpc)
 find_library(LIB_GPR NAMES gpr)

--- a/CmakeLists.txt
+++ b/CmakeLists.txt
@@ -37,6 +37,7 @@ set(RGM_SOURCES
     Editors/TimelineEditor.cpp
     Editors/RoomEditor.cpp
     Editors/SpriteEditor.cpp
+    Editors/SettingsEditor.cpp
     Models/TreeModel.cpp
     Models/SpriteModel.cpp
     Models/ProtoModel.cpp
@@ -67,6 +68,7 @@ set(RGM_HEADERS
     Editors/TimelineEditor.h
     Editors/RoomEditor.h
     Editors/SpriteEditor.h
+    Editors/SettingsEditor.h
     Models/TreeModel.h
     Models/ProtoModel.h
     Models/ImmediateMapper.h
@@ -92,6 +94,7 @@ set(RGM_UI
     Editors/TimelineEditor.ui
     Editors/RoomEditor.ui
     Editors/SpriteEditor.ui
+    Editors/SettingsEditor.ui
 )
 
 set(RGM_RC

--- a/Editors/BackgroundEditor.cpp
+++ b/Editors/BackgroundEditor.cpp
@@ -22,7 +22,6 @@ BackgroundEditor::BackgroundEditor(ProtoModel* model, QWidget* parent)
 
   mapper->addMapping(ui->smoothCheckBox, Background::kSmoothEdgesFieldNumber);
   mapper->addMapping(ui->preloadCheckBox, Background::kPreloadFieldNumber);
-  mapper->addMapping(ui->transparentCheckBox, Background::kTransparentFieldNumber);
   mapper->addMapping(ui->tilesetGroupBox, Background::kUseAsTilesetFieldNumber);
   mapper->addMapping(ui->tileWidthSpinBox, Background::kTileWidthFieldNumber);
   mapper->addMapping(ui->tileHeightSpinBox, Background::kTileHeightFieldNumber);

--- a/Editors/BackgroundEditor.ui
+++ b/Editors/BackgroundEditor.ui
@@ -116,13 +116,6 @@
         </widget>
        </item>
        <item>
-        <widget class="QCheckBox" name="transparentCheckBox">
-         <property name="text">
-          <string>&amp;Transparent</string>
-         </property>
-        </widget>
-       </item>
-       <item>
         <widget class="QCheckBox" name="preloadCheckBox">
          <property name="text">
           <string>Pre&amp;load texture</string>

--- a/Editors/BaseEditor.h
+++ b/Editors/BaseEditor.h
@@ -14,7 +14,8 @@ static const QHash<int, int> ResTypeFields = {{TypeCase::kSprite, TreeNode::kSpr
                                               {TypeCase::kScript, TreeNode::kScriptFieldNumber},
                                               {TypeCase::kTimeline, TreeNode::kTimelineFieldNumber},
                                               {TypeCase::kObject, TreeNode::kObjectFieldNumber},
-                                              {TypeCase::kRoom, TreeNode::kRoomFieldNumber}};
+                                              {TypeCase::kRoom, TreeNode::kRoomFieldNumber},
+                                              {TypeCase::kSettings, TreeNode::kSettingsFieldNumber}};
 
 class BaseEditor : public QWidget {
   Q_OBJECT

--- a/Editors/SettingsEditor.cpp
+++ b/Editors/SettingsEditor.cpp
@@ -1,9 +1,29 @@
 #include "SettingsEditor.h"
+#include "MainWindow.h"
 #include "ui_SettingsEditor.h"
+
+#include <QDebug>
 
 SettingsEditor::SettingsEditor(ProtoModel* model, QWidget* parent)
     : BaseEditor(model, parent), ui(new Ui::SettingsEditor) {
   ui->setupUi(this);
+
+  const QMap<QString, QComboBox*> systemUIMap = {
+      {QString("Audio"), ui->audioCombo},          {QString("Platform"), ui->platformCombo},
+      {QString("Graphics"), ui->graphicsCombo},    {QString("Widget"), ui->widgetsCombo},
+      {QString("Collision"), ui->collisionsCombo}, {QString("Compilers"), ui->compilerCombo},
+      {QString("Network"), ui->networkingCombo},
+  };
+  foreach (auto system, MainWindow::systemCache) {
+    const QString systemName = QString::fromStdString(system.name());
+    auto it = systemUIMap.find(systemName);
+    if (it == systemUIMap.end()) continue;
+    foreach (auto subsystem, system.subsystems()) {
+      const QString subsystemName = QString::fromStdString(subsystem.name());
+      auto combo = it.value();
+      combo->addItem(subsystemName);
+    }
+  }
 }
 
 SettingsEditor::~SettingsEditor() { delete ui; }

--- a/Editors/SettingsEditor.cpp
+++ b/Editors/SettingsEditor.cpp
@@ -53,7 +53,7 @@ SettingsEditor::SettingsEditor(ProtoModel* model, QWidget* parent)
       {QString("Collision"), ui->collisionCombo}, {QString("Compilers"), ui->compilerCombo},
       {QString("Network"), ui->networkCombo},     {QString("Extensions"), ui->extensionsList},
   };
-  foreach (auto system, MainWindow::systemCache) {
+  for (auto system : MainWindow::systemCache) {
     const QString systemName = QString::fromStdString(system.name());
     auto it = systemUIMap.find(systemName);
     if (it == systemUIMap.end()) continue;
@@ -74,7 +74,7 @@ SettingsEditor::SettingsEditor(ProtoModel* model, QWidget* parent)
         ui->systemDesc->setPlainText(subsystemDesc);
       });
     }
-    foreach (auto subsystem, system.subsystems()) {
+    for (auto subsystem : system.subsystems()) {
       const QString subsystemName = QString::fromStdString(subsystem.name());
       const QString subsystemId = QString::fromStdString(subsystem.id());
       const QString subsystemDesc = QString::fromStdString(subsystem.description());

--- a/Editors/SettingsEditor.cpp
+++ b/Editors/SettingsEditor.cpp
@@ -1,0 +1,9 @@
+#include "SettingsEditor.h"
+#include "ui_SettingsEditor.h"
+
+SettingsEditor::SettingsEditor(ProtoModel* model, QWidget* parent)
+    : BaseEditor(model, parent), ui(new Ui::SettingsEditor) {
+  ui->setupUi(this);
+}
+
+SettingsEditor::~SettingsEditor() { delete ui; }

--- a/Editors/SettingsEditor.cpp
+++ b/Editors/SettingsEditor.cpp
@@ -46,7 +46,8 @@ SettingsEditor::SettingsEditor(ProtoModel* model, QWidget* parent)
   pageMap = {{"api", ui->apiPage},
              {"extensions", ui->extensionsPage},
              {"compiler", ui->compilerPage},
-             {"graphics", ui->graphicsPage}};
+             {"graphics", ui->graphicsPage},
+             {"project info", ui->projectInfoPage}};
 
   const QMap<QString, QWidget*> systemUIMap = {
       {QString("Audio"), ui->audioCombo},         {QString("Platform"), ui->platformCombo},

--- a/Editors/SettingsEditor.cpp
+++ b/Editors/SettingsEditor.cpp
@@ -11,6 +11,12 @@ using namespace buffers::resources;
 
 Q_DECLARE_METATYPE(buffers::SystemInfo);
 
+static std::string get_combo_system_id(const QComboBox* combo) {
+  auto data = combo->currentData();
+  auto subsystem = data.value<buffers::SystemInfo>();
+  return subsystem.id();
+}
+
 SettingsEditor::SettingsEditor(ProtoModel* model, QWidget* parent)
     : BaseEditor(model, parent), ui(new Ui::SettingsEditor) {
   ui->setupUi(this);
@@ -21,13 +27,13 @@ SettingsEditor::SettingsEditor(ProtoModel* model, QWidget* parent)
     qDebug() << "hey";
     Settings settings;
     auto* api = settings.mutable_api();
-    api->set_target_audio(ui->audioCombo->currentData().toString().toStdString());
-    api->set_target_collision(ui->collisionCombo->currentData().toString().toStdString());
-    api->set_target_compiler(ui->compilerCombo->currentData().toString().toStdString());
-    api->set_target_graphics(ui->graphicsCombo->currentData().toString().toStdString());
-    api->set_target_network(ui->networkCombo->currentData().toString().toStdString());
-    api->set_target_platform(ui->platformCombo->currentData().toString().toStdString());
-    api->set_target_widgets(ui->widgetsCombo->currentData().toString().toStdString());
+    api->set_target_audio(get_combo_system_id(ui->audioCombo));
+    api->set_target_collision(get_combo_system_id(ui->collisionCombo));
+    api->set_target_compiler(get_combo_system_id(ui->compilerCombo));
+    api->set_target_graphics(get_combo_system_id(ui->graphicsCombo));
+    api->set_target_network(get_combo_system_id(ui->networkCombo));
+    api->set_target_platform(get_combo_system_id(ui->platformCombo));
+    api->set_target_widgets(get_combo_system_id(ui->widgetsCombo));
     api->add_extensions("Paths");
 
     qDebug() << "hi" << ui->audioCombo->currentData().toString();

--- a/Editors/SettingsEditor.cpp
+++ b/Editors/SettingsEditor.cpp
@@ -4,11 +4,18 @@
 
 #include "codegen/Settings.pb.h"
 
+#include <QPushButton>
+
 using namespace buffers::resources;
 
 SettingsEditor::SettingsEditor(ProtoModel* model, QWidget* parent)
     : BaseEditor(model, parent), ui(new Ui::SettingsEditor) {
   ui->setupUi(this);
+
+  QPushButton* saveButton = ui->buttonBox->button(QDialogButtonBox::Save);
+  saveButton->setIcon(QIcon(":/actions/accept.png"));
+  QPushButton* discardButton = ui->buttonBox->button(QDialogButtonBox::Discard);
+  discardButton->setIcon(QIcon(":/actions/cancel.png"));
 
   const QMap<QString, QComboBox*> systemUIMap = {
       {QString("Audio"), ui->audioCombo},          {QString("Platform"), ui->platformCombo},

--- a/Editors/SettingsEditor.cpp
+++ b/Editors/SettingsEditor.cpp
@@ -17,22 +17,58 @@ SettingsEditor::SettingsEditor(ProtoModel* model, QWidget* parent)
   QPushButton* discardButton = ui->buttonBox->button(QDialogButtonBox::Discard);
   discardButton->setIcon(QIcon(":/actions/cancel.png"));
 
-  const QMap<QString, QComboBox*> systemUIMap = {
+  treePageMap = {{QString("ENIGMA/API"), ui->apiPage}, {QString("ENIGMA/Extensions"), ui->extensionsPage}};
+
+  const QMap<QString, QWidget*> systemUIMap = {
       {QString("Audio"), ui->audioCombo},          {QString("Platform"), ui->platformCombo},
       {QString("Graphics"), ui->graphicsCombo},    {QString("Widget"), ui->widgetsCombo},
       {QString("Collision"), ui->collisionsCombo}, {QString("Compilers"), ui->compilerCombo},
-      {QString("Network"), ui->networkingCombo},
+      {QString("Network"), ui->networkingCombo},   {QString("Extensions"), ui->extensionsList},
   };
   foreach (auto system, MainWindow::systemCache) {
     const QString systemName = QString::fromStdString(system.name());
     auto it = systemUIMap.find(systemName);
     if (it == systemUIMap.end()) continue;
+    auto widget = it.value();
+    const QString className = widget->metaObject()->className();
+    QListWidget* listWidget = nullptr;
+    QComboBox* combo = nullptr;
+    if (className == "QListWidget") {
+      listWidget = static_cast<QListWidget*>(widget);
+    } else if (className == "QComboBox") {
+      combo = static_cast<QComboBox*>(widget);
+    }
     foreach (auto subsystem, system.subsystems()) {
       const QString subsystemName = QString::fromStdString(subsystem.name());
-      auto combo = it.value();
-      combo->addItem(subsystemName);
+      const QString subsystemDesc = QString::fromStdString(subsystem.description());
+      if (combo)
+        combo->addItem(subsystemName);
+      else if (listWidget) {
+        auto item = new QListWidgetItem(subsystemName, listWidget);
+        item->setFlags(item->flags() | Qt::ItemFlag::ItemIsUserCheckable);
+        item->setCheckState(Qt::Unchecked);
+        item->setToolTip(subsystemDesc);
+      }
     }
   }
 }
 
 SettingsEditor::~SettingsEditor() { delete ui; }
+
+void SettingsEditor::on_treeWidget_currentItemChanged(QTreeWidgetItem* current, QTreeWidgetItem* /*previous*/) {
+  QWidget* widget = ui->emptyPage;
+  auto item = current;
+  if (item) {
+    QString path = item->text(0);
+    while (item->parent()) {
+      item = item->parent();
+      path.prepend(item->text(0) + "/");
+    }
+    auto it = treePageMap.find(path);
+    if (it != treePageMap.end()) {
+      widget = it.value();
+    }
+  }
+
+  ui->stackedWidget->setCurrentWidget(widget);
+}

--- a/Editors/SettingsEditor.cpp
+++ b/Editors/SettingsEditor.cpp
@@ -43,7 +43,10 @@ SettingsEditor::SettingsEditor(ProtoModel* model, QWidget* parent)
   QPushButton* discardButton = ui->buttonBox->button(QDialogButtonBox::Discard);
   discardButton->setIcon(QIcon(":/actions/cancel.png"));
 
-  pageMap = {{"api", ui->apiPage}, {"extensions", ui->extensionsPage}, {"compiler", ui->compilerPage}};
+  pageMap = {{"api", ui->apiPage},
+             {"extensions", ui->extensionsPage},
+             {"compiler", ui->compilerPage},
+             {"graphics", ui->graphicsPage}};
 
   const QMap<QString, QWidget*> systemUIMap = {
       {QString("Audio"), ui->audioCombo},         {QString("Platform"), ui->platformCombo},

--- a/Editors/SettingsEditor.cpp
+++ b/Editors/SettingsEditor.cpp
@@ -43,11 +43,9 @@ SettingsEditor::SettingsEditor(ProtoModel* model, QWidget* parent)
   QPushButton* discardButton = ui->buttonBox->button(QDialogButtonBox::Discard);
   discardButton->setIcon(QIcon(":/actions/cancel.png"));
 
-  pageMap = {{"api", ui->apiPage},
-             {"extensions", ui->extensionsPage},
-             {"compiler", ui->compilerPage},
-             {"graphics", ui->graphicsPage},
-             {"project info", ui->projectInfoPage}};
+  pageMap = {{"api", ui->apiPage},           {"extensions", ui->extensionsPage}, {"compiler", ui->compilerPage},
+             {"controls", ui->controlsPage}, {"graphics", ui->graphicsPage},     {"project info", ui->projectInfoPage},
+             {"version", ui->versionPage}};
 
   const QMap<QString, QWidget*> systemUIMap = {
       {QString("Audio"), ui->audioCombo},         {QString("Platform"), ui->platformCombo},

--- a/Editors/SettingsEditor.cpp
+++ b/Editors/SettingsEditor.cpp
@@ -2,7 +2,9 @@
 #include "MainWindow.h"
 #include "ui_SettingsEditor.h"
 
-#include <QDebug>
+#include "codegen/Settings.pb.h"
+
+using namespace buffers::resources;
 
 SettingsEditor::SettingsEditor(ProtoModel* model, QWidget* parent)
     : BaseEditor(model, parent), ui(new Ui::SettingsEditor) {

--- a/Editors/SettingsEditor.cpp
+++ b/Editors/SettingsEditor.cpp
@@ -4,7 +4,6 @@
 
 #include "codegen/Settings.pb.h"
 
-#include <QDebug>
 #include <QPushButton>
 
 using namespace buffers::resources;
@@ -24,7 +23,6 @@ SettingsEditor::SettingsEditor(ProtoModel* model, QWidget* parent)
   QPushButton* saveButton = ui->buttonBox->button(QDialogButtonBox::Save);
   saveButton->setIcon(QIcon(":/actions/accept.png"));
   connect(saveButton, &QPushButton::clicked, [=]() {
-    qDebug() << "hey";
     Settings settings;
     auto* api = settings.mutable_api();
     api->set_target_audio(get_combo_system_id(ui->audioCombo));
@@ -35,8 +33,6 @@ SettingsEditor::SettingsEditor(ProtoModel* model, QWidget* parent)
     api->set_target_platform(get_combo_system_id(ui->platformCombo));
     api->set_target_widgets(get_combo_system_id(ui->widgetsCombo));
     api->add_extensions("Paths");
-
-    qDebug() << "hi" << ui->audioCombo->currentData().toString();
 
     emit MainWindow::setCurrentConfig(settings);
   });

--- a/Editors/SettingsEditor.cpp
+++ b/Editors/SettingsEditor.cpp
@@ -43,7 +43,7 @@ SettingsEditor::SettingsEditor(ProtoModel* model, QWidget* parent)
   QPushButton* discardButton = ui->buttonBox->button(QDialogButtonBox::Discard);
   discardButton->setIcon(QIcon(":/actions/cancel.png"));
 
-  pageMap = {{QString("api"), ui->apiPage}, {QString("extensions"), ui->extensionsPage}};
+  pageMap = {{"api", ui->apiPage}, {"extensions", ui->extensionsPage}, {"compiler", ui->compilerPage}};
 
   const QMap<QString, QWidget*> systemUIMap = {
       {QString("Audio"), ui->audioCombo},         {QString("Platform"), ui->platformCombo},

--- a/Editors/SettingsEditor.h
+++ b/Editors/SettingsEditor.h
@@ -3,6 +3,8 @@
 
 #include "BaseEditor.h"
 
+#include "codegen/Settings.pb.h"
+
 namespace Ui {
 class SettingsEditor;
 }

--- a/Editors/SettingsEditor.h
+++ b/Editors/SettingsEditor.h
@@ -3,8 +3,6 @@
 
 #include "BaseEditor.h"
 
-#include "codegen/Settings.pb.h"
-
 namespace Ui {
 class SettingsEditor;
 }

--- a/Editors/SettingsEditor.h
+++ b/Editors/SettingsEditor.h
@@ -1,0 +1,21 @@
+#ifndef SETTINGSEDITOR_H
+#define SETTINGSEDITOR_H
+
+#include "BaseEditor.h"
+
+namespace Ui {
+class SettingsEditor;
+}
+
+class SettingsEditor : public BaseEditor {
+  Q_OBJECT
+
+ public:
+  explicit SettingsEditor(ProtoModel* model, QWidget* parent);
+  ~SettingsEditor();
+
+ private:
+  Ui::SettingsEditor* ui;
+};
+
+#endif  // SETTINGSEDITOR_H

--- a/Editors/SettingsEditor.h
+++ b/Editors/SettingsEditor.h
@@ -3,6 +3,8 @@
 
 #include "BaseEditor.h"
 
+#include <QTreeWidgetItem>
+
 namespace Ui {
 class SettingsEditor;
 }
@@ -14,8 +16,12 @@ class SettingsEditor : public BaseEditor {
   explicit SettingsEditor(ProtoModel* model, QWidget* parent);
   ~SettingsEditor();
 
+ private slots:
+  void on_treeWidget_currentItemChanged(QTreeWidgetItem* current, QTreeWidgetItem* previous);
+
  private:
   Ui::SettingsEditor* ui;
+  QMap<QString, QWidget*> treePageMap;
 };
 
 #endif  // SETTINGSEDITOR_H

--- a/Editors/SettingsEditor.h
+++ b/Editors/SettingsEditor.h
@@ -3,7 +3,7 @@
 
 #include "BaseEditor.h"
 
-#include <QTreeWidgetItem>
+#include <QListWidgetItem>
 
 namespace Ui {
 class SettingsEditor;
@@ -17,11 +17,11 @@ class SettingsEditor : public BaseEditor {
   ~SettingsEditor();
 
  private slots:
-  void on_treeWidget_currentItemChanged(QTreeWidgetItem* current, QTreeWidgetItem* previous);
+  void on_listWidget_currentItemChanged(QListWidgetItem* current, QListWidgetItem* previous);
 
  private:
   Ui::SettingsEditor* ui;
-  QMap<QString, QWidget*> treePageMap;
+  QMap<QString, QWidget*> pageMap;
 };
 
 #endif  // SETTINGSEDITOR_H

--- a/Editors/SettingsEditor.ui
+++ b/Editors/SettingsEditor.ui
@@ -81,13 +81,17 @@
       </item>
      </widget>
      <widget class="QStackedWidget" name="stackedWidget">
+      <property name="enabled">
+       <bool>true</bool>
+      </property>
       <property name="sizePolicy">
        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
         <horstretch>1</horstretch>
         <verstretch>0</verstretch>
        </sizepolicy>
       </property>
-      <widget class="QWidget" name="API">
+      <widget class="QWidget" name="emptyPage"/>
+      <widget class="QWidget" name="apiPage">
        <layout class="QFormLayout" name="formLayout">
         <property name="labelAlignment">
          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
@@ -179,6 +183,28 @@
         </item>
         <item row="6" column="1">
          <widget class="QComboBox" name="networkingCombo"/>
+        </item>
+       </layout>
+      </widget>
+      <widget class="QWidget" name="extensionsPage">
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <property name="spacing">
+         <number>4</number>
+        </property>
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
+         <number>0</number>
+        </property>
+        <item>
+         <widget class="QListWidget" name="extensionsList"/>
         </item>
        </layout>
       </widget>

--- a/Editors/SettingsEditor.ui
+++ b/Editors/SettingsEditor.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>656</width>
-    <height>379</height>
+    <width>665</width>
+    <height>511</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -44,40 +44,42 @@
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>
-     <widget class="QTreeWidget" name="treeWidget">
+     <widget class="QListWidget" name="listWidget">
       <property name="sizePolicy">
        <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
         <horstretch>0</horstretch>
         <verstretch>0</verstretch>
        </sizepolicy>
       </property>
-      <attribute name="headerVisible">
-       <bool>false</bool>
-      </attribute>
-      <column>
-       <property name="text">
-        <string>1</string>
-       </property>
-      </column>
       <item>
        <property name="text">
-        <string>ENIGMA</string>
+        <string>General</string>
        </property>
-       <item>
-        <property name="text">
-         <string>General</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>API</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Extensions</string>
-        </property>
-       </item>
+      </item>
+      <item>
+       <property name="text">
+        <string>Project Info</string>
+       </property>
+      </item>
+      <item>
+       <property name="text">
+        <string>Graphics</string>
+       </property>
+      </item>
+      <item>
+       <property name="text">
+        <string>API</string>
+       </property>
+      </item>
+      <item>
+       <property name="text">
+        <string>Compiler</string>
+       </property>
+      </item>
+      <item>
+       <property name="text">
+        <string>Extensions</string>
+       </property>
       </item>
      </widget>
      <widget class="QStackedWidget" name="stackedWidget">
@@ -92,14 +94,8 @@
       </property>
       <widget class="QWidget" name="emptyPage"/>
       <widget class="QWidget" name="apiPage">
-       <layout class="QFormLayout" name="formLayout">
-        <property name="labelAlignment">
-         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-        </property>
-        <property name="horizontalSpacing">
-         <number>4</number>
-        </property>
-        <property name="verticalSpacing">
+       <layout class="QVBoxLayout" name="verticalLayout_2">
+        <property name="spacing">
          <number>4</number>
         </property>
         <property name="leftMargin">
@@ -114,75 +110,162 @@
         <property name="bottomMargin">
          <number>0</number>
         </property>
-        <item row="0" column="0">
-         <widget class="QLabel" name="audioLabel">
-          <property name="text">
-           <string>Audio</string>
+        <item>
+         <widget class="QWidget" name="widget" native="true">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
           </property>
+          <layout class="QFormLayout" name="formLayout">
+           <property name="horizontalSpacing">
+            <number>4</number>
+           </property>
+           <property name="verticalSpacing">
+            <number>4</number>
+           </property>
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
+           <item row="0" column="0">
+            <widget class="QLabel" name="audioLabel">
+             <property name="text">
+              <string>Audio</string>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <widget class="QComboBox" name="audioCombo"/>
+           </item>
+           <item row="1" column="0">
+            <widget class="QLabel" name="platformLabel">
+             <property name="text">
+              <string>Platform</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="1">
+            <widget class="QComboBox" name="platformCombo"/>
+           </item>
+           <item row="2" column="0">
+            <widget class="QLabel" name="compilerLabel">
+             <property name="text">
+              <string>Compiler</string>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="1">
+            <widget class="QComboBox" name="compilerCombo"/>
+           </item>
+           <item row="3" column="1">
+            <widget class="QComboBox" name="graphicsCombo"/>
+           </item>
+           <item row="3" column="0">
+            <widget class="QLabel" name="graphicsLabel">
+             <property name="text">
+              <string>Graphics</string>
+             </property>
+            </widget>
+           </item>
+           <item row="4" column="1">
+            <widget class="QComboBox" name="widgetsCombo"/>
+           </item>
+           <item row="4" column="0">
+            <widget class="QLabel" name="widgetsLabel">
+             <property name="text">
+              <string>Widgets</string>
+             </property>
+            </widget>
+           </item>
+           <item row="5" column="1">
+            <widget class="QComboBox" name="collisionCombo"/>
+           </item>
+           <item row="5" column="0">
+            <widget class="QLabel" name="collisionLabel">
+             <property name="text">
+              <string>Collision</string>
+             </property>
+            </widget>
+           </item>
+           <item row="6" column="1">
+            <widget class="QComboBox" name="networkCombo"/>
+           </item>
+           <item row="6" column="0">
+            <widget class="QLabel" name="networkLabel">
+             <property name="text">
+              <string>Network</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
          </widget>
         </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="platformLabel">
-          <property name="text">
-           <string>Platform</string>
+        <item>
+         <widget class="QGroupBox" name="aboutSystemBox">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>1</verstretch>
+           </sizepolicy>
           </property>
-         </widget>
-        </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="compilerLabel">
-          <property name="text">
-           <string>Compiler</string>
+          <property name="title">
+           <string>About</string>
           </property>
-         </widget>
-        </item>
-        <item row="3" column="0">
-         <widget class="QLabel" name="graphicsLabel">
-          <property name="text">
-           <string>Graphics</string>
+          <property name="alignment">
+           <set>Qt::AlignCenter</set>
           </property>
-         </widget>
-        </item>
-        <item row="4" column="0">
-         <widget class="QLabel" name="widgetsLabel">
-          <property name="text">
-           <string>Widgets</string>
+          <property name="flat">
+           <bool>true</bool>
           </property>
+          <layout class="QGridLayout" name="gridLayout">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
+           <property name="spacing">
+            <number>4</number>
+           </property>
+           <item row="0" column="1">
+            <widget class="QLineEdit" name="authorName">
+             <property name="readOnly">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="0">
+            <widget class="QLabel" name="authorLabel">
+             <property name="text">
+              <string>Author</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="0" colspan="2">
+            <widget class="QPlainTextEdit" name="systemDesc">
+             <property name="readOnly">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+          </layout>
          </widget>
-        </item>
-        <item row="5" column="0">
-         <widget class="QLabel" name="collisionLabel">
-          <property name="text">
-           <string>Collision</string>
-          </property>
-         </widget>
-        </item>
-        <item row="6" column="0">
-         <widget class="QLabel" name="networkLabel">
-          <property name="text">
-           <string>Network</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="QComboBox" name="audioCombo"/>
-        </item>
-        <item row="1" column="1">
-         <widget class="QComboBox" name="platformCombo"/>
-        </item>
-        <item row="2" column="1">
-         <widget class="QComboBox" name="compilerCombo"/>
-        </item>
-        <item row="3" column="1">
-         <widget class="QComboBox" name="graphicsCombo"/>
-        </item>
-        <item row="4" column="1">
-         <widget class="QComboBox" name="widgetsCombo"/>
-        </item>
-        <item row="5" column="1">
-         <widget class="QComboBox" name="collisionCombo"/>
-        </item>
-        <item row="6" column="1">
-         <widget class="QComboBox" name="networkCombo"/>
         </item>
        </layout>
       </widget>

--- a/Editors/SettingsEditor.ui
+++ b/Editors/SettingsEditor.ui
@@ -99,16 +99,16 @@
          <number>4</number>
         </property>
         <property name="leftMargin">
-         <number>4</number>
+         <number>0</number>
         </property>
         <property name="topMargin">
-         <number>4</number>
+         <number>0</number>
         </property>
         <property name="rightMargin">
-         <number>4</number>
+         <number>0</number>
         </property>
         <property name="bottomMargin">
-         <number>4</number>
+         <number>0</number>
         </property>
         <item row="0" column="0">
          <widget class="QLabel" name="audioLabel">

--- a/Editors/SettingsEditor.ui
+++ b/Editors/SettingsEditor.ui
@@ -150,16 +150,16 @@
          </widget>
         </item>
         <item row="5" column="0">
-         <widget class="QLabel" name="collisionsLabel">
+         <widget class="QLabel" name="collisionLabel">
           <property name="text">
-           <string>Collisions</string>
+           <string>Collision</string>
           </property>
          </widget>
         </item>
         <item row="6" column="0">
-         <widget class="QLabel" name="networkingLabel">
+         <widget class="QLabel" name="networkLabel">
           <property name="text">
-           <string>Networking</string>
+           <string>Network</string>
           </property>
          </widget>
         </item>
@@ -179,10 +179,10 @@
          <widget class="QComboBox" name="widgetsCombo"/>
         </item>
         <item row="5" column="1">
-         <widget class="QComboBox" name="collisionsCombo"/>
+         <widget class="QComboBox" name="collisionCombo"/>
         </item>
         <item row="6" column="1">
-         <widget class="QComboBox" name="networkingCombo"/>
+         <widget class="QComboBox" name="networkCombo"/>
         </item>
        </layout>
       </widget>

--- a/Editors/SettingsEditor.ui
+++ b/Editors/SettingsEditor.ui
@@ -118,9 +118,9 @@
          </widget>
         </item>
         <item row="1" column="0">
-         <widget class="QLabel" name="windowingLabel">
+         <widget class="QLabel" name="platformLabel">
           <property name="text">
-           <string>Windowing</string>
+           <string>Platform</string>
           </property>
          </widget>
         </item>
@@ -160,25 +160,25 @@
          </widget>
         </item>
         <item row="0" column="1">
-         <widget class="QComboBox" name="comboBox"/>
+         <widget class="QComboBox" name="audioCombo"/>
         </item>
         <item row="1" column="1">
-         <widget class="QComboBox" name="comboBox_2"/>
+         <widget class="QComboBox" name="platformCombo"/>
         </item>
         <item row="2" column="1">
-         <widget class="QComboBox" name="comboBox_3"/>
+         <widget class="QComboBox" name="compilerCombo"/>
         </item>
         <item row="3" column="1">
-         <widget class="QComboBox" name="comboBox_4"/>
+         <widget class="QComboBox" name="graphicsCombo"/>
         </item>
         <item row="4" column="1">
-         <widget class="QComboBox" name="comboBox_5"/>
+         <widget class="QComboBox" name="widgetsCombo"/>
         </item>
         <item row="5" column="1">
-         <widget class="QComboBox" name="comboBox_6"/>
+         <widget class="QComboBox" name="collisionsCombo"/>
         </item>
         <item row="6" column="1">
-         <widget class="QComboBox" name="comboBox_7"/>
+         <widget class="QComboBox" name="networkingCombo"/>
         </item>
        </layout>
       </widget>

--- a/Editors/SettingsEditor.ui
+++ b/Editors/SettingsEditor.ui
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>SettingsEditor</class>
+ <widget class="QWidget" name="SettingsEditor">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>656</width>
+    <height>379</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="windowTitle">
+   <string>Settings</string>
+  </property>
+  <property name="windowIcon">
+   <iconset resource="../images.qrc">
+    <normaloff>:/resources/settings.png</normaloff>:/resources/settings.png</iconset>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout" stretch="1,0">
+   <property name="spacing">
+    <number>4</number>
+   </property>
+   <property name="leftMargin">
+    <number>4</number>
+   </property>
+   <property name="topMargin">
+    <number>4</number>
+   </property>
+   <property name="rightMargin">
+    <number>4</number>
+   </property>
+   <property name="bottomMargin">
+    <number>4</number>
+   </property>
+   <item>
+    <widget class="QSplitter" name="splitter">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <widget class="QTreeWidget" name="treeWidget">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <attribute name="headerVisible">
+       <bool>false</bool>
+      </attribute>
+      <column>
+       <property name="text">
+        <string>1</string>
+       </property>
+      </column>
+      <item>
+       <property name="text">
+        <string>ENIGMA</string>
+       </property>
+       <item>
+        <property name="text">
+         <string>General</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>API</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Extensions</string>
+        </property>
+       </item>
+      </item>
+     </widget>
+     <widget class="QStackedWidget" name="stackedWidget">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+        <horstretch>1</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+     </widget>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Discard|QDialogButtonBox::Save</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources>
+  <include location="../images.qrc"/>
+ </resources>
+ <connections/>
+</ui>

--- a/Editors/SettingsEditor.ui
+++ b/Editors/SettingsEditor.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>665</width>
+    <width>765</width>
     <height>511</height>
    </rect>
   </property>
@@ -93,6 +93,236 @@
        </sizepolicy>
       </property>
       <widget class="QWidget" name="emptyPage"/>
+      <widget class="QWidget" name="compilerPage">
+       <layout class="QVBoxLayout" name="verticalLayout_3">
+        <property name="spacing">
+         <number>4</number>
+        </property>
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
+         <number>0</number>
+        </property>
+        <item>
+         <widget class="QGroupBox" name="groupBox">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="title">
+           <string>Compatibility</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignCenter</set>
+          </property>
+          <property name="flat">
+           <bool>true</bool>
+          </property>
+          <layout class="QGridLayout" name="gridLayout_2">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
+           <property name="spacing">
+            <number>4</number>
+           </property>
+           <item row="1" column="2">
+            <widget class="QRadioButton" name="radioButton_3">
+             <property name="text">
+              <string>C++ (\n)</string>
+             </property>
+             <attribute name="buttonGroup">
+              <string notr="true">inheritEscapesGroup</string>
+             </attribute>
+            </widget>
+           </item>
+           <item row="4" column="2">
+            <widget class="QRadioButton" name="radioButton_9">
+             <property name="text">
+              <string>C++ (scalar)</string>
+             </property>
+             <attribute name="buttonGroup">
+              <string notr="true">treatLiteralsGroup</string>
+             </attribute>
+            </widget>
+           </item>
+           <item row="5" column="2">
+            <widget class="QRadioButton" name="radioButton_11">
+             <property name="text">
+              <string>C++ (true != 0)</string>
+             </property>
+             <attribute name="buttonGroup">
+              <string notr="true">treatNegativesGroup</string>
+             </attribute>
+            </widget>
+           </item>
+           <item row="2" column="2">
+            <widget class="QRadioButton" name="radioButton_5">
+             <property name="text">
+              <string>C++ (+=1/-=1)</string>
+             </property>
+             <attribute name="buttonGroup">
+              <string notr="true">inheritIncrementGroup</string>
+             </attribute>
+            </widget>
+           </item>
+           <item row="0" column="2">
+            <widget class="QRadioButton" name="radioButton_2">
+             <property name="text">
+              <string>C++ ('A'=65)</string>
+             </property>
+             <attribute name="buttonGroup">
+              <string notr="true">inheritStringsGroup</string>
+             </attribute>
+            </widget>
+           </item>
+           <item row="3" column="2">
+            <widget class="QRadioButton" name="radioButton_7">
+             <property name="text">
+              <string>C++ (b=c;a=c)</string>
+             </property>
+             <attribute name="buttonGroup">
+              <string notr="true">inheritEqualityGroup</string>
+             </attribute>
+            </widget>
+           </item>
+           <item row="2" column="1">
+            <widget class="QRadioButton" name="radioButton_6">
+             <property name="text">
+              <string>GML (+)</string>
+             </property>
+             <attribute name="buttonGroup">
+              <string notr="true">inheritIncrementGroup</string>
+             </attribute>
+            </widget>
+           </item>
+           <item row="1" column="1">
+            <widget class="QRadioButton" name="radioButton_4">
+             <property name="text">
+              <string>GML (#)</string>
+             </property>
+             <attribute name="buttonGroup">
+              <string notr="true">inheritEscapesGroup</string>
+             </attribute>
+            </widget>
+           </item>
+           <item row="3" column="1">
+            <widget class="QRadioButton" name="radioButton_8">
+             <property name="text">
+              <string>GMl (a=b==c)</string>
+             </property>
+             <attribute name="buttonGroup">
+              <string notr="true">inheritEqualityGroup</string>
+             </attribute>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <widget class="QRadioButton" name="radioButton">
+             <property name="text">
+              <string>GML ('A'=&quot;A&quot;)</string>
+             </property>
+             <attribute name="buttonGroup">
+              <string notr="true">inheritStringsGroup</string>
+             </attribute>
+            </widget>
+           </item>
+           <item row="0" column="0">
+            <widget class="QLabel" name="label">
+             <property name="text">
+              <string>Inherit strings from:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="0">
+            <widget class="QLabel" name="label_2">
+             <property name="text">
+              <string>Inherit escapes from:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="4" column="0">
+            <widget class="QLabel" name="label_5">
+             <property name="text">
+              <string>Treat literals as:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="0">
+            <widget class="QLabel" name="label_4">
+             <property name="text">
+              <string>Inherit a=b=c from:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="5" column="0">
+            <widget class="QLabel" name="label_6">
+             <property name="text">
+              <string>Treat negatives as:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="0">
+            <widget class="QLabel" name="label_3">
+             <property name="text">
+              <string>Inherit ++/-- from:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="4" column="1">
+            <widget class="QRadioButton" name="radioButton_10">
+             <property name="text">
+              <string>EDL (variant)</string>
+             </property>
+             <attribute name="buttonGroup">
+              <string notr="true">treatLiteralsGroup</string>
+             </attribute>
+            </widget>
+           </item>
+           <item row="5" column="1">
+            <widget class="QRadioButton" name="radioButton_12">
+             <property name="text">
+              <string>GML (true &gt; 0)</string>
+             </property>
+             <attribute name="buttonGroup">
+              <string notr="true">treatNegativesGroup</string>
+             </attribute>
+            </widget>
+           </item>
+           <item row="6" column="1">
+            <spacer name="verticalSpacer">
+             <property name="orientation">
+              <enum>Qt::Vertical</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>20</width>
+               <height>40</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
+         </widget>
+        </item>
+       </layout>
+      </widget>
       <widget class="QWidget" name="apiPage">
        <layout class="QVBoxLayout" name="verticalLayout_2">
         <property name="spacing">
@@ -307,4 +537,12 @@
   <include location="../images.qrc"/>
  </resources>
  <connections/>
+ <buttongroups>
+  <buttongroup name="inheritStringsGroup"/>
+  <buttongroup name="inheritEscapesGroup"/>
+  <buttongroup name="inheritIncrementGroup"/>
+  <buttongroup name="inheritEqualityGroup"/>
+  <buttongroup name="treatLiteralsGroup"/>
+  <buttongroup name="treatNegativesGroup"/>
+ </buttongroups>
 </ui>

--- a/Editors/SettingsEditor.ui
+++ b/Editors/SettingsEditor.ui
@@ -114,21 +114,14 @@
          <number>0</number>
         </property>
         <item row="0" column="0">
-         <widget class="QLabel" name="label">
+         <widget class="QLabel" name="authorLabel_2">
           <property name="text">
            <string>Author</string>
           </property>
          </widget>
         </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="label_2">
-          <property name="text">
-           <string>Email</string>
-          </property>
-         </widget>
-        </item>
         <item row="0" column="1">
-         <widget class="QLineEdit" name="lineEdit">
+         <widget class="QLineEdit" name="authorEdit">
           <property name="inputMask">
            <string/>
           </property>
@@ -143,60 +136,80 @@
           </property>
          </widget>
         </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="emailLabel">
+          <property name="text">
+           <string>Email</string>
+          </property>
+         </widget>
+        </item>
         <item row="1" column="1">
-         <widget class="QLineEdit" name="lineEdit_2">
+         <widget class="QLineEdit" name="emailEdit">
           <property name="placeholderText">
            <string>johndoe@mail.com</string>
           </property>
          </widget>
         </item>
-        <item row="8" column="0" colspan="2">
-         <widget class="Line" name="line">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="0">
-         <widget class="QLabel" name="label_4">
-          <property name="text">
-           <string>Version</string>
-          </property>
-         </widget>
-        </item>
-        <item row="5" column="0">
-         <widget class="QLabel" name="label_5">
-          <property name="text">
-           <string>Brief</string>
-          </property>
-         </widget>
-        </item>
         <item row="2" column="0">
-         <widget class="QLabel" name="label_3">
+         <widget class="QLabel" name="websiteLabel">
           <property name="text">
            <string>Website</string>
           </property>
          </widget>
         </item>
         <item row="2" column="1">
-         <widget class="QLineEdit" name="lineEdit_3">
+         <widget class="QLineEdit" name="websiteEdit">
           <property name="placeholderText">
            <string>http://www.johndoe.com</string>
           </property>
          </widget>
         </item>
+        <item row="3" column="0">
+         <widget class="QLabel" name="versionLabel">
+          <property name="text">
+           <string>Version</string>
+          </property>
+         </widget>
+        </item>
         <item row="3" column="1">
-         <widget class="QLineEdit" name="lineEdit_4">
+         <widget class="QLineEdit" name="versionEdit">
           <property name="text">
            <string>100</string>
           </property>
          </widget>
         </item>
+        <item row="4" column="0">
+         <widget class="QLabel" name="lastChangedLabel">
+          <property name="text">
+           <string>Changed</string>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="1">
+         <widget class="QDateTimeEdit" name="lastChangedEdit">
+          <property name="enabled">
+           <bool>true</bool>
+          </property>
+          <property name="readOnly">
+           <bool>true</bool>
+          </property>
+          <property name="buttonSymbols">
+           <enum>QAbstractSpinBox::NoButtons</enum>
+          </property>
+         </widget>
+        </item>
+        <item row="5" column="0">
+         <widget class="QLabel" name="briefLabel">
+          <property name="text">
+           <string>Brief</string>
+          </property>
+         </widget>
+        </item>
         <item row="5" column="1">
-         <widget class="QLineEdit" name="lineEdit_5"/>
+         <widget class="QLineEdit" name="briefEdit"/>
         </item>
         <item row="7" column="0" colspan="2">
-         <widget class="QGroupBox" name="groupBox_3">
+         <widget class="QGroupBox" name="informationBox">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
             <horstretch>0</horstretch>
@@ -229,29 +242,9 @@
             <number>0</number>
            </property>
            <item>
-            <widget class="QPlainTextEdit" name="plainTextEdit"/>
+            <widget class="QPlainTextEdit" name="informationPlainEdit"/>
            </item>
           </layout>
-         </widget>
-        </item>
-        <item row="4" column="0">
-         <widget class="QLabel" name="label_6">
-          <property name="text">
-           <string>Changed</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="1">
-         <widget class="QDateTimeEdit" name="dateTimeEdit">
-          <property name="enabled">
-           <bool>true</bool>
-          </property>
-          <property name="readOnly">
-           <bool>true</bool>
-          </property>
-          <property name="buttonSymbols">
-           <enum>QAbstractSpinBox::NoButtons</enum>
-          </property>
          </widget>
         </item>
        </layout>
@@ -279,56 +272,56 @@
            <number>4</number>
           </property>
           <item row="3" column="0">
-           <widget class="QCheckBox" name="checkBox_4">
+           <widget class="QCheckBox" name="stayontopCheckBox">
             <property name="text">
              <string>Window stay on &amp;top</string>
             </property>
            </widget>
           </item>
           <item row="0" column="0">
-           <widget class="QCheckBox" name="checkBox_3">
+           <widget class="QCheckBox" name="showCursorCheckBox">
             <property name="text">
              <string>Display the &amp;cursor</string>
             </property>
            </widget>
           </item>
           <item row="2" column="0">
-           <widget class="QCheckBox" name="checkBox_5">
+           <widget class="QCheckBox" name="windowBorderCheckBox">
             <property name="text">
              <string>Show window &amp;border</string>
             </property>
            </widget>
           </item>
           <item row="1" column="0">
-           <widget class="QCheckBox" name="checkBox_6">
+           <widget class="QCheckBox" name="showCaptionButtonsCheckBox">
             <property name="text">
              <string>Show &amp;caption buttons</string>
             </property>
            </widget>
           </item>
           <item row="0" column="1">
-           <widget class="QCheckBox" name="checkBox_2">
+           <widget class="QCheckBox" name="smoothColorsCheckBox">
             <property name="text">
              <string>&amp;Smooth colors</string>
             </property>
            </widget>
           </item>
           <item row="1" column="1">
-           <widget class="QCheckBox" name="checkBox">
+           <widget class="QCheckBox" name="startFullscreenCheckBox">
             <property name="text">
              <string>Start &amp;fullscreen</string>
             </property>
            </widget>
           </item>
           <item row="2" column="1">
-           <widget class="QCheckBox" name="checkBox_7">
+           <widget class="QCheckBox" name="windowResizeableCheckBox">
             <property name="text">
              <string>Window &amp;resizeable</string>
             </property>
            </widget>
           </item>
           <item row="3" column="1">
-           <widget class="QCheckBox" name="checkBox_8">
+           <widget class="QCheckBox" name="pauseCheckBox">
             <property name="text">
              <string>&amp;Pause on focus lost</string>
             </property>
@@ -364,14 +357,14 @@
             <number>4</number>
            </property>
            <item row="2" column="0">
-            <widget class="QRadioButton" name="radioButton_2">
+            <widget class="QRadioButton" name="keepAspectButton">
              <property name="text">
               <string>Keep aspect ratio</string>
              </property>
             </widget>
            </item>
            <item row="1" column="1">
-            <widget class="QSpinBox" name="spinBox">
+            <widget class="QSpinBox" name="fixedScaleSpinBox">
              <property name="sizePolicy">
               <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
                <horstretch>0</horstretch>
@@ -390,14 +383,14 @@
             </widget>
            </item>
            <item row="3" column="0">
-            <widget class="QRadioButton" name="radioButton_3">
+            <widget class="QRadioButton" name="fullScaleButton">
              <property name="text">
               <string>Full scale</string>
              </property>
             </widget>
            </item>
            <item row="1" column="0">
-            <widget class="QRadioButton" name="radioButton">
+            <widget class="QRadioButton" name="fixedScaleButton">
              <property name="sizePolicy">
               <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
                <horstretch>0</horstretch>
@@ -413,7 +406,7 @@
          </widget>
         </item>
         <item>
-         <spacer name="verticalSpacer_2">
+         <spacer name="graphicsVerticalSpacer">
           <property name="orientation">
            <enum>Qt::Vertical</enum>
           </property>
@@ -445,7 +438,7 @@
          <number>0</number>
         </property>
         <item>
-         <widget class="QGroupBox" name="groupBox">
+         <widget class="QGroupBox" name="compatibilityBox">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
             <horstretch>0</horstretch>
@@ -640,7 +633,7 @@
             </widget>
            </item>
            <item row="6" column="1">
-            <spacer name="verticalSpacer">
+            <spacer name="compilerPageVerticalSpacer">
              <property name="orientation">
               <enum>Qt::Vertical</enum>
              </property>
@@ -852,11 +845,11 @@
  </resources>
  <connections/>
  <buttongroups>
-  <buttongroup name="inheritEscapesGroup"/>
+  <buttongroup name="treatNegativesGroup"/>
+  <buttongroup name="inheritIncrementGroup"/>
+  <buttongroup name="inheritStringsGroup"/>
   <buttongroup name="treatLiteralsGroup"/>
   <buttongroup name="inheritEquivalenceGroup"/>
-  <buttongroup name="treatNegativesGroup"/>
-  <buttongroup name="inheritStringsGroup"/>
-  <buttongroup name="inheritIncrementGroup"/>
+  <buttongroup name="inheritEscapesGroup"/>
  </buttongroups>
 </ui>

--- a/Editors/SettingsEditor.ui
+++ b/Editors/SettingsEditor.ui
@@ -63,6 +63,16 @@
       </item>
       <item>
        <property name="text">
+        <string>Version</string>
+       </property>
+      </item>
+      <item>
+       <property name="text">
+        <string>Controls</string>
+       </property>
+      </item>
+      <item>
+       <property name="text">
         <string>Graphics</string>
        </property>
       </item>
@@ -198,17 +208,7 @@
           </property>
          </widget>
         </item>
-        <item row="5" column="0">
-         <widget class="QLabel" name="briefLabel">
-          <property name="text">
-           <string>Brief</string>
-          </property>
-         </widget>
-        </item>
-        <item row="5" column="1">
-         <widget class="QLineEdit" name="briefEdit"/>
-        </item>
-        <item row="7" column="0" colspan="2">
+        <item row="6" column="0" colspan="2">
          <widget class="QGroupBox" name="informationBox">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -230,16 +230,16 @@
             <number>4</number>
            </property>
            <property name="leftMargin">
-            <number>0</number>
+            <number>4</number>
            </property>
            <property name="topMargin">
-            <number>0</number>
+            <number>4</number>
            </property>
            <property name="rightMargin">
-            <number>0</number>
+            <number>4</number>
            </property>
            <property name="bottomMargin">
-            <number>0</number>
+            <number>4</number>
            </property>
            <item>
             <widget class="QPlainTextEdit" name="informationPlainEdit"/>
@@ -339,6 +339,9 @@
           </property>
           <property name="title">
            <string>Scaling</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
           </property>
           <layout class="QGridLayout" name="gridLayout_3" columnstretch="0,1">
            <property name="leftMargin">
@@ -440,7 +443,7 @@
         <item>
          <widget class="QGroupBox" name="compatibilityBox">
           <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+           <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
@@ -456,16 +459,16 @@
           </property>
           <layout class="QGridLayout" name="gridLayout_2">
            <property name="leftMargin">
-            <number>0</number>
+            <number>4</number>
            </property>
            <property name="topMargin">
-            <number>0</number>
+            <number>4</number>
            </property>
            <property name="rightMargin">
-            <number>0</number>
+            <number>4</number>
            </property>
            <property name="bottomMargin">
-            <number>0</number>
+            <number>4</number>
            </property>
            <property name="spacing">
             <number>4</number>
@@ -632,21 +635,21 @@
              </attribute>
             </widget>
            </item>
-           <item row="6" column="1">
-            <spacer name="compilerPageVerticalSpacer">
-             <property name="orientation">
-              <enum>Qt::Vertical</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>20</width>
-               <height>40</height>
-              </size>
-             </property>
-            </spacer>
-           </item>
           </layout>
          </widget>
+        </item>
+        <item>
+         <spacer name="compilerPageVerticalSpacer">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>40</height>
+           </size>
+          </property>
+         </spacer>
         </item>
        </layout>
       </widget>
@@ -766,16 +769,16 @@
           </property>
           <layout class="QGridLayout" name="gridLayout">
            <property name="leftMargin">
-            <number>0</number>
+            <number>4</number>
            </property>
            <property name="topMargin">
-            <number>0</number>
+            <number>4</number>
            </property>
            <property name="rightMargin">
-            <number>0</number>
+            <number>4</number>
            </property>
            <property name="bottomMargin">
-            <number>0</number>
+            <number>4</number>
            </property>
            <property name="spacing">
             <number>4</number>
@@ -803,6 +806,373 @@
            </item>
           </layout>
          </widget>
+        </item>
+       </layout>
+      </widget>
+      <widget class="QWidget" name="controlsPage">
+       <layout class="QVBoxLayout" name="verticalLayout_6" stretch="0,0,0">
+        <property name="spacing">
+         <number>4</number>
+        </property>
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
+         <number>0</number>
+        </property>
+        <item>
+         <layout class="QGridLayout" name="controlsGridLayout">
+          <property name="sizeConstraint">
+           <enum>QLayout::SetDefaultConstraint</enum>
+          </property>
+          <property name="spacing">
+           <number>4</number>
+          </property>
+          <item row="1" column="0">
+           <widget class="QLabel" name="showGameInfoKeyLabel">
+            <property name="text">
+             <string>Show game &amp;information</string>
+            </property>
+            <property name="buddy">
+             <cstring>showGameInfoKeyEdit</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="1">
+           <widget class="QKeySequenceEdit" name="screenshotKeyEdit">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="keySequence">
+             <string>F9</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QKeySequenceEdit" name="fullscreenKeyEdit">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="keySequence">
+             <string>F4</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QKeySequenceEdit" name="showGameInfoKeyEdit">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="keySequence">
+             <string>F1</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="QKeySequenceEdit" name="saveGameKeyEdit">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="keySequence">
+             <string>F5</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="1">
+           <widget class="QKeySequenceEdit" name="loadSavedGameKeyEdit">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="keySequence">
+             <string>F6</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="0">
+           <widget class="QLabel" name="endGameKeyLabel">
+            <property name="text">
+             <string>&amp;End the game</string>
+            </property>
+            <property name="buddy">
+             <cstring>endGameKeyEdit</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="saveGameKeyLabel">
+            <property name="text">
+             <string>Save the &amp;game</string>
+            </property>
+            <property name="buddy">
+             <cstring>saveGameKeyEdit</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="fullscreenKeyLabel">
+            <property name="text">
+             <string>Toggle &amp;fullscreen</string>
+            </property>
+            <property name="buddy">
+             <cstring>fullscreenKeyEdit</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="0">
+           <widget class="QLabel" name="screenshotKeyLabel">
+            <property name="text">
+             <string>Take a &amp;screenshot</string>
+            </property>
+            <property name="buddy">
+             <cstring>screenshotKeyEdit</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0">
+           <widget class="QLabel" name="loadSavedGameKeyLabel">
+            <property name="text">
+             <string>&amp;Load saved game</string>
+            </property>
+            <property name="buddy">
+             <cstring>loadSavedGameKeyEdit</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QKeySequenceEdit" name="endGameKeyEdit">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="keySequence">
+             <string>Esc</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <layout class="QHBoxLayout" name="horizontalLayout_3">
+          <property name="spacing">
+           <number>4</number>
+          </property>
+          <item>
+           <widget class="QCheckBox" name="closeButtonEndsCheckBox">
+            <property name="text">
+             <string>&amp;Close button ends game</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPushButton" name="defaultKeysButton">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>Defaults</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPushButton" name="clearAllkeysButton">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>Clear All</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <spacer name="controlsPageVerticalSpacer">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>40</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </widget>
+      <widget class="QWidget" name="versionPage">
+       <layout class="QVBoxLayout" name="verticalLayout_7">
+        <property name="spacing">
+         <number>4</number>
+        </property>
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
+         <number>0</number>
+        </property>
+        <item>
+         <layout class="QGridLayout" name="versionInfoGridLayout">
+          <property name="spacing">
+           <number>4</number>
+          </property>
+          <item row="1" column="0">
+           <widget class="QLabel" name="companyLabel">
+            <property name="text">
+             <string>&amp;Company</string>
+            </property>
+            <property name="buddy">
+             <cstring>companyLineEdit</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="6">
+           <widget class="QLabel" name="buildVersionLabel">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>&amp;Build</string>
+            </property>
+            <property name="buddy">
+             <cstring>buildVersionSpinBox</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="0">
+           <widget class="QLabel" name="majorVersionLabel">
+            <property name="text">
+             <string>&amp;Major</string>
+            </property>
+            <property name="buddy">
+             <cstring>majorVersionSpinBox</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="2">
+           <widget class="QLabel" name="minorVersionLabel">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>&amp;Minor</string>
+            </property>
+            <property name="buddy">
+             <cstring>minorVersionSpinBox</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="5">
+           <widget class="QSpinBox" name="releaseVersionSpinBox"/>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="productLabel">
+            <property name="text">
+             <string>&amp;Product</string>
+            </property>
+            <property name="buddy">
+             <cstring>productLineEdit</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QSpinBox" name="majorVersionSpinBox">
+            <property name="value">
+             <number>1</number>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="4">
+           <widget class="QLabel" name="releaseVersionLabel">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>&amp;Release</string>
+            </property>
+            <property name="buddy">
+             <cstring>releaseVersionSpinBox</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="3">
+           <widget class="QSpinBox" name="minorVersionSpinBox"/>
+          </item>
+          <item row="4" column="0">
+           <widget class="QLabel" name="descriptionLabel">
+            <property name="text">
+             <string>&amp;Description</string>
+            </property>
+            <property name="buddy">
+             <cstring>descriptionLineEdit</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="copyrightLabel">
+            <property name="text">
+             <string>&amp;Copyright</string>
+            </property>
+            <property name="buddy">
+             <cstring>copyrightLineEdit</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="7">
+           <widget class="QSpinBox" name="buildVersionSpinBox"/>
+          </item>
+          <item row="1" column="1" colspan="7">
+           <widget class="QLineEdit" name="companyLineEdit"/>
+          </item>
+          <item row="2" column="1" colspan="7">
+           <widget class="QLineEdit" name="productLineEdit"/>
+          </item>
+          <item row="3" column="1" colspan="7">
+           <widget class="QLineEdit" name="copyrightLineEdit"/>
+          </item>
+          <item row="4" column="1" colspan="7">
+           <widget class="QLineEdit" name="descriptionLineEdit"/>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <spacer name="versionPageVerticalSpacer">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>40</height>
+           </size>
+          </property>
+         </spacer>
         </item>
        </layout>
       </widget>
@@ -845,11 +1215,11 @@
  </resources>
  <connections/>
  <buttongroups>
-  <buttongroup name="treatNegativesGroup"/>
   <buttongroup name="inheritIncrementGroup"/>
-  <buttongroup name="inheritStringsGroup"/>
   <buttongroup name="treatLiteralsGroup"/>
-  <buttongroup name="inheritEquivalenceGroup"/>
+  <buttongroup name="treatNegativesGroup"/>
+  <buttongroup name="inheritStringsGroup"/>
   <buttongroup name="inheritEscapesGroup"/>
+  <buttongroup name="inheritEquivalenceGroup"/>
  </buttongroups>
 </ui>

--- a/Editors/SettingsEditor.ui
+++ b/Editors/SettingsEditor.ui
@@ -93,6 +93,191 @@
        </sizepolicy>
       </property>
       <widget class="QWidget" name="emptyPage"/>
+      <widget class="QWidget" name="graphicsPage">
+       <layout class="QVBoxLayout" name="verticalLayout_4" stretch="0,0,0">
+        <property name="spacing">
+         <number>4</number>
+        </property>
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
+         <number>0</number>
+        </property>
+        <item>
+         <widget class="QWidget" name="widget_2" native="true">
+          <layout class="QGridLayout" name="gridLayout_4">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
+           <property name="spacing">
+            <number>4</number>
+           </property>
+           <item row="9" column="0">
+            <widget class="QCheckBox" name="checkBox_4">
+             <property name="text">
+              <string>Window stay on &amp;top</string>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="1">
+            <widget class="QCheckBox" name="checkBox_2">
+             <property name="text">
+              <string>&amp;Smooth colors</string>
+             </property>
+            </widget>
+           </item>
+           <item row="4" column="1">
+            <widget class="QCheckBox" name="checkBox">
+             <property name="text">
+              <string>Start &amp;fullscreen</string>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="0">
+            <widget class="QCheckBox" name="checkBox_3">
+             <property name="text">
+              <string>Display the &amp;cursor</string>
+             </property>
+            </widget>
+           </item>
+           <item row="4" column="0">
+            <widget class="QCheckBox" name="checkBox_6">
+             <property name="text">
+              <string>Show &amp;caption buttons</string>
+             </property>
+            </widget>
+           </item>
+           <item row="7" column="1">
+            <widget class="QCheckBox" name="checkBox_7">
+             <property name="text">
+              <string>Window &amp;resizeable</string>
+             </property>
+            </widget>
+           </item>
+           <item row="7" column="0">
+            <widget class="QCheckBox" name="checkBox_5">
+             <property name="text">
+              <string>Show window &amp;border</string>
+             </property>
+            </widget>
+           </item>
+           <item row="9" column="1">
+            <widget class="QCheckBox" name="checkBox_8">
+             <property name="text">
+              <string>&amp;Pause on focus lost</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <item>
+         <widget class="QGroupBox" name="groupBox_2">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="title">
+           <string>Scaling</string>
+          </property>
+          <layout class="QGridLayout" name="gridLayout_3" columnstretch="0,1">
+           <property name="leftMargin">
+            <number>4</number>
+           </property>
+           <property name="topMargin">
+            <number>4</number>
+           </property>
+           <property name="rightMargin">
+            <number>4</number>
+           </property>
+           <property name="bottomMargin">
+            <number>4</number>
+           </property>
+           <property name="spacing">
+            <number>4</number>
+           </property>
+           <item row="2" column="0">
+            <widget class="QRadioButton" name="radioButton_2">
+             <property name="text">
+              <string>Keep aspect ratio</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="1">
+            <widget class="QSpinBox" name="spinBox">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimum">
+              <number>1</number>
+             </property>
+             <property name="maximum">
+              <number>1000</number>
+             </property>
+             <property name="value">
+              <number>100</number>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="0">
+            <widget class="QRadioButton" name="radioButton_3">
+             <property name="text">
+              <string>Full scale</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="0">
+            <widget class="QRadioButton" name="radioButton">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string>Fixed scale (in %):</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <item>
+         <spacer name="verticalSpacer_2">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>40</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </widget>
       <widget class="QWidget" name="compilerPage">
        <layout class="QVBoxLayout" name="verticalLayout_3">
         <property name="spacing">
@@ -538,11 +723,11 @@
  </resources>
  <connections/>
  <buttongroups>
-  <buttongroup name="treatNegativesGroup"/>
-  <buttongroup name="treatLiteralsGroup"/>
-  <buttongroup name="inheritEscapesGroup"/>
   <buttongroup name="inheritEquivalenceGroup"/>
-  <buttongroup name="inheritIncrementGroup"/>
+  <buttongroup name="treatLiteralsGroup"/>
   <buttongroup name="inheritStringsGroup"/>
+  <buttongroup name="inheritEscapesGroup"/>
+  <buttongroup name="treatNegativesGroup"/>
+  <buttongroup name="inheritIncrementGroup"/>
  </buttongroups>
 </ui>

--- a/Editors/SettingsEditor.ui
+++ b/Editors/SettingsEditor.ui
@@ -144,7 +144,7 @@
             <number>4</number>
            </property>
            <item row="1" column="2">
-            <widget class="QRadioButton" name="radioButton_3">
+            <widget class="QRadioButton" name="inheritEscapesCPP">
              <property name="text">
               <string>C++ (\n)</string>
              </property>
@@ -154,7 +154,7 @@
             </widget>
            </item>
            <item row="4" column="2">
-            <widget class="QRadioButton" name="radioButton_9">
+            <widget class="QRadioButton" name="treatLiteralsCPP">
              <property name="text">
               <string>C++ (scalar)</string>
              </property>
@@ -164,7 +164,7 @@
             </widget>
            </item>
            <item row="5" column="2">
-            <widget class="QRadioButton" name="radioButton_11">
+            <widget class="QRadioButton" name="treatNegativesCPP">
              <property name="text">
               <string>C++ (true != 0)</string>
              </property>
@@ -174,7 +174,7 @@
             </widget>
            </item>
            <item row="2" column="2">
-            <widget class="QRadioButton" name="radioButton_5">
+            <widget class="QRadioButton" name="inheritIncrementCPP">
              <property name="text">
               <string>C++ (+=1/-=1)</string>
              </property>
@@ -184,7 +184,7 @@
             </widget>
            </item>
            <item row="0" column="2">
-            <widget class="QRadioButton" name="radioButton_2">
+            <widget class="QRadioButton" name="inheritStringsCPP">
              <property name="text">
               <string>C++ ('A'=65)</string>
              </property>
@@ -194,17 +194,17 @@
             </widget>
            </item>
            <item row="3" column="2">
-            <widget class="QRadioButton" name="radioButton_7">
+            <widget class="QRadioButton" name="inheritEquivalenceCPP">
              <property name="text">
               <string>C++ (b=c;a=c)</string>
              </property>
              <attribute name="buttonGroup">
-              <string notr="true">inheritEqualityGroup</string>
+              <string notr="true">inheritEquivalenceGroup</string>
              </attribute>
             </widget>
            </item>
            <item row="2" column="1">
-            <widget class="QRadioButton" name="radioButton_6">
+            <widget class="QRadioButton" name="inheritIncrementGML">
              <property name="text">
               <string>GML (+)</string>
              </property>
@@ -214,7 +214,7 @@
             </widget>
            </item>
            <item row="1" column="1">
-            <widget class="QRadioButton" name="radioButton_4">
+            <widget class="QRadioButton" name="inheritEscapesGML">
              <property name="text">
               <string>GML (#)</string>
              </property>
@@ -224,17 +224,17 @@
             </widget>
            </item>
            <item row="3" column="1">
-            <widget class="QRadioButton" name="radioButton_8">
+            <widget class="QRadioButton" name="inheritEquivalenceGML">
              <property name="text">
               <string>GMl (a=b==c)</string>
              </property>
              <attribute name="buttonGroup">
-              <string notr="true">inheritEqualityGroup</string>
+              <string notr="true">inheritEquivalenceGroup</string>
              </attribute>
             </widget>
            </item>
            <item row="0" column="1">
-            <widget class="QRadioButton" name="radioButton">
+            <widget class="QRadioButton" name="inheritStringsGML">
              <property name="text">
               <string>GML ('A'=&quot;A&quot;)</string>
              </property>
@@ -244,49 +244,49 @@
             </widget>
            </item>
            <item row="0" column="0">
-            <widget class="QLabel" name="label">
+            <widget class="QLabel" name="inheritStringsLabel">
              <property name="text">
               <string>Inherit strings from:</string>
              </property>
             </widget>
            </item>
            <item row="1" column="0">
-            <widget class="QLabel" name="label_2">
+            <widget class="QLabel" name="inheritEscapesLabel">
              <property name="text">
               <string>Inherit escapes from:</string>
              </property>
             </widget>
            </item>
            <item row="4" column="0">
-            <widget class="QLabel" name="label_5">
+            <widget class="QLabel" name="treatLiteralsLabel">
              <property name="text">
               <string>Treat literals as:</string>
              </property>
             </widget>
            </item>
            <item row="3" column="0">
-            <widget class="QLabel" name="label_4">
+            <widget class="QLabel" name="inheritEquivalenceLabel">
              <property name="text">
               <string>Inherit a=b=c from:</string>
              </property>
             </widget>
            </item>
            <item row="5" column="0">
-            <widget class="QLabel" name="label_6">
+            <widget class="QLabel" name="treatNegativesLabel">
              <property name="text">
               <string>Treat negatives as:</string>
              </property>
             </widget>
            </item>
            <item row="2" column="0">
-            <widget class="QLabel" name="label_3">
+            <widget class="QLabel" name="inheritIncrementLabel">
              <property name="text">
               <string>Inherit ++/-- from:</string>
              </property>
             </widget>
            </item>
            <item row="4" column="1">
-            <widget class="QRadioButton" name="radioButton_10">
+            <widget class="QRadioButton" name="treatLiteralsEDL">
              <property name="text">
               <string>EDL (variant)</string>
              </property>
@@ -296,7 +296,7 @@
             </widget>
            </item>
            <item row="5" column="1">
-            <widget class="QRadioButton" name="radioButton_12">
+            <widget class="QRadioButton" name="treatNegativesGML">
              <property name="text">
               <string>GML (true &gt; 0)</string>
              </property>
@@ -538,11 +538,11 @@
  </resources>
  <connections/>
  <buttongroups>
-  <buttongroup name="inheritStringsGroup"/>
-  <buttongroup name="inheritEscapesGroup"/>
-  <buttongroup name="inheritIncrementGroup"/>
-  <buttongroup name="inheritEqualityGroup"/>
-  <buttongroup name="treatLiteralsGroup"/>
   <buttongroup name="treatNegativesGroup"/>
+  <buttongroup name="treatLiteralsGroup"/>
+  <buttongroup name="inheritEscapesGroup"/>
+  <buttongroup name="inheritEquivalenceGroup"/>
+  <buttongroup name="inheritIncrementGroup"/>
+  <buttongroup name="inheritStringsGroup"/>
  </buttongroups>
 </ui>

--- a/Editors/SettingsEditor.ui
+++ b/Editors/SettingsEditor.ui
@@ -93,6 +93,169 @@
        </sizepolicy>
       </property>
       <widget class="QWidget" name="emptyPage"/>
+      <widget class="QWidget" name="projectInfoPage">
+       <layout class="QFormLayout" name="formLayout_2">
+        <property name="horizontalSpacing">
+         <number>4</number>
+        </property>
+        <property name="verticalSpacing">
+         <number>4</number>
+        </property>
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
+         <number>0</number>
+        </property>
+        <item row="0" column="0">
+         <widget class="QLabel" name="label">
+          <property name="text">
+           <string>Author</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="label_2">
+          <property name="text">
+           <string>Email</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="QLineEdit" name="lineEdit">
+          <property name="inputMask">
+           <string/>
+          </property>
+          <property name="text">
+           <string/>
+          </property>
+          <property name="frame">
+           <bool>true</bool>
+          </property>
+          <property name="placeholderText">
+           <string>John Doe</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <widget class="QLineEdit" name="lineEdit_2">
+          <property name="placeholderText">
+           <string>johndoe@mail.com</string>
+          </property>
+         </widget>
+        </item>
+        <item row="8" column="0" colspan="2">
+         <widget class="Line" name="line">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="0">
+         <widget class="QLabel" name="label_4">
+          <property name="text">
+           <string>Version</string>
+          </property>
+         </widget>
+        </item>
+        <item row="5" column="0">
+         <widget class="QLabel" name="label_5">
+          <property name="text">
+           <string>Brief</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="0">
+         <widget class="QLabel" name="label_3">
+          <property name="text">
+           <string>Website</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="1">
+         <widget class="QLineEdit" name="lineEdit_3">
+          <property name="placeholderText">
+           <string>http://www.johndoe.com</string>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="1">
+         <widget class="QLineEdit" name="lineEdit_4">
+          <property name="text">
+           <string>100</string>
+          </property>
+         </widget>
+        </item>
+        <item row="5" column="1">
+         <widget class="QLineEdit" name="lineEdit_5"/>
+        </item>
+        <item row="7" column="0" colspan="2">
+         <widget class="QGroupBox" name="groupBox_3">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>1</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="title">
+           <string>Information</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignCenter</set>
+          </property>
+          <property name="flat">
+           <bool>true</bool>
+          </property>
+          <layout class="QVBoxLayout" name="verticalLayout_5">
+           <property name="spacing">
+            <number>4</number>
+           </property>
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
+           <item>
+            <widget class="QPlainTextEdit" name="plainTextEdit"/>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <item row="4" column="0">
+         <widget class="QLabel" name="label_6">
+          <property name="text">
+           <string>Changed</string>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="1">
+         <widget class="QDateTimeEdit" name="dateTimeEdit">
+          <property name="enabled">
+           <bool>true</bool>
+          </property>
+          <property name="readOnly">
+           <bool>true</bool>
+          </property>
+          <property name="buttonSymbols">
+           <enum>QAbstractSpinBox::NoButtons</enum>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
       <widget class="QWidget" name="graphicsPage">
        <layout class="QVBoxLayout" name="verticalLayout_4" stretch="0,0,0">
         <property name="spacing">
@@ -111,81 +274,67 @@
          <number>0</number>
         </property>
         <item>
-         <widget class="QWidget" name="widget_2" native="true">
-          <layout class="QGridLayout" name="gridLayout_4">
-           <property name="leftMargin">
-            <number>0</number>
-           </property>
-           <property name="topMargin">
-            <number>0</number>
-           </property>
-           <property name="rightMargin">
-            <number>0</number>
-           </property>
-           <property name="bottomMargin">
-            <number>0</number>
-           </property>
-           <property name="spacing">
-            <number>4</number>
-           </property>
-           <item row="9" column="0">
-            <widget class="QCheckBox" name="checkBox_4">
-             <property name="text">
-              <string>Window stay on &amp;top</string>
-             </property>
-            </widget>
-           </item>
-           <item row="3" column="1">
-            <widget class="QCheckBox" name="checkBox_2">
-             <property name="text">
-              <string>&amp;Smooth colors</string>
-             </property>
-            </widget>
-           </item>
-           <item row="4" column="1">
-            <widget class="QCheckBox" name="checkBox">
-             <property name="text">
-              <string>Start &amp;fullscreen</string>
-             </property>
-            </widget>
-           </item>
-           <item row="3" column="0">
-            <widget class="QCheckBox" name="checkBox_3">
-             <property name="text">
-              <string>Display the &amp;cursor</string>
-             </property>
-            </widget>
-           </item>
-           <item row="4" column="0">
-            <widget class="QCheckBox" name="checkBox_6">
-             <property name="text">
-              <string>Show &amp;caption buttons</string>
-             </property>
-            </widget>
-           </item>
-           <item row="7" column="1">
-            <widget class="QCheckBox" name="checkBox_7">
-             <property name="text">
-              <string>Window &amp;resizeable</string>
-             </property>
-            </widget>
-           </item>
-           <item row="7" column="0">
-            <widget class="QCheckBox" name="checkBox_5">
-             <property name="text">
-              <string>Show window &amp;border</string>
-             </property>
-            </widget>
-           </item>
-           <item row="9" column="1">
-            <widget class="QCheckBox" name="checkBox_8">
-             <property name="text">
-              <string>&amp;Pause on focus lost</string>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </widget>
+         <layout class="QGridLayout" name="gridLayout_5">
+          <property name="spacing">
+           <number>4</number>
+          </property>
+          <item row="3" column="0">
+           <widget class="QCheckBox" name="checkBox_4">
+            <property name="text">
+             <string>Window stay on &amp;top</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="0">
+           <widget class="QCheckBox" name="checkBox_3">
+            <property name="text">
+             <string>Display the &amp;cursor</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QCheckBox" name="checkBox_5">
+            <property name="text">
+             <string>Show window &amp;border</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QCheckBox" name="checkBox_6">
+            <property name="text">
+             <string>Show &amp;caption buttons</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QCheckBox" name="checkBox_2">
+            <property name="text">
+             <string>&amp;Smooth colors</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QCheckBox" name="checkBox">
+            <property name="text">
+             <string>Start &amp;fullscreen</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QCheckBox" name="checkBox_7">
+            <property name="text">
+             <string>Window &amp;resizeable</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="QCheckBox" name="checkBox_8">
+            <property name="text">
+             <string>&amp;Pause on focus lost</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </item>
         <item>
          <widget class="QGroupBox" name="groupBox_2">
@@ -526,104 +675,84 @@
          <number>0</number>
         </property>
         <item>
-         <widget class="QWidget" name="widget" native="true">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
+         <layout class="QFormLayout" name="systemsLayout">
+          <property name="horizontalSpacing">
+           <number>4</number>
           </property>
-          <layout class="QFormLayout" name="formLayout">
-           <property name="horizontalSpacing">
-            <number>4</number>
-           </property>
-           <property name="verticalSpacing">
-            <number>4</number>
-           </property>
-           <property name="leftMargin">
-            <number>0</number>
-           </property>
-           <property name="topMargin">
-            <number>0</number>
-           </property>
-           <property name="rightMargin">
-            <number>0</number>
-           </property>
-           <property name="bottomMargin">
-            <number>0</number>
-           </property>
-           <item row="0" column="0">
-            <widget class="QLabel" name="audioLabel">
-             <property name="text">
-              <string>Audio</string>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="1">
-            <widget class="QComboBox" name="audioCombo"/>
-           </item>
-           <item row="1" column="0">
-            <widget class="QLabel" name="platformLabel">
-             <property name="text">
-              <string>Platform</string>
-             </property>
-            </widget>
-           </item>
-           <item row="1" column="1">
-            <widget class="QComboBox" name="platformCombo"/>
-           </item>
-           <item row="2" column="0">
-            <widget class="QLabel" name="compilerLabel">
-             <property name="text">
-              <string>Compiler</string>
-             </property>
-            </widget>
-           </item>
-           <item row="2" column="1">
-            <widget class="QComboBox" name="compilerCombo"/>
-           </item>
-           <item row="3" column="1">
-            <widget class="QComboBox" name="graphicsCombo"/>
-           </item>
-           <item row="3" column="0">
-            <widget class="QLabel" name="graphicsLabel">
-             <property name="text">
-              <string>Graphics</string>
-             </property>
-            </widget>
-           </item>
-           <item row="4" column="1">
-            <widget class="QComboBox" name="widgetsCombo"/>
-           </item>
-           <item row="4" column="0">
-            <widget class="QLabel" name="widgetsLabel">
-             <property name="text">
-              <string>Widgets</string>
-             </property>
-            </widget>
-           </item>
-           <item row="5" column="1">
-            <widget class="QComboBox" name="collisionCombo"/>
-           </item>
-           <item row="5" column="0">
-            <widget class="QLabel" name="collisionLabel">
-             <property name="text">
-              <string>Collision</string>
-             </property>
-            </widget>
-           </item>
-           <item row="6" column="1">
-            <widget class="QComboBox" name="networkCombo"/>
-           </item>
-           <item row="6" column="0">
-            <widget class="QLabel" name="networkLabel">
-             <property name="text">
-              <string>Network</string>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </widget>
+          <property name="verticalSpacing">
+           <number>4</number>
+          </property>
+          <item row="0" column="0">
+           <widget class="QLabel" name="audioLabel">
+            <property name="text">
+             <string>Audio</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QComboBox" name="audioCombo"/>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="platformLabel">
+            <property name="text">
+             <string>Platform</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QComboBox" name="platformCombo"/>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="compilerLabel">
+            <property name="text">
+             <string>Compiler</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="graphicsLabel">
+            <property name="text">
+             <string>Graphics</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0">
+           <widget class="QLabel" name="widgetsLabel">
+            <property name="text">
+             <string>Widgets</string>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="0">
+           <widget class="QLabel" name="collisionLabel">
+            <property name="text">
+             <string>Collision</string>
+            </property>
+           </widget>
+          </item>
+          <item row="6" column="0">
+           <widget class="QLabel" name="networkLabel">
+            <property name="text">
+             <string>Network</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QComboBox" name="compilerCombo"/>
+          </item>
+          <item row="3" column="1">
+           <widget class="QComboBox" name="graphicsCombo"/>
+          </item>
+          <item row="4" column="1">
+           <widget class="QComboBox" name="widgetsCombo"/>
+          </item>
+          <item row="5" column="1">
+           <widget class="QComboBox" name="collisionCombo"/>
+          </item>
+          <item row="6" column="1">
+           <widget class="QComboBox" name="networkCombo"/>
+          </item>
+         </layout>
         </item>
         <item>
          <widget class="QGroupBox" name="aboutSystemBox">
@@ -658,17 +787,17 @@
            <property name="spacing">
             <number>4</number>
            </property>
-           <item row="0" column="1">
-            <widget class="QLineEdit" name="authorName">
-             <property name="readOnly">
-              <bool>true</bool>
-             </property>
-            </widget>
-           </item>
            <item row="0" column="0">
             <widget class="QLabel" name="authorLabel">
              <property name="text">
               <string>Author</string>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <widget class="QLineEdit" name="authorName">
+             <property name="readOnly">
+              <bool>true</bool>
              </property>
             </widget>
            </item>
@@ -723,11 +852,11 @@
  </resources>
  <connections/>
  <buttongroups>
-  <buttongroup name="inheritEquivalenceGroup"/>
-  <buttongroup name="treatLiteralsGroup"/>
-  <buttongroup name="inheritStringsGroup"/>
   <buttongroup name="inheritEscapesGroup"/>
+  <buttongroup name="treatLiteralsGroup"/>
+  <buttongroup name="inheritEquivalenceGroup"/>
   <buttongroup name="treatNegativesGroup"/>
+  <buttongroup name="inheritStringsGroup"/>
   <buttongroup name="inheritIncrementGroup"/>
  </buttongroups>
 </ui>

--- a/Editors/SettingsEditor.ui
+++ b/Editors/SettingsEditor.ui
@@ -87,6 +87,101 @@
         <verstretch>0</verstretch>
        </sizepolicy>
       </property>
+      <widget class="QWidget" name="API">
+       <layout class="QFormLayout" name="formLayout">
+        <property name="labelAlignment">
+         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+        </property>
+        <property name="horizontalSpacing">
+         <number>4</number>
+        </property>
+        <property name="verticalSpacing">
+         <number>4</number>
+        </property>
+        <property name="leftMargin">
+         <number>4</number>
+        </property>
+        <property name="topMargin">
+         <number>4</number>
+        </property>
+        <property name="rightMargin">
+         <number>4</number>
+        </property>
+        <property name="bottomMargin">
+         <number>4</number>
+        </property>
+        <item row="0" column="0">
+         <widget class="QLabel" name="audioLabel">
+          <property name="text">
+           <string>Audio</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="windowingLabel">
+          <property name="text">
+           <string>Windowing</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="0">
+         <widget class="QLabel" name="compilerLabel">
+          <property name="text">
+           <string>Compiler</string>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="0">
+         <widget class="QLabel" name="graphicsLabel">
+          <property name="text">
+           <string>Graphics</string>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="0">
+         <widget class="QLabel" name="widgetsLabel">
+          <property name="text">
+           <string>Widgets</string>
+          </property>
+         </widget>
+        </item>
+        <item row="5" column="0">
+         <widget class="QLabel" name="collisionsLabel">
+          <property name="text">
+           <string>Collisions</string>
+          </property>
+         </widget>
+        </item>
+        <item row="6" column="0">
+         <widget class="QLabel" name="networkingLabel">
+          <property name="text">
+           <string>Networking</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="QComboBox" name="comboBox"/>
+        </item>
+        <item row="1" column="1">
+         <widget class="QComboBox" name="comboBox_2"/>
+        </item>
+        <item row="2" column="1">
+         <widget class="QComboBox" name="comboBox_3"/>
+        </item>
+        <item row="3" column="1">
+         <widget class="QComboBox" name="comboBox_4"/>
+        </item>
+        <item row="4" column="1">
+         <widget class="QComboBox" name="comboBox_5"/>
+        </item>
+        <item row="5" column="1">
+         <widget class="QComboBox" name="comboBox_6"/>
+        </item>
+        <item row="6" column="1">
+         <widget class="QComboBox" name="comboBox_7"/>
+        </item>
+       </layout>
+      </widget>
      </widget>
     </widget>
    </item>

--- a/Editors/SpriteEditor.ui
+++ b/Editors/SpriteEditor.ui
@@ -94,13 +94,6 @@
         </widget>
        </item>
        <item>
-        <widget class="QCheckBox" name="transparentCheckBox">
-         <property name="text">
-          <string>&amp;Transparent</string>
-         </property>
-        </widget>
-       </item>
-       <item>
         <widget class="QCheckBox" name="preloadCheckBox">
          <property name="text">
           <string>Pre&amp;load texture</string>

--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -10,6 +10,7 @@
 #include "Editors/PathEditor.h"
 #include "Editors/RoomEditor.h"
 #include "Editors/ScriptEditor.h"
+#include "Editors/SettingsEditor.h"
 #include "Editors/SoundEditor.h"
 #include "Editors/SpriteEditor.h"
 #include "Editors/TimelineEditor.h"
@@ -112,7 +113,8 @@ void MainWindow::openSubWindow(buffers::TreeNode *item) {
                                 {TypeCase::kScript, EditorFactory<ScriptEditor>},
                                 {TypeCase::kTimeline, EditorFactory<TimelineEditor>},
                                 {TypeCase::kObject, EditorFactory<ObjectEditor>},
-                                {TypeCase::kRoom, EditorFactory<RoomEditor>}});
+                                {TypeCase::kRoom, EditorFactory<RoomEditor>},
+                                {TypeCase::kSettings, EditorFactory<SettingsEditor>}});
 
   const Descriptor *desc = item->GetDescriptor();
   const Reflection *refl = item->GetReflection();

--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -31,6 +31,8 @@
 
 #undef GetMessage
 
+QList<buffers::SystemType> MainWindow::systemCache;
+
 MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWindow) {
   ArtManager::Init();
 

--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -57,6 +57,7 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWi
   auto outputTextBrowser = this->ui->outputTextBrowser;
   connect(pluginServer, &RGMPlugin::OutputRead, outputTextBrowser, &QTextBrowser::append);
   connect(pluginServer, &RGMPlugin::ErrorRead, outputTextBrowser, &QTextBrowser::append);
+  connect(this, &MainWindow::CurrentConfigChanged, pluginServer, &RGMPlugin::SetCurrentConfig);
   connect(ui->actionRun, &QAction::triggered, pluginServer, &RGMPlugin::Run);
   connect(ui->actionDebug, &QAction::triggered, pluginServer, &RGMPlugin::Debug);
   connect(ui->actionCreateExecutable, &QAction::triggered, pluginServer, &RGMPlugin::CreateExecutable);

--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -62,10 +62,6 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWi
 
 MainWindow::~MainWindow() { delete ui; }
 
-void MainWindow::addSystemMenu(QAction *menu) {
-  ui->menuChangeGameSettings->insertAction(ui->actionSettingsProperties, menu);
-}
-
 void MainWindow::readSettings() {
   QSettings settings;
 

--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -59,8 +59,7 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWi
 
   RGMPlugin *pluginServer = new ServerPlugin(*this);
   auto outputTextBrowser = this->ui->outputTextBrowser;
-  connect(pluginServer, &RGMPlugin::OutputRead, outputTextBrowser, &QTextBrowser::append);
-  connect(pluginServer, &RGMPlugin::ErrorRead, outputTextBrowser, &QTextBrowser::append);
+  connect(pluginServer, &RGMPlugin::LogOutput, outputTextBrowser, &QTextBrowser::append);
   connect(pluginServer, &RGMPlugin::CompileStatusChanged, [=](bool finished) {
     ui->outputDockWidget->show();
     ui->actionRun->setEnabled(finished);

--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -61,8 +61,8 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWi
 
 MainWindow::~MainWindow() { delete ui; }
 
-void MainWindow::addSystemMenu(QMenu *menu) {
-  ui->menuChangeGameSettings->insertMenu(ui->actionSettingsProperties, menu);
+void MainWindow::addSystemMenu(QAction *menu) {
+  ui->menuChangeGameSettings->insertAction(ui->actionSettingsProperties, menu);
 }
 
 void MainWindow::readSettings() {

--- a/MainWindow.h
+++ b/MainWindow.h
@@ -37,6 +37,7 @@ class MainWindow : public QMainWindow {
 
  public slots:
   void openFile(QString fName);
+  static void setCurrentConfig(const buffers::resources::Settings &settings);
 
  private slots:
   // file menu
@@ -66,6 +67,8 @@ class MainWindow : public QMainWindow {
   void on_treeView_doubleClicked(const QModelIndex &index);
 
  private:
+  static MainWindow *m_instance;
+
   QHash<buffers::TreeNode *, ProtoModel *> resourceModels;
   QHash<buffers::TreeNode *, QMdiSubWindow *> subWindows;
 

--- a/MainWindow.h
+++ b/MainWindow.h
@@ -26,7 +26,7 @@ class MainWindow : public QMainWindow {
   ~MainWindow();
   void closeEvent(QCloseEvent *event);
 
-  void addSystemMenu(QMenu *menu);
+  void addSystemMenu(QAction *menu);
 
   buffers::Game *Game() const { return this->project->mutable_game(); }
 

--- a/MainWindow.h
+++ b/MainWindow.h
@@ -26,8 +26,6 @@ class MainWindow : public QMainWindow {
   ~MainWindow();
   void closeEvent(QCloseEvent *event);
 
-  void addSystemMenu(QAction *menu);
-
   buffers::Game *Game() const { return this->project->mutable_game(); }
 
  public slots:

--- a/MainWindow.h
+++ b/MainWindow.h
@@ -8,7 +8,9 @@ class MainWindow;
 #include "Components/RecentFiles.h"
 
 #include "codegen/project.pb.h"
+#include "codegen/server.pb.h"
 
+#include <QList>
 #include <QMainWindow>
 #include <QMdiSubWindow>
 #include <QPointer>
@@ -27,6 +29,8 @@ class MainWindow : public QMainWindow {
   void closeEvent(QCloseEvent *event);
 
   buffers::Game *Game() const { return this->project->mutable_game(); }
+
+  static QList<buffers::SystemType> systemCache;
 
  public slots:
   void openFile(QString fName);

--- a/MainWindow.h
+++ b/MainWindow.h
@@ -32,6 +32,9 @@ class MainWindow : public QMainWindow {
 
   static QList<buffers::SystemType> systemCache;
 
+ signals:
+  void CurrentConfigChanged(const buffers::resources::Settings &settings);
+
  public slots:
   void openFile(QString fName);
 

--- a/MainWindow.ui
+++ b/MainWindow.ui
@@ -788,11 +788,6 @@
     <string>Target</string>
    </property>
   </action>
-  <action name="actionSelect">
-   <property name="text">
-    <string>Select</string>
-   </property>
-  </action>
   <action name="actionAddNewConfig">
    <property name="icon">
     <iconset resource="images.qrc">
@@ -800,29 +795,6 @@
    </property>
    <property name="text">
     <string>Add New</string>
-   </property>
-  </action>
-  <action name="actionSelect_2">
-   <property name="text">
-    <string>Select</string>
-   </property>
-  </action>
-  <action name="actionDelete">
-   <property name="icon">
-    <iconset resource="images.qrc">
-     <normaloff>:/actions/delete.png</normaloff>:/actions/delete.png</iconset>
-   </property>
-   <property name="text">
-    <string>Delete</string>
-   </property>
-  </action>
-  <action name="actionDelete_2">
-   <property name="icon">
-    <iconset resource="images.qrc">
-     <normaloff>:/actions/delete.png</normaloff>:/actions/delete.png</iconset>
-   </property>
-   <property name="text">
-    <string>Delete</string>
    </property>
   </action>
   <action name="actionSettingsProperties">
@@ -864,101 +836,6 @@
     </property>
     <property name="text">
      <string>Configuration 1</string>
-    </property>
-   </action>
-  </actiongroup>
-  <actiongroup name="platformActionGroup">
-   <action name="actionWin32">
-    <property name="checkable">
-     <bool>true</bool>
-    </property>
-    <property name="checked">
-     <bool>true</bool>
-    </property>
-    <property name="text">
-     <string>Win32</string>
-    </property>
-   </action>
-   <action name="actionXlib">
-    <property name="checkable">
-     <bool>true</bool>
-    </property>
-    <property name="text">
-     <string>Xlib</string>
-    </property>
-   </action>
-   <action name="actionCocoa">
-    <property name="checkable">
-     <bool>true</bool>
-    </property>
-    <property name="text">
-     <string>Cocoa</string>
-    </property>
-   </action>
-  </actiongroup>
-  <actiongroup name="graphicsActionGroup">
-   <action name="actionOpenGL1">
-    <property name="checkable">
-     <bool>true</bool>
-    </property>
-    <property name="text">
-     <string>OpenGL1</string>
-    </property>
-   </action>
-   <action name="actionOpenGL3">
-    <property name="checkable">
-     <bool>true</bool>
-    </property>
-    <property name="text">
-     <string>OpenGL3</string>
-    </property>
-   </action>
-   <action name="actionDirect3D9">
-    <property name="checkable">
-     <bool>true</bool>
-    </property>
-    <property name="checked">
-     <bool>true</bool>
-    </property>
-    <property name="text">
-     <string>Direct3D9</string>
-    </property>
-   </action>
-   <action name="actionDirect3D11">
-    <property name="checkable">
-     <bool>true</bool>
-    </property>
-    <property name="text">
-     <string>Direct3D11</string>
-    </property>
-   </action>
-  </actiongroup>
-  <actiongroup name="targetActionGroup">
-   <action name="actionGCC32">
-    <property name="checkable">
-     <bool>true</bool>
-    </property>
-    <property name="checked">
-     <bool>true</bool>
-    </property>
-    <property name="text">
-     <string>GCC 32</string>
-    </property>
-   </action>
-   <action name="actionGCC64">
-    <property name="checkable">
-     <bool>true</bool>
-    </property>
-    <property name="text">
-     <string>GCC 64</string>
-    </property>
-   </action>
-   <action name="actionMSVC17">
-    <property name="checkable">
-     <bool>true</bool>
-    </property>
-    <property name="text">
-     <string>MSVC 17</string>
     </property>
    </action>
   </actiongroup>

--- a/MainWindow.ui
+++ b/MainWindow.ui
@@ -175,7 +175,7 @@
     </property>
     <widget class="QMenu" name="menuChangeGameSettings">
      <property name="title">
-      <string>Change Game Settings</string>
+      <string>Change &amp;Game Settings</string>
      </property>
      <property name="icon">
       <iconset resource="images.qrc">
@@ -650,7 +650,7 @@
      <normaloff>:/resources/sprite.png</normaloff>:/resources/sprite.png</iconset>
    </property>
    <property name="text">
-    <string>Create Sprite</string>
+    <string>Create &amp;Sprite</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+Shift+S</string>
@@ -662,7 +662,7 @@
      <normaloff>:/resources/sound.png</normaloff>:/resources/sound.png</iconset>
    </property>
    <property name="text">
-    <string>Create Sound</string>
+    <string>Create &amp;Sound</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+Shift+U</string>
@@ -674,7 +674,7 @@
      <normaloff>:/resources/background.png</normaloff>:/resources/background.png</iconset>
    </property>
    <property name="text">
-    <string>Create Background</string>
+    <string>Create &amp;Background</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+Shift+B</string>
@@ -686,7 +686,7 @@
      <normaloff>:/resources/path.png</normaloff>:/resources/path.png</iconset>
    </property>
    <property name="text">
-    <string>Create Path</string>
+    <string>Create &amp;Path</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+Shift+P</string>
@@ -698,7 +698,7 @@
      <normaloff>:/resources/script.png</normaloff>:/resources/script.png</iconset>
    </property>
    <property name="text">
-    <string>Create Script</string>
+    <string>Create &amp;Script</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+Shift+C</string>
@@ -710,7 +710,7 @@
      <normaloff>:/resources/shader.png</normaloff>:/resources/shader.png</iconset>
    </property>
    <property name="text">
-    <string>Create Shader</string>
+    <string>Create &amp;Shader</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+Shift+A</string>
@@ -722,7 +722,7 @@
      <normaloff>:/resources/font.png</normaloff>:/resources/font.png</iconset>
    </property>
    <property name="text">
-    <string>Create Font</string>
+    <string>Create &amp;Font</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+Shift+F</string>
@@ -734,7 +734,7 @@
      <normaloff>:/resources/timeline.png</normaloff>:/resources/timeline.png</iconset>
    </property>
    <property name="text">
-    <string>Create Timeline</string>
+    <string>Create &amp;Timeline</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+Shift+T</string>
@@ -746,7 +746,7 @@
      <normaloff>:/resources/object-empty.png</normaloff>:/resources/object-empty.png</iconset>
    </property>
    <property name="text">
-    <string>Create Object</string>
+    <string>Create &amp;Object</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+Shift+O</string>
@@ -758,7 +758,7 @@
      <normaloff>:/resources/room.png</normaloff>:/resources/room.png</iconset>
    </property>
    <property name="text">
-    <string>Create Room</string>
+    <string>Create &amp;Room</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+Shift+R</string>
@@ -770,7 +770,7 @@
      <normaloff>:/resources/constants.png</normaloff>:/resources/constants.png</iconset>
    </property>
    <property name="text">
-    <string>Define Macros...</string>
+    <string>Define &amp;Macros...</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+Shift+N</string>
@@ -787,7 +787,10 @@
      <normaloff>:/actions/add.png</normaloff>:/actions/add.png</iconset>
    </property>
    <property name="text">
-    <string>Add New</string>
+    <string>Create &amp;Config</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+Alt+G</string>
    </property>
   </action>
   <action name="actionSettingsProperties">

--- a/MainWindow.ui
+++ b/MainWindow.ui
@@ -181,18 +181,11 @@
       <iconset resource="images.qrc">
        <normaloff>:/resources/settings.png</normaloff>:/resources/settings.png</iconset>
      </property>
-     <widget class="QMenu" name="menuConfigurations">
-      <property name="title">
-       <string>Configurations</string>
-      </property>
-      <addaction name="actionConfiguration0"/>
-      <addaction name="actionConfiguration1"/>
-      <addaction name="separator"/>
-      <addaction name="actionSettingsProperties"/>
-      <addaction name="actionAddNewConfig"/>
-     </widget>
-     <addaction name="menuConfigurations"/>
+     <addaction name="actionConfiguration0"/>
+     <addaction name="actionConfiguration1"/>
      <addaction name="separator"/>
+     <addaction name="actionSettingsProperties"/>
+     <addaction name="actionAddNewConfig"/>
     </widget>
     <addaction name="actionCreate_Sprite"/>
     <addaction name="actionCreate_Sound"/>
@@ -240,6 +233,7 @@
    <addaction name="actionSave"/>
    <addaction name="actionSaveAll"/>
    <addaction name="separator"/>
+   <addaction name="actionSettings"/>
    <addaction name="actionRun"/>
    <addaction name="actionDebug"/>
    <addaction name="actionCreateExecutable"/>
@@ -255,7 +249,6 @@
    <addaction name="actionCreate_Timeline"/>
    <addaction name="actionCreate_Room"/>
    <addaction name="separator"/>
-   <addaction name="actionSettings"/>
    <addaction name="actionPreferences"/>
    <addaction name="separator"/>
    <addaction name="actionDocumentation"/>

--- a/MainWindow.ui
+++ b/MainWindow.ui
@@ -776,11 +776,6 @@
     <string>Ctrl+Shift+N</string>
    </property>
   </action>
-  <action name="actionTarget">
-   <property name="text">
-    <string>Target</string>
-   </property>
-  </action>
   <action name="actionAddNewConfig">
    <property name="icon">
     <iconset resource="images.qrc">

--- a/Models/TreeModel.cpp
+++ b/Models/TreeModel.cpp
@@ -3,9 +3,22 @@
 #include "Components/ArtManager.h"
 #include "Models/ResourceModelMap.h"
 
-#include <unordered_map>
+IconMap TreeModel::iconMap;
 
 TreeModel::TreeModel(buffers::TreeNode *root, QObject *parent) : QAbstractItemModel(parent), root(root) {
+  iconMap = {{TypeCase::kFolder, ArtManager::GetIcon("group")},
+             {TypeCase::kSprite, ArtManager::GetIcon("sprite")},
+             {TypeCase::kSound, ArtManager::GetIcon("sound")},
+             {TypeCase::kBackground, ArtManager::GetIcon("background")},
+             {TypeCase::kPath, ArtManager::GetIcon("path")},
+             {TypeCase::kScript, ArtManager::GetIcon("script")},
+             {TypeCase::kShader, ArtManager::GetIcon("shader")},
+             {TypeCase::kFont, ArtManager::GetIcon("font")},
+             {TypeCase::kTimeline, ArtManager::GetIcon("timeline")},
+             {TypeCase::kObject, ArtManager::GetIcon("object")},
+             {TypeCase::kRoom, ArtManager::GetIcon("room")},
+             {TypeCase::kSettings, ArtManager::GetIcon("settings")}};
+
   SetupParents(root);
 }
 
@@ -28,26 +41,10 @@ bool TreeModel::setData(const QModelIndex &index, const QVariant &value, int rol
 }
 
 QVariant TreeModel::data(const QModelIndex &index, int role) const {
-  using TypeCase = buffers::TreeNode::TypeCase;
-  using IconMap = std::unordered_map<TypeCase, QIcon>;
-
   if (!index.isValid()) return QVariant();
 
   buffers::TreeNode *item = static_cast<buffers::TreeNode *>(index.internalPointer());
   if (role == Qt::DecorationRole) {
-    static IconMap iconMap({{TypeCase::kFolder, ArtManager::GetIcon("group")},
-                            {TypeCase::kSprite, ArtManager::GetIcon("sprite")},
-                            {TypeCase::kSound, ArtManager::GetIcon("sound")},
-                            {TypeCase::kBackground, ArtManager::GetIcon("background")},
-                            {TypeCase::kPath, ArtManager::GetIcon("path")},
-                            {TypeCase::kScript, ArtManager::GetIcon("script")},
-                            {TypeCase::kShader, ArtManager::GetIcon("shader")},
-                            {TypeCase::kFont, ArtManager::GetIcon("font")},
-                            {TypeCase::kTimeline, ArtManager::GetIcon("timeline")},
-                            {TypeCase::kObject, ArtManager::GetIcon("object")},
-                            {TypeCase::kRoom, ArtManager::GetIcon("room")},
-                            {TypeCase::kSettings, ArtManager::GetIcon("settings")}});
-
     auto it = iconMap.find(item->type_case());
     if (it == iconMap.end()) return ArtManager::GetIcon("info");
 
@@ -62,7 +59,7 @@ QVariant TreeModel::data(const QModelIndex &index, int role) const {
     }
 
     if (item->type_case() == TypeCase::kObject) {
-      const ProtoModel* sprModel = GetObjectSprite(item->name());
+      const ProtoModel *sprModel = GetObjectSprite(item->name());
       if (sprModel != nullptr) {
         QString spr = sprModel->GetString(Sprite::kSubimagesFieldNumber, 0);
         if (!spr.isEmpty()) return ArtManager::GetIcon(spr);

--- a/Models/TreeModel.cpp
+++ b/Models/TreeModel.cpp
@@ -44,7 +44,8 @@ QVariant TreeModel::data(const QModelIndex &index, int role) const {
                             {TypeCase::kFont, ArtManager::GetIcon("font")},
                             {TypeCase::kTimeline, ArtManager::GetIcon("timeline")},
                             {TypeCase::kObject, ArtManager::GetIcon("object")},
-                            {TypeCase::kRoom, ArtManager::GetIcon("room")}});
+                            {TypeCase::kRoom, ArtManager::GetIcon("room")},
+                            {TypeCase::kSettings, ArtManager::GetIcon("settings")}});
 
     auto it = iconMap.find(item->type_case());
     if (it == iconMap.end()) return ArtManager::GetIcon("info");

--- a/Models/TreeModel.h
+++ b/Models/TreeModel.h
@@ -1,15 +1,23 @@
 #ifndef TREEMODEL_H
 #define TREEMODEL_H
 
+#include "Components/ArtManager.h"
 #include "codegen/treenode.pb.h"
 
 #include <QAbstractItemModel>
 #include <QHash>
 
+#include <unordered_map>
+
+using TypeCase = buffers::TreeNode::TypeCase;
+using IconMap = std::unordered_map<TypeCase, QIcon>;
+
 class TreeModel : public QAbstractItemModel {
   Q_OBJECT
 
  public:
+  static IconMap iconMap;
+
   explicit TreeModel(buffers::TreeNode *root, QObject *parent);
 
   bool setData(const QModelIndex &index, const QVariant &value, int role) override;

--- a/Plugins/RGMPlugin.h
+++ b/Plugins/RGMPlugin.h
@@ -21,7 +21,7 @@ class RGMPlugin : public QObject {
   virtual void Run() {}
   virtual void Debug() {}
   virtual void CreateExecutable() {}
-  virtual void SetCurrentConfig(const buffers::resources::Settings &settings) {}
+  virtual void SetCurrentConfig(const buffers::resources::Settings & /*settings*/) {}
 
  protected:
   MainWindow &mainWindow;

--- a/Plugins/RGMPlugin.h
+++ b/Plugins/RGMPlugin.h
@@ -4,6 +4,7 @@
 #include "MainWindow.h"
 
 #include "codegen/Settings.pb.h"
+#include "codegen/server.pb.h"
 
 #include <QApplication>
 
@@ -14,8 +15,7 @@ class RGMPlugin : public QObject {
   ~RGMPlugin();
 
  signals:
-  void OutputRead(const QString &output);
-  void ErrorRead(const QString &error);
+  void LogOutput(const QString &output);
   void CompileStatusChanged(bool finished = false);
 
  public slots:

--- a/Plugins/RGMPlugin.h
+++ b/Plugins/RGMPlugin.h
@@ -3,6 +3,8 @@
 
 #include "MainWindow.h"
 
+#include "codegen/Settings.pb.h"
+
 #include <QApplication>
 
 class RGMPlugin : public QObject {
@@ -19,6 +21,7 @@ class RGMPlugin : public QObject {
   virtual void Run() {}
   virtual void Debug() {}
   virtual void CreateExecutable() {}
+  virtual void SetCurrentConfig(const buffers::resources::Settings &settings) {}
 
  protected:
   MainWindow &mainWindow;

--- a/Plugins/RGMPlugin.h
+++ b/Plugins/RGMPlugin.h
@@ -16,6 +16,7 @@ class RGMPlugin : public QObject {
  signals:
   void OutputRead(const QString &output);
   void ErrorRead(const QString &error);
+  void CompileStatusChanged(bool finished = false);
 
  public slots:
   virtual void Run() {}

--- a/Plugins/ServerPlugin.cpp
+++ b/Plugins/ServerPlugin.cpp
@@ -1,167 +1,190 @@
-#ifndef _WIN32_WINNT
-#define _WIN32_WINNT 0x0600  // at least windows vista required for grpc
-#endif
-
 #include "ServerPlugin.h"
 #include "Widgets/CodeWidget.h"
-
-#include "codegen/server.grpc.pb.h"
 
 #include <QDebug>
 #include <QFileDialog>
 #include <QTemporaryFile>
-
-#include <grpc++/channel.h>
-#include <grpc++/client_context.h>
-#include <grpc++/create_channel.h>
-#include <grpc/grpc.h>
-
-using namespace grpc;
-using namespace buffers;
-
-class CompilerClient {
- public:
-  explicit CompilerClient(std::shared_ptr<Channel> channel, MainWindow& mainWindow)
-      : stub(Compiler::NewStub(channel)), mainWindow(mainWindow) {}
-
-  void CompileBuffer(Game* game, CompileMode mode, std::string name) {
-    ClientContext context;
-    CompileRequest request;
-
-    request.mutable_game()->CopyFrom(*game);
-    request.set_name(name);
-    request.set_mode(mode);
-
-    std::unique_ptr<ClientReader<CompileReply> > reader(stub->CompileBuffer(&context, request));
-    CompileReply reply;
-    while (reader->Read(&reply)) {
-      qDebug() << reply.message().c_str() << reply.progress();
-    }
-    Status status = reader->Finish();
-  }
-
-  void CompileBuffer(Game* game, CompileMode mode) {
-    QTemporaryFile t("enigma");
-    if (!t.open()) return;
-    CompileBuffer(game, mode, t.fileName().toStdString());
-  }
-
-  void GetResources() {
-    qDebug() << "GetResources()";
-    ClientContext context;
-    Empty emptyRequest;
-
-    std::unique_ptr<ClientReader<Resource> > reader(stub->GetResources(&context, emptyRequest));
-    Resource resource;
-    CodeWidget::prepareKeywordStore();
-    while (reader->Read(&resource)) {
-      const QString& name = QString::fromStdString(resource.name().c_str());
-      int type = 0;
-      if (resource.is_function()) {
-        type = 3;
-        for (int i = 0; i < resource.overload_count(); ++i) {
-          QString overload = QString::fromStdString(resource.parameters(i));
-          const QStringRef signature = QStringRef(&overload, overload.indexOf("(") + 1, overload.lastIndexOf(")"));
-          CodeWidget::addKeyword(QObject::tr("%0?3(%1)").arg(name).arg(signature));
-        }
-      } else {
-        if (resource.is_global()) type = 1;
-        if (resource.is_type_name()) type = 2;
-        CodeWidget::addKeyword(name + QObject::tr("?%0").arg(type));
-      }
-      qDebug() << name << type;
-    }
-    CodeWidget::finalizeKeywords();
-    qDebug() << "done";
-    Status status = reader->Finish();
-  }
-
-  void GetSystems() {
-    qDebug() << "GetSystems()";
-    ClientContext context;
-    Empty emptyRequest;
-
-    std::unique_ptr<ClientReader<SystemType> > reader(stub->GetSystems(&context, emptyRequest));
-    SystemType system;
-    auto& systemCache = MainWindow::systemCache;
-    while (reader->Read(&system)) {
-      const QString systemName = QString::fromStdString(system.name());
-      qDebug() << systemName;
-      systemCache.append(system);
-    }
-
-    qDebug() << "done";
-    Status status = reader->Finish();
-  }
-
-  void SetDefinitions(std::string code, std::string yaml) {
-    qDebug() << "SetDefinitions()";
-    ClientContext context;
-    SetDefinitionsRequest definitionsRequest;
-
-    definitionsRequest.set_code(code);
-    definitionsRequest.set_yaml(yaml);
-
-    SyntaxError reply;
-    Status status = stub->SetDefinitions(&context, definitionsRequest, &reply);
-  }
-
-  void SetCurrentConfig(const resources::Settings& settings) {
-    qDebug() << "SetCurrentConfig()";
-    ClientContext context;
-    SetCurrentConfigRequest setConfigRequest;
-    setConfigRequest.mutable_settings()->CopyFrom(settings);
-
-    Empty reply;
-    Status status = stub->SetCurrentConfig(&context, setConfigRequest, &reply);
-  }
-
-  void SyntaxCheck() {
-    qDebug() << "SyntaxCheck()";
-    ClientContext context;
-    SyntaxCheckRequest syntaxCheckRequest;
-
-    SyntaxError reply;
-    Status status = stub->SyntaxCheck(&context, syntaxCheckRequest, &reply);
-  }
-
- private:
-  std::unique_ptr<Compiler::Stub> stub;
-  MainWindow& mainWindow;
-};
+#include <QTimer>
 
 #include <chrono>
-#include <ctime>
+#include <memory>
+
+namespace {
+
+inline std::chrono::system_clock::time_point future_deadline(size_t us) {
+  return (std::chrono::system_clock::now() + std::chrono::microseconds(us));
+}
+
+void* tag(int i) { return reinterpret_cast<void*>(static_cast<intptr_t>(i)); }
+int detag(void* p) { return static_cast<int>(reinterpret_cast<intptr_t>(p)); }
+
+}  // anonymous namespace
+
+CompilerClient::CompilerClient(std::shared_ptr<Channel> channel, MainWindow& mainWindow)
+    : stub(Compiler::NewStub(channel)), mainWindow(mainWindow) {}
+
+void CompilerClient::CompileBuffer(Game* game, CompileMode mode, std::string name) {
+  qDebug() << "CompilerBuffer()";
+  qDebug() << name.c_str();
+  name = "/tmp/holyshit.exe";
+  static ClientContext context;
+  CompileRequest request;
+
+  request.mutable_game()->CopyFrom(*game);
+  request.set_name(name);
+  request.set_mode(mode);
+
+  qDebug() << "wtf1";
+  emit CompileStatusChanged();
+  CompileBufferStream = stub->AsyncCompileBuffer(&context, request, &cq, tag(1));
+  qDebug() << "wtf2";
+}
+
+void CompilerClient::CompileBuffer(Game* game, CompileMode mode) {
+  QTemporaryFile t("enigma");
+  if (!t.open()) return;
+  CompileBuffer(game, mode, t.fileName().toStdString());
+}
+
+void CompilerClient::GetResources() {
+  qDebug() << "GetResources()";
+  ClientContext context;
+  Empty emptyRequest;
+
+  std::unique_ptr<ClientReader<Resource>> reader(stub->GetResources(&context, emptyRequest));
+  Resource resource;
+  CodeWidget::prepareKeywordStore();
+  while (reader->Read(&resource)) {
+    const QString& name = QString::fromStdString(resource.name().c_str());
+    int type = 0;
+    if (resource.is_function()) {
+      type = 3;
+      for (int i = 0; i < resource.overload_count(); ++i) {
+        QString overload = QString::fromStdString(resource.parameters(i));
+        const QStringRef signature = QStringRef(&overload, overload.indexOf("(") + 1, overload.lastIndexOf(")"));
+        CodeWidget::addKeyword(QObject::tr("%0?3(%1)").arg(name).arg(signature));
+      }
+    } else {
+      if (resource.is_global()) type = 1;
+      if (resource.is_type_name()) type = 2;
+      CodeWidget::addKeyword(name + QObject::tr("?%0").arg(type));
+    }
+    qDebug() << name << type;
+  }
+  CodeWidget::finalizeKeywords();
+  qDebug() << "done";
+  Status status = reader->Finish();
+}
+
+void CompilerClient::GetSystems() {
+  qDebug() << "GetSystems()";
+  ClientContext context;
+  Empty emptyRequest;
+
+  std::unique_ptr<ClientReader<SystemType>> reader(stub->GetSystems(&context, emptyRequest));
+  SystemType system;
+  auto& systemCache = MainWindow::systemCache;
+  while (reader->Read(&system)) {
+    const QString systemName = QString::fromStdString(system.name());
+    qDebug() << systemName;
+    systemCache.append(system);
+  }
+
+  qDebug() << "done";
+  Status status = reader->Finish();
+}
+
+void CompilerClient::SetDefinitions(std::string code, std::string yaml) {
+  qDebug() << "SetDefinitions()";
+  ClientContext context;
+  SetDefinitionsRequest definitionsRequest;
+
+  definitionsRequest.set_code(code);
+  definitionsRequest.set_yaml(yaml);
+
+  SyntaxError reply;
+  Status status = stub->SetDefinitions(&context, definitionsRequest, &reply);
+}
+
+void CompilerClient::SetCurrentConfig(const resources::Settings& settings) {
+  qDebug() << "SetCurrentConfig()";
+  ClientContext context;
+  SetCurrentConfigRequest setConfigRequest;
+  setConfigRequest.mutable_settings()->CopyFrom(settings);
+
+  Empty reply;
+  Status status = stub->SetCurrentConfig(&context, setConfigRequest, &reply);
+}
+
+void CompilerClient::SyntaxCheck() {
+  qDebug() << "SyntaxCheck()";
+  ClientContext context;
+  SyntaxCheckRequest syntaxCheckRequest;
+
+  SyntaxError reply;
+  Status status = stub->SyntaxCheck(&context, syntaxCheckRequest, &reply);
+}
+
+void CompilerClient::UpdateLoop() {
+  void* got_tag = nullptr;
+  bool ok = false;
+
+  auto status = cq.AsyncNext(&got_tag, &ok, future_deadline(0));
+  // yield to application main event loop
+  if (status != CompletionQueue::NextStatus::GOT_EVENT || !ok || !got_tag) return;
+
+  int msg_id = detag(got_tag);
+
+  static CompileReply reply;
+
+  switch (msg_id) {
+    case 1: {
+      qDebug() << "ONE";
+      CompileBufferStream->Read(&reply, tag(2));
+      break;
+    }
+    default:
+      //error
+      break;
+  }
+}
 
 ServerPlugin::ServerPlugin(MainWindow& mainWindow) : RGMPlugin(mainWindow) {
+  qDebug() << "heller1";
+  process = new QProcess(this);
+  qDebug() << "heller2";
+  connect(process, &QProcess::readyReadStandardOutput, this, &ServerPlugin::HandleOutput);
+  connect(process, &QProcess::readyReadStandardError, this, &ServerPlugin::HandleError);
+  process->setWorkingDirectory("../RadialGM/Submodules/enigma-dev");
+
+  qDebug() << "heller3";
+  QString program = "emake";
+  QStringList arguments;
+  arguments << "--server"
+            << "-e"
+            << "Paths";
+  qDebug() << "heller4";
+  process->start(program, arguments);
+  qDebug() << "heller5";
+  process->waitForStarted();
+  qDebug() << "heller6";
+
+  // construct the channel and connect to the server
   std::shared_ptr<Channel> channel = CreateChannel("localhost:37818", InsecureChannelCredentials());
-  ChannelInterface* clangIsAPieceOfShit = (ChannelInterface*)channel.get();
-
-  if (!clangIsAPieceOfShit->WaitForConnected(std::chrono::system_clock::now() + std::chrono::milliseconds(1000))) {
-    qDebug() << "heller1";
-    process = new QProcess(this);
-    qDebug() << "heller2";
-    connect(process, &QProcess::readyReadStandardOutput, this, &ServerPlugin::HandleOutput);
-    connect(process, &QProcess::readyReadStandardError, this, &ServerPlugin::HandleError);
-
-    qDebug() << "heller3";
-    QString program = "emake.exe";
-    QStringList arguments;
-    arguments << "--server"
-              << "--quiet";
-    qDebug() << "heller4";
-    process->startDetached(program, arguments, "../RadialGM/Submodules/enigma-dev");
-    qDebug() << "heller5";
-    process->waitForStarted();
-    qDebug() << "heller6";
-  }
   compilerClient = new CompilerClient(channel, mainWindow);
+  connect(compilerClient, &CompilerClient::CompileStatusChanged, this, &RGMPlugin::CompileStatusChanged);
+
+  //TODO: timer
+  QTimer* timer = new QTimer(this);
+  connect(timer, &QTimer::timeout, compilerClient, &CompilerClient::UpdateLoop);
+  timer->start();
+
+  // update initial keyword set and systems
   compilerClient->GetResources();
   compilerClient->GetSystems();
 }
 
-ServerPlugin::~ServerPlugin() {  //process->terminate();
-}
+ServerPlugin::~ServerPlugin() { process->close(); }
 
 void ServerPlugin::Run() { compilerClient->CompileBuffer(mainWindow.Game(), CompileMode::RUN); };
 

--- a/Plugins/ServerPlugin.cpp
+++ b/Plugins/ServerPlugin.cpp
@@ -181,6 +181,14 @@ ServerPlugin::ServerPlugin(MainWindow& mainWindow) : RGMPlugin(mainWindow) {
             << "-e"
             << "Paths"
             << "-r";
+
+  // listen for the server process to stop and output the exit code
+  // this makes it easier to tell if an issue is just emake misbehaving
+  connect(process, &QProcess::stateChanged, [=](QProcess::ProcessState state) {
+    if (state != QProcess::NotRunning) return;
+    emit OutputRead(tr("Server process has stopped with exit code: %0").arg(process->exitCode()));
+  });
+
   process->start(program, arguments);
   process->waitForStarted();
 

--- a/Plugins/ServerPlugin.cpp
+++ b/Plugins/ServerPlugin.cpp
@@ -82,8 +82,8 @@ class CompilerClient {
     ClientContext context;
     Empty emptyRequest;
 
-    std::unique_ptr<ClientReader<System> > reader(stub->GetSystems(&context, emptyRequest));
-    System system;
+    std::unique_ptr<ClientReader<SystemType> > reader(stub->GetSystems(&context, emptyRequest));
+    SystemType system;
     while (reader->Read(&system)) {
       const QString systemName = QString::fromStdString(system.name());
       qDebug() << systemName;

--- a/Plugins/ServerPlugin.cpp
+++ b/Plugins/ServerPlugin.cpp
@@ -96,6 +96,7 @@ class CompilerClient {
     widgetAction->setDefaultWidget(widget);
 
     QMenu* extensionsMenu = new QMenu();
+    extensionsMenu->setToolTipsVisible(true);
 
     std::unique_ptr<ClientReader<SystemType> > reader(stub->GetSystems(&context, emptyRequest));
     SystemType system;
@@ -106,7 +107,10 @@ class CompilerClient {
       if (systemName.toLower() == "extensions") {
         for (auto extension : system.subsystems()) {
           const QString extensionName = QString::fromStdString(extension.name());
+          const QString extensionDesc = QString::fromStdString(extension.description());
           QAction* extensionAction = extensionsMenu->addAction(extensionName);
+          extensionAction->setToolTip(extensionDesc);
+
           extensionAction->setCheckable(true);
         }
         continue;

--- a/Plugins/ServerPlugin.cpp
+++ b/Plugins/ServerPlugin.cpp
@@ -143,7 +143,7 @@ void CompilerClient::UpdateLoop() {
       qDebug() << "ONE";
       CompileBufferStream->Read(&compileReply, tag(1));
       for (auto log : compileReply.message()) {
-        emit OutputRead(log.message().c_str());
+        emit LogOutput(log.message().c_str());
       }
       break;
     }
@@ -189,8 +189,7 @@ ServerPlugin::ServerPlugin(MainWindow& mainWindow) : RGMPlugin(mainWindow) {
   connect(compilerClient, &CompilerClient::CompileStatusChanged, this, &RGMPlugin::CompileStatusChanged);
   // hookup emake's output to our plugin's output signals so it redirects to the
   // main output dock widget (thread safe and don't block the main event loop!)
-  connect(compilerClient, &CompilerClient::OutputRead, this, &RGMPlugin::OutputRead);
-  connect(compilerClient, &CompilerClient::ErrorRead, this, &RGMPlugin::ErrorRead);
+  connect(compilerClient, &CompilerClient::LogOutput, this, &RGMPlugin::LogOutput);
 
   // use a timer to process async grpc events at regular intervals
   // without us needing any threading or blocking the main thread

--- a/Plugins/ServerPlugin.cpp
+++ b/Plugins/ServerPlugin.cpp
@@ -38,6 +38,8 @@ void CompilerClient::CompileBuffer(Game* game, CompileMode mode, std::string nam
   emit CompileStatusChanged();
   CompileBufferStream = stub->AsyncCompileBuffer(&context, request, &cq, tag(1));
   qDebug() << "wtf2";
+  static Status lol;
+  CompileBufferStream->Finish(&lol, tag(3));
 }
 
 void CompilerClient::CompileBuffer(Game* game, CompileMode mode) {
@@ -141,10 +143,22 @@ void CompilerClient::UpdateLoop() {
   switch (msg_id) {
     case 1: {
       qDebug() << "ONE";
-      CompileBufferStream->Read(&compileReply, tag(1));
+      CompileBufferStream->Read(&compileReply, tag(2));
+      qDebug() << compileReply.progress().progress() << compileReply.progress().message().c_str();
+      break;
+    }
+    case 2: {
+      qDebug() << "TWO";
+      qDebug() << compileReply.progress().progress() << compileReply.progress().message().c_str();
       for (auto log : compileReply.message()) {
         emit LogOutput(log.message().c_str());
       }
+      CompileBufferStream->Read(&compileReply, tag(2));
+      break;
+    }
+    case 3: {
+      qDebug() << "BING";
+      emit CompileStatusChanged(true);
       break;
     }
     default:

--- a/Plugins/ServerPlugin.cpp
+++ b/Plugins/ServerPlugin.cpp
@@ -54,7 +54,7 @@ struct AsyncReadWorker : public CallData {
 
   virtual void started() {}
   virtual void finished() {}
-  virtual void process(const T& data) = 0;
+  virtual void process(const T&) = 0;
 };
 
 template <class T>
@@ -82,7 +82,7 @@ struct AsyncResponseReadWorker : public CallData {
   virtual void finish() final {}
 
   virtual void started() {}
-  virtual void finished(const T& data) {}
+  virtual void finished(const T&) {}
 };
 
 struct ResourceReader : public AsyncReadWorker<Resource> {
@@ -128,7 +128,7 @@ struct CompileReader : public AsyncReadWorker<CompileReply> {
 
 struct SyntaxCheckReader : public AsyncResponseReadWorker<SyntaxError> {
   virtual ~SyntaxCheckReader() {}
-  virtual void finished(const SyntaxError& /*err*/) final {}
+  virtual void finished(const SyntaxError&) final {}
 };
 
 CompilerClient::~CompilerClient() {}

--- a/Plugins/ServerPlugin.cpp
+++ b/Plugins/ServerPlugin.cpp
@@ -111,6 +111,16 @@ class CompilerClient {
     Status status = stub->SetDefinitions(&context, definitionsRequest, &reply);
   }
 
+  void SetCurrentConfig(const resources::Settings& settings) {
+    qDebug() << "SetCurrentConfig()";
+    ClientContext context;
+    SetCurrentConfigRequest setConfigRequest;
+    setConfigRequest.mutable_settings()->CopyFrom(settings);
+
+    Empty reply;
+    Status status = stub->SetCurrentConfig(&context, setConfigRequest, &reply);
+  }
+
   void SyntaxCheck() {
     qDebug() << "SyntaxCheck()";
     ClientContext context;
@@ -167,6 +177,10 @@ void ServerPlugin::CreateExecutable() {
       QFileDialog::getSaveFileName(&mainWindow, tr("Create Executable"), "", tr("Executable (*.exe);;All Files (*)"));
   if (!fileName.isEmpty())
     compilerClient->CompileBuffer(mainWindow.Game(), CompileMode::COMPILE, fileName.toStdString());
+};
+
+void ServerPlugin::SetCurrentConfig(const resources::Settings& settings) {
+  compilerClient->SetCurrentConfig(settings);
 };
 
 void ServerPlugin::HandleOutput() { emit OutputRead(process->readAllStandardOutput()); }

--- a/Plugins/ServerPlugin.cpp
+++ b/Plugins/ServerPlugin.cpp
@@ -86,58 +86,14 @@ class CompilerClient {
     ClientContext context;
     Empty emptyRequest;
 
-    QWidget* widget = new QWidget();
-    QWidgetAction* widgetAction = new QWidgetAction(&mainWindow);
-    QFormLayout* layout = new QFormLayout();
-    layout->setSpacing(4);
-    layout->setMargin(4);
-    layout->setLabelAlignment(Qt::AlignmentFlag::AlignRight);
-    widget->setLayout(layout);
-    widgetAction->setDefaultWidget(widget);
-
-    QMenu* extensionsMenu = new QMenu();
-    extensionsMenu->setToolTipsVisible(true);
-
     std::unique_ptr<ClientReader<SystemType> > reader(stub->GetSystems(&context, emptyRequest));
     SystemType system;
+    auto& systemCache = MainWindow::systemCache;
     while (reader->Read(&system)) {
       const QString systemName = QString::fromStdString(system.name());
       qDebug() << systemName;
-
-      if (systemName.toLower() == "extensions") {
-        for (auto extension : system.subsystems()) {
-          const QString extensionName = QString::fromStdString(extension.name());
-          const QString extensionDesc = QString::fromStdString(extension.description());
-          QAction* extensionAction = extensionsMenu->addAction(extensionName);
-          extensionAction->setToolTip(extensionDesc);
-
-          extensionAction->setCheckable(true);
-        }
-        continue;
-      }
-
-      QLabel* label = new QLabel(systemName);
-      QComboBox* combo = new QComboBox();
-      layout->addRow(label, combo);
-
-      for (auto subsystem : system.subsystems()) {
-        const QString subsystemName = QString::fromStdString(subsystem.name());
-        combo->addItem(subsystemName);
-        //qDebug() << subsystem.name().c_str();
-        //qDebug() << subsystem.id().c_str();
-        //qDebug() << subsystem.description().c_str();
-        //qDebug() << subsystem.target().c_str();
-      }
+      systemCache.append(system);
     }
-
-    QAction* extensionsSeperator = new QAction();
-    extensionsSeperator->setSeparator(true);
-    QAction* extensionsMenuAction = new QAction(QObject::tr("Extensions"));
-    extensionsMenuAction->setMenu(extensionsMenu);
-
-    //mainWindow.addSystemMenu(extensionsMenuAction);
-    //mainWindow.addSystemMenu(extensionsSeperator);
-    //mainWindow.addSystemMenu(widgetAction);
 
     qDebug() << "done";
     Status status = reader->Finish();

--- a/Plugins/ServerPlugin.cpp
+++ b/Plugins/ServerPlugin.cpp
@@ -193,7 +193,8 @@ ServerPlugin::ServerPlugin(MainWindow& mainWindow) : RGMPlugin(mainWindow) {
   arguments << "--server"
             << "-e"
             << "Paths"
-            << "-r";
+            << "-r"
+            << "--quiet";
 
   process->start(program, arguments);
   process->waitForStarted();

--- a/Plugins/ServerPlugin.cpp
+++ b/Plugins/ServerPlugin.cpp
@@ -26,7 +26,6 @@ CompilerClient::CompilerClient(std::shared_ptr<Channel> channel, MainWindow& mai
 void CompilerClient::CompileBuffer(Game* game, CompileMode mode, std::string name) {
   qDebug() << "CompilerBuffer()";
   qDebug() << name.c_str();
-  name = "/tmp/holyshit.exe";
   static ClientContext context;
   CompileRequest request;
 
@@ -41,9 +40,10 @@ void CompilerClient::CompileBuffer(Game* game, CompileMode mode, std::string nam
 }
 
 void CompilerClient::CompileBuffer(Game* game, CompileMode mode) {
-  QTemporaryFile t("enigma");
-  if (!t.open()) return;
-  CompileBuffer(game, mode, t.fileName().toStdString());
+  QTemporaryFile* t = new QTemporaryFile(QDir::temp().filePath("enigmaXXXXXX"), &mainWindow);
+  if (!t->open()) return;
+  t->close();
+  CompileBuffer(game, mode, (t->fileName()).toStdString());
 }
 
 void CompilerClient::GetResources() {
@@ -162,7 +162,8 @@ ServerPlugin::ServerPlugin(MainWindow& mainWindow) : RGMPlugin(mainWindow) {
   QStringList arguments;
   arguments << "--server"
             << "-e"
-            << "Paths";
+            << "Paths"
+            << "-r";
   qDebug() << "heller4";
   process->start(program, arguments);
   qDebug() << "heller5";

--- a/Plugins/ServerPlugin.cpp
+++ b/Plugins/ServerPlugin.cpp
@@ -28,6 +28,7 @@ void CompilerClient::CompileBuffer(Game* game, CompileMode mode, std::string nam
   qDebug() << "CompilerBuffer()";
   qDebug() << name.c_str();
   static ClientContext context;
+  qDebug() << "are we really against the bing";
   CompileRequest request;
 
   request.mutable_game()->CopyFrom(*game);

--- a/Plugins/ServerPlugin.cpp
+++ b/Plugins/ServerPlugin.cpp
@@ -63,18 +63,18 @@ struct ResourceReader : public AsyncReadWorker<Resource> {
   virtual void started() final { CodeWidget::prepareKeywordStore(); }
   virtual void process(const Resource& resource) final {
     const QString& name = QString::fromStdString(resource.name().c_str());
-    int type = 0;
+    KeywordType type = KeywordType::UNKNOWN;
     if (resource.is_function()) {
-      type = 3;
+      type = KeywordType::FUNCTION;
       for (int i = 0; i < resource.overload_count(); ++i) {
         QString overload = QString::fromStdString(resource.parameters(i));
         const QStringRef signature = QStringRef(&overload, overload.indexOf("(") + 1, overload.lastIndexOf(")"));
-        CodeWidget::addKeyword(QObject::tr("%0?3(%1)").arg(name).arg(signature));
+        CodeWidget::addCalltip(name, signature.toString(), type);
       }
     } else {
-      if (resource.is_global()) type = 1;
-      if (resource.is_type_name()) type = 2;
-      CodeWidget::addKeyword(name + QObject::tr("?%0").arg(type));
+      if (resource.is_global()) type = KeywordType::GLOBAL;
+      if (resource.is_type_name()) type = KeywordType::TYPE_NAME;
+      CodeWidget::addKeyword(name, type);
     }
     qDebug() << name << type;
   }

--- a/Plugins/ServerPlugin.cpp
+++ b/Plugins/ServerPlugin.cpp
@@ -205,15 +205,15 @@ ServerPlugin::ServerPlugin(MainWindow& mainWindow) : RGMPlugin(mainWindow) {
 
 ServerPlugin::~ServerPlugin() { process->close(); }
 
-void ServerPlugin::Run() { compilerClient->CompileBuffer(mainWindow.Game(), CompileMode::RUN); };
+void ServerPlugin::Run() { compilerClient->CompileBuffer(mainWindow.Game(), CompileRequest::RUN); };
 
-void ServerPlugin::Debug() { compilerClient->CompileBuffer(mainWindow.Game(), CompileMode::DEBUG); };
+void ServerPlugin::Debug() { compilerClient->CompileBuffer(mainWindow.Game(), CompileRequest::DEBUG); };
 
 void ServerPlugin::CreateExecutable() {
   const QString& fileName =
       QFileDialog::getSaveFileName(&mainWindow, tr("Create Executable"), "", tr("Executable (*.exe);;All Files (*)"));
   if (!fileName.isEmpty())
-    compilerClient->CompileBuffer(mainWindow.Game(), CompileMode::COMPILE, fileName.toStdString());
+    compilerClient->CompileBuffer(mainWindow.Game(), CompileRequest::COMPILE, fileName.toStdString());
 };
 
 void ServerPlugin::SetCurrentConfig(const resources::Settings& settings) {

--- a/Plugins/ServerPlugin.cpp
+++ b/Plugins/ServerPlugin.cpp
@@ -36,13 +36,13 @@ void CompilerClient::CompileBuffer(Game* game, CompileMode mode, std::string nam
   request.set_mode(mode);
 
   qDebug() << "wtf1";
-  static std::unique_ptr<ClientAsyncReader<CompileReply>> stream;
-  stream = stub->AsyncCompileBuffer(&callData->context, request, &cq, tag(AsyncState::CONNECT));
+  callData->stream = stub->AsyncCompileBuffer(&callData->context, request, &cq, tag(AsyncState::CONNECT));
   qDebug() << "wtf2";
-  stream->Finish(&status, tag(AsyncState::FINISH));
+  callData->stream->Finish(&status, tag(AsyncState::FINISH));
 
   callData->process = [=](const AsyncState state, const Status & /*status*/) -> void {
     static CompileReply compileReply;
+    auto stream = (ClientAsyncReader<CompileReply>*)callData->stream.get();
 
     switch (state) {
       case AsyncState::CONNECT: {
@@ -62,7 +62,6 @@ void CompilerClient::CompileBuffer(Game* game, CompileMode mode, std::string nam
       }
       case AsyncState::FINISH: {
         qDebug() << "FINISH";
-        stream.release();
         emit CompileStatusChanged(true);
       }
       default:

--- a/Plugins/ServerPlugin.cpp
+++ b/Plugins/ServerPlugin.cpp
@@ -7,14 +7,9 @@
 
 #include "codegen/server.grpc.pb.h"
 
-#include <QComboBox>
 #include <QDebug>
 #include <QFileDialog>
-#include <QFormLayout>
-#include <QLabel>
-#include <QMenu>
 #include <QTemporaryFile>
-#include <QWidgetAction>
 
 #include <grpc++/channel.h>
 #include <grpc++/client_context.h>

--- a/Plugins/ServerPlugin.cpp
+++ b/Plugins/ServerPlugin.cpp
@@ -135,9 +135,9 @@ class CompilerClient {
     QAction* extensionsMenuAction = new QAction(QObject::tr("Extensions"));
     extensionsMenuAction->setMenu(extensionsMenu);
 
-    mainWindow.addSystemMenu(extensionsMenuAction);
-    mainWindow.addSystemMenu(extensionsSeperator);
-    mainWindow.addSystemMenu(widgetAction);
+    //mainWindow.addSystemMenu(extensionsMenuAction);
+    //mainWindow.addSystemMenu(extensionsSeperator);
+    //mainWindow.addSystemMenu(widgetAction);
 
     qDebug() << "done";
     Status status = reader->Finish();

--- a/Plugins/ServerPlugin.h
+++ b/Plugins/ServerPlugin.h
@@ -16,6 +16,7 @@ class ServerPlugin : public RGMPlugin {
   void Run() override;
   void Debug() override;
   void CreateExecutable() override;
+  void SetCurrentConfig(const buffers::resources::Settings &settings) override;
 
  private slots:
   void HandleOutput();

--- a/Plugins/ServerPlugin.h
+++ b/Plugins/ServerPlugin.h
@@ -16,6 +16,7 @@
 
 using namespace grpc;
 using namespace buffers;
+using CompileMode = CompileRequest_CompileMode;
 
 class CompilerClient : public QObject {
   Q_OBJECT

--- a/Plugins/ServerPlugin.h
+++ b/Plugins/ServerPlugin.h
@@ -30,20 +30,34 @@ enum AsyncState { READ = 1, WRITE = 2, CONNECT = 3, WRITES_DONE = 4, FINISH = 5 
 struct CallData {
   Status status;
   ClientContext context;
-  std::unique_ptr<ClientAsyncStreamingInterface> stream;
   std::function<void(const AsyncState, const Status&)> process;
+  virtual ~CallData();
+  virtual void StartCall(void* tag) = 0;
+  virtual void Finish(Status* status, void* tag) = 0;
 };
 
 struct CompileBufferCallData : public CallData {
   CompileReply reply;
+  std::unique_ptr<ClientAsyncReader<CompileReply>> stream;
+  ~CompileBufferCallData() override;
+  void StartCall(void* tag) override;
+  void Finish(Status* status, void* tag) override;
 };
 
 struct GetResourcesCallData : public CallData {
   Resource resource;
+  std::unique_ptr<ClientAsyncReader<Resource>> stream;
+  ~GetResourcesCallData() override;
+  void StartCall(void* tag) override;
+  void Finish(Status* status, void* tag) override;
 };
 
 struct GetSystemsCallData : public CallData {
   SystemType system;
+  std::unique_ptr<ClientAsyncReader<SystemType>> stream;
+  ~GetSystemsCallData() override;
+  void StartCall(void* tag) override;
+  void Finish(Status* status, void* tag) override;
 };
 
 class CompilerClient : public QObject {

--- a/Plugins/ServerPlugin.h
+++ b/Plugins/ServerPlugin.h
@@ -9,8 +9,8 @@
 
 #include <grpc++/channel.h>
 #include <grpc++/client_context.h>
+#include <grpc++/completion_queue.h>
 #include <grpc++/create_channel.h>
-#include <grpc++/support/async_stream.h>
 #include <grpc/grpc.h>
 
 #include <QList>

--- a/Plugins/ServerPlugin.h
+++ b/Plugins/ServerPlugin.h
@@ -26,8 +26,6 @@ enum AsyncState { READ = 1, WRITE = 2, CONNECT = 3, WRITES_DONE = 4, FINISH = 5 
 
 struct CallData {
   ClientContext context;
-  // stream uses context so keep its declaration after
-  // because destruction is in reverse order of declaration
   std::unique_ptr<ClientAsyncStreamingInterface> stream;
   std::function<void(const AsyncState, const Status&)> process;
 };

--- a/Plugins/ServerPlugin.h
+++ b/Plugins/ServerPlugin.h
@@ -10,6 +10,7 @@
 #include <grpc++/channel.h>
 #include <grpc++/client_context.h>
 #include <grpc++/create_channel.h>
+#include <grpc++/support/async_stream.h>
 #include <grpc/grpc.h>
 
 #include <QList>

--- a/Plugins/ServerPlugin.h
+++ b/Plugins/ServerPlugin.h
@@ -24,9 +24,11 @@ using CompileMode = CompileRequest_CompileMode;
 
 enum AsyncState { READ = 1, WRITE = 2, CONNECT = 3, WRITES_DONE = 4, FINISH = 5 };
 
-class CallData {
- public:
+struct CallData {
   ClientContext context;
+  // stream uses context so keep its declaration after
+  // because destruction is in reverse order of declaration
+  std::unique_ptr<ClientAsyncStreamingInterface> stream;
   std::function<void(const AsyncState, const Status&)> process;
 };
 

--- a/Plugins/ServerPlugin.h
+++ b/Plugins/ServerPlugin.h
@@ -25,7 +25,7 @@ using namespace grpc;
 using namespace buffers;
 using CompileMode = CompileRequest_CompileMode;
 
-enum AsyncState { READ = 1, WRITE = 2, CONNECT = 3, WRITES_DONE = 4, FINISH = 5 };
+enum AsyncState { DISCONNECTED = 0, READ = 1, WRITE = 2, CONNECT = 3, WRITES_DONE = 4, FINISH = 5 };
 
 struct CallData {
   Status status;

--- a/Plugins/ServerPlugin.h
+++ b/Plugins/ServerPlugin.h
@@ -3,28 +3,69 @@
 
 #include "RGMPlugin.h"
 
+#define _WIN32_WINNT 0x0600  // at least windows vista required for grpc
+
+#include "codegen/server.grpc.pb.h"
+
+#include <grpc++/channel.h>
+#include <grpc++/client_context.h>
+#include <grpc++/create_channel.h>
+#include <grpc/grpc.h>
+
 #include <QProcess>
 
-class CompilerClient;
+using namespace grpc;
+using namespace buffers;
+
+class CompilerClient : public QObject {
+  Q_OBJECT
+
+ public:
+  explicit CompilerClient(std::shared_ptr<Channel> channel, MainWindow& mainWindow);
+  void CompileBuffer(Game* game, CompileMode mode, std::string name);
+  void CompileBuffer(Game* game, CompileMode mode);
+  void GetResources();
+  void GetSystems();
+  void SetDefinitions(std::string code, std::string yaml);
+  void SetCurrentConfig(const resources::Settings& settings);
+  void SyntaxCheck();
+
+ signals:
+  void CompileStatusChanged(bool finished = false);
+
+ public slots:
+  void UpdateLoop();
+
+ private:
+  CompletionQueue cq;
+  Status status;
+
+  std::unique_ptr<ClientAsyncReader<CompileReply>> CompileBufferStream;
+
+  std::unique_ptr<Compiler::Stub> stub;
+  MainWindow& mainWindow;
+};
 
 class ServerPlugin : public RGMPlugin {
+  Q_OBJECT
+
  public:
-  ServerPlugin(MainWindow &mainWindow);
+  ServerPlugin(MainWindow& mainWindow);
   ~ServerPlugin() override;
 
  public slots:
   void Run() override;
   void Debug() override;
   void CreateExecutable() override;
-  void SetCurrentConfig(const buffers::resources::Settings &settings) override;
+  void SetCurrentConfig(const buffers::resources::Settings& settings) override;
 
  private slots:
   void HandleOutput();
   void HandleError();
 
  private:
-  QProcess *process;
-  CompilerClient *compilerClient;
+  QProcess* process;
+  CompilerClient* compilerClient;
 };
 
 #endif  // PLUGINSERVER_H

--- a/Plugins/ServerPlugin.h
+++ b/Plugins/ServerPlugin.h
@@ -34,8 +34,7 @@ class CompilerClient : public QObject {
 
  signals:
   void CompileStatusChanged(bool finished = false);
-  void OutputRead(const QString& output);
-  void ErrorRead(const QString& error);
+  void LogOutput(const QString& output);
 
  public slots:
   void UpdateLoop();

--- a/Plugins/ServerPlugin.h
+++ b/Plugins/ServerPlugin.h
@@ -26,12 +26,15 @@ class CompilerClient : public QObject {
   void CompileBuffer(Game* game, CompileMode mode);
   void GetResources();
   void GetSystems();
+  void GetOutput();
   void SetDefinitions(std::string code, std::string yaml);
   void SetCurrentConfig(const resources::Settings& settings);
   void SyntaxCheck();
 
  signals:
   void CompileStatusChanged(bool finished = false);
+  void OutputRead(const QString& output);
+  void ErrorRead(const QString& error);
 
  public slots:
   void UpdateLoop();
@@ -58,10 +61,6 @@ class ServerPlugin : public RGMPlugin {
   void Debug() override;
   void CreateExecutable() override;
   void SetCurrentConfig(const buffers::resources::Settings& settings) override;
-
- private slots:
-  void HandleOutput();
-  void HandleError();
 
  private:
   QProcess* process;

--- a/RadialGM.pro
+++ b/RadialGM.pro
@@ -80,6 +80,7 @@ SOURCES += \
     Components/RecentFiles.cpp \
     Editors/CodeEditor.cpp \
     Editors/ScriptEditor.cpp \
+    Editors/SettingsEditor.cpp
 
 HEADERS += \
     MainWindow.h \
@@ -107,7 +108,8 @@ HEADERS += \
     main.h \
     Dialogs/PreferencesKeys.h \
     Editors/CodeEditor.h \
-    Editors/ScriptEditor.h
+    Editors/ScriptEditor.h \
+    Editors/SettingsEditor.h
 
 FORMS += \
     MainWindow.ui \
@@ -121,7 +123,8 @@ FORMS += \
     Editors/RoomEditor.ui \
     Editors/SpriteEditor.ui \
     Editors/SoundEditor.ui \
-    Editors/CodeEditor.ui
+    Editors/CodeEditor.ui \
+    Editors/SettingsEditor.ui
 
 RESOURCES += \
     images.qrc

--- a/Widgets/BackgroundRenderer.cpp
+++ b/Widgets/BackgroundRenderer.cpp
@@ -70,7 +70,7 @@ void BackgroundRenderer::paintEvent(QPaintEvent * /* event */) {
     painter.fillRect(QRectF(0, 0, pixmap.width() * zoom, pixmap.height() * zoom), ArtManager::GetTransparenyBrush());
 
     painter.scale(zoom, zoom);
-    bool transparent = model->data(Background::kTransparentFieldNumber).toBool();
+    bool transparent = true;  // deprecated
     painter.drawPixmap(0, 0, (transparent) ? transparentPixmap : pixmap);
 
     bool gridVisible = model->data(Background::kUseAsTilesetFieldNumber).toBool();

--- a/Widgets/CodeWidget.h
+++ b/Widgets/CodeWidget.h
@@ -5,6 +5,8 @@
 #include <QPrinter>
 #include <QWidget>
 
+enum KeywordType { UNKNOWN = 0, FUNCTION = 1, GLOBAL = 2, TYPE_NAME = 3, MAX = 4 };
+
 class CodeWidget : public QWidget {
   Q_OBJECT
   // this is a shim property over the real property
@@ -21,7 +23,8 @@ class CodeWidget : public QWidget {
   QPair<int, int> cursorPosition();
 
   static void prepareKeywordStore();
-  static void addKeyword(const QString& keyword);
+  static void addKeyword(const QString& keyword, KeywordType type);
+  static void addCalltip(const QString& keyword, const QString& calltip, KeywordType type = KeywordType::FUNCTION);
   static void finalizeKeywords();
 
  public slots:

--- a/Widgets/CodeWidgetPlain.cpp
+++ b/Widgets/CodeWidgetPlain.cpp
@@ -6,6 +6,11 @@
 #include <QTextBlock>
 #include <QTextCursor>
 
+void CodeWidget::prepareKeywordStore() {}
+void CodeWidget::addKeyword(const QString& /*keyword*/, KeywordType /*type*/) {}
+void CodeWidget::addCalltip(const QString& /*keyword*/, const QString& /*calltip*/, KeywordType /*type*/) {}
+void CodeWidget::finalizeKeywords() {}
+
 CodeWidget::CodeWidget(QWidget* parent) : QWidget(parent), font(QFont("Courier", 10)) {
   QPlainTextEdit* plainTextEdit = new QPlainTextEdit(this);
   this->textWidget = plainTextEdit;


### PR DESCRIPTION
There are two main goals of this pull request. I was hoping to mock up a nice way of selecting configurations and targets and make compiling work. Additionally I wanted to get completions working for the script editor.

![Compiling Games](https://user-images.githubusercontent.com/3212801/47434261-34fb6600-d770-11e8-9084-f14dbafc1529.png)

Summary of Changes
----
* Added `SettingsEditor` designer form class with the basic ENIGMA settings for compiling.
* Added 4 new icons to use in the script editor's autocompletion window. One of them is an f(x) icon for functions and the other three are colored right-facing arrows for constants/variables/globals. Resources will later just use their resource icons when we add that.
* Added a system cache to the main window for plugins to communicate available systems to the built in editors. This is primarily just used by the settings editor so it can populate the API combos using systems found by the GRPC plugin.
* Added a static instance accessor to the main window I'd like to later remove that is used to emit a config change signal from outside the main window itself. The reason is that signals require a QObject instance.
* Added a `CompileStatusChanged` signal to RGMPlugin interface so plugins can inform the main window when the compile status changes. This is how running the game disables the other buttons and forces the output dock widget visible.
* Added a static mutator to set the currently selected config which for now just fires a signal on the static instance that I want to remove. This is used temporarily for the settings editor to have a save button that actually tells the GRPC plugin to tell emake to update its API targets.
* Added the settings editor to the editor factory map so config resources can actually be opened.
* Replaced the change game settings action with a menu for config selection under the resources menu in the same place.
* Added a config selector to the main toolbar and gave it a split popup mode.
* Renamed the timeline actions in the menu to be a single word instead of two words. I never agreed with GameMaker making them two words, unlike every other resource group in the tree.
* Added mnemonics to the resource creation menu to facilitate keyboard navigation.
* Merged `ErrorRead` and `OutputRead` signals into a `LogOutput` signal on the main window. This is to support more granularity of logging which we can later allow the user to filter.
* Moved the initialization of the `TreeModel` icon map to its constructor to allow public access. This is so that later the icons can be used to represent resource keywords in the autocompletions.
* Added `future_deadline` helper to facilitate in calculating GRPC deadlines in the `ServerPlugin`.
* Added `tag`/`detag` helpers to the `ServerPlugin` to faciliate in tagging RPC states with async GRPC.
* Added `CallData` to manage the common state of async RPC calls in the `ServerPlugin`.
* Added `AsyncReadWorker` to drive the state machine of an async streaming read RPC in the `ServerPlugin`.
* Added `AsyncResponseReadWorker` to drive the state machine of a non-streaming async read RPC in the `ServerPlugin`.
* Changed all RPC stub implementations in `CompilerClient` to async using derivations of the above classes, helpers, and abstractions.
* Added `CompilerClient::ScheduleTask` to schedule an RPC to be started and processed asynchronously.
* Added `CompilerClient::UpdateLoop` for processing RPC calls asynchronously one at a time (for now). This is triggered regularly by a QTimer with an interval of 0 ms.
* Added a list of search paths for emake that looks for executable files in known locations. This means RGM can now find emake if it's directly next to it in the filesystem.
* Changed the `ServerPlugin` destructor to call `QProcess::close` instead of `QProcess::terminate` because the latter does not work for console programs that do not run an event loop on Windows.
* Added a static keyword API to `CodeWidget` that can be used to communicate keywords to QScintilla for syntax highlighting and autocompletion.

Change Details
----
There is only a single drop down for the current config and target options. Clicking on the button will open the game settings for the currently selected config.
![Edit Selected Config](https://user-images.githubusercontent.com/3212801/47084574-d8cd9a80-d1e1-11e8-8e13-7c379c10f5e1.png)

Selecting the arrow will bring up the menu to select a different config, edit the selected one, or add a new one. There is no option to delete a config because I did not want to overcomplicate this menu. Because configs will be a regular resource group, they can be deleted from the main project tree.
![Change Selected Config](https://user-images.githubusercontent.com/3212801/47084208-db7bc000-d1e0-11e8-8054-d81d4c31565d.png)

Finally, the exact same menu will be displayed under the "Resources" menu. The main reason is not just because it's consistent with how GM always was, but just to facilitate keyboard navigation using mnemonics.
![Change Settings from Resources Menu](https://user-images.githubusercontent.com/3212801/47084269-0108c980-d1e1-11e8-9b30-59339f59baf8.png)

The ENIGMA settings will be integrated with the settings editor.
![ENIGMA API Settings](https://user-images.githubusercontent.com/3212801/47677276-11338800-db95-11e8-9711-487cb067e4f2.png)

Extensions appear here as well, as we have come to expect.
![ENIGMA Extension Settings](https://user-images.githubusercontent.com/3212801/47677314-27414880-db95-11e8-8311-5fd75314698f.png)


