### PR TITLE
Basic Color Picking Widget

### DIFF
--- a/CmakeLists.txt
+++ b/CmakeLists.txt
@@ -46,6 +46,7 @@ set(RGM_SOURCES
     Components/RecentFiles.cpp
     Widgets/BackgroundRenderer.cpp
     Widgets/CodeWidget.cpp
+    Widgets/ColorPicker.cpp
     Plugins/RGMPlugin.cpp
     Plugins/ServerPlugin.cpp
     qtplugins.cpp
@@ -76,6 +77,7 @@ set(RGM_HEADERS
     Components/Utility.h
     Widgets/BackgroundRenderer.h
     Widgets/CodeWidget.h
+    Widgets/ColorPicker.h
     Plugins/RGMPlugin.h
     Plugins/ServerPlugin.h
 )

--- a/Editors/RoomEditor.ui
+++ b/Editors/RoomEditor.ui
@@ -452,7 +452,7 @@
                <number>4</number>
               </property>
               <item>
-               <widget class="QLabel" name="colorLabel">
+               <widget class="QLabel" name="gridColorLabel">
                 <property name="sizePolicy">
                  <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
                   <horstretch>0</horstretch>
@@ -465,9 +465,9 @@
                </widget>
               </item>
               <item>
-               <widget class="ColorPicker" name="widget" native="true">
+               <widget class="ColorPicker" name="gridColorPicker" native="true">
                 <property name="sizePolicy">
-                 <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                 <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                   <horstretch>0</horstretch>
                   <verstretch>0</verstretch>
                  </sizepolicy>

--- a/Editors/RoomEditor.ui
+++ b/Editors/RoomEditor.ui
@@ -47,7 +47,7 @@
         </sizepolicy>
        </property>
        <property name="currentIndex">
-        <number>2</number>
+        <number>1</number>
        </property>
        <property name="elideMode">
         <enum>Qt::ElideNone</enum>
@@ -465,25 +465,18 @@
                </widget>
               </item>
               <item>
-               <widget class="QToolButton" name="gridColorButton">
-                <property name="toolTip">
-                 <string>Choose Grid Color</string>
+               <widget class="ColorPicker" name="widget" native="true">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
                 </property>
-                <property name="text">
-                 <string>Choose Color</string>
-                </property>
-                <property name="icon">
-                 <iconset resource="../images.qrc">
-                  <normaloff>:/actions/colorize.png</normaloff>:/actions/colorize.png</iconset>
-                </property>
-                <property name="popupMode">
-                 <enum>QToolButton::MenuButtonPopup</enum>
-                </property>
-                <property name="toolButtonStyle">
-                 <enum>Qt::ToolButtonIconOnly</enum>
-                </property>
-                <property name="arrowType">
-                 <enum>Qt::NoArrow</enum>
+                <property name="minimumSize">
+                 <size>
+                  <width>24</width>
+                  <height>24</height>
+                 </size>
                 </property>
                </widget>
               </item>
@@ -1393,6 +1386,14 @@
    </property>
   </action>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>ColorPicker</class>
+   <extends>QWidget</extends>
+   <header>Widgets/ColorPicker.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
  <resources>
   <include location="../images.qrc"/>
  </resources>

--- a/RadialGM.pro
+++ b/RadialGM.pro
@@ -80,6 +80,7 @@ SOURCES += \
     Components/RecentFiles.cpp \
     Editors/CodeEditor.cpp \
     Editors/ScriptEditor.cpp \
+    Widgets/ColorPicker.cpp
 
 HEADERS += \
     MainWindow.h \
@@ -107,7 +108,8 @@ HEADERS += \
     main.h \
     Dialogs/PreferencesKeys.h \
     Editors/CodeEditor.h \
-    Editors/ScriptEditor.h
+    Editors/ScriptEditor.h \
+    Widgets/ColorPicker.h
 
 FORMS += \
     MainWindow.ui \

--- a/Widgets/ColorPicker.cpp
+++ b/Widgets/ColorPicker.cpp
@@ -12,19 +12,20 @@ ColorPicker::ColorPicker(QWidget *parent) : QWidget(parent) {
   this->setLayout(layout);
 
   connect(button, &QToolButton::clicked, [=]() {
-    QColor color = QColorDialog::getColor(this->color_, this, tr("Choose a color"), QColorDialog::ShowAlphaChannel);
+    QColor color = QColorDialog::getColor(color_, this, tr("Choose a color"), QColorDialog::ShowAlphaChannel);
+    // don't accept the color if the user cancelled the dialog
     if (!color.isValid()) return;
     this->setColor(color);
   });
   connect(this, &ColorPicker::colorChanged, this, &ColorPicker::updateButtonIcon);
-  this->updateButtonIcon();
+  updateButtonIcon();
 }
 
-QColor ColorPicker::color() const { return this->color_; }
+QColor ColorPicker::color() const { return color_; }
 
 void ColorPicker::setColor(QColor color) {
-  if (this->color_ == color) return;
-  this->color_ = color;
+  if (color_ == color) return;
+  color_ = color;
   emit colorChanged(color);
 }
 
@@ -32,6 +33,6 @@ void ColorPicker::updateButtonIcon() {
   QIcon transparencyIcon(":/transparent.png");
   QPixmap pixmap = transparencyIcon.pixmap(24, 24);
   QPainter painter(&pixmap);
-  painter.fillRect(pixmap.rect(), QBrush(this->color_));
+  painter.fillRect(pixmap.rect(), QBrush(color_));
   button->setIcon(pixmap);
 }

--- a/Widgets/ColorPicker.cpp
+++ b/Widgets/ColorPicker.cpp
@@ -4,7 +4,7 @@
 #include <QHBoxLayout>
 #include <QPainter>
 
-ColorPicker::ColorPicker(QWidget *parent) : QWidget(parent) {
+ColorPicker::ColorPicker(QWidget *parent) : QWidget(parent), color_(Qt::black), alpha_enabled_(true) {
   QHBoxLayout *layout = new QHBoxLayout(this);
   layout->setMargin(0);
   button = new QToolButton(this);
@@ -12,7 +12,9 @@ ColorPicker::ColorPicker(QWidget *parent) : QWidget(parent) {
   this->setLayout(layout);
 
   connect(button, &QToolButton::clicked, [=]() {
-    QColor color = QColorDialog::getColor(color_, this, tr("Choose a color"), QColorDialog::ShowAlphaChannel);
+    QColorDialog::ColorDialogOptions options;
+    if (alpha_enabled_) options |= QColorDialog::ShowAlphaChannel;
+    QColor color = QColorDialog::getColor(color_, this, tr("Choose a color"), options);
     // don't accept the color if the user cancelled the dialog
     if (!color.isValid()) return;
     this->setColor(color);
@@ -23,7 +25,7 @@ ColorPicker::ColorPicker(QWidget *parent) : QWidget(parent) {
 
 QColor ColorPicker::color() const { return color_; }
 
-void ColorPicker::setColor(QColor color) {
+void ColorPicker::setColor(const QColor &color) {
   if (color_ == color) return;
   color_ = color;
   emit colorChanged(color);
@@ -36,3 +38,7 @@ void ColorPicker::updateButtonIcon() {
   painter.fillRect(pixmap.rect(), QBrush(color_));
   button->setIcon(pixmap);
 }
+
+bool ColorPicker::alphaEnabled() const { return alpha_enabled_; }
+
+void ColorPicker::setAlphaEnabled(bool enabled) { alpha_enabled_ = enabled; }

--- a/Widgets/ColorPicker.cpp
+++ b/Widgets/ColorPicker.cpp
@@ -1,0 +1,37 @@
+#include "ColorPicker.h"
+
+#include <QColorDialog>
+#include <QHBoxLayout>
+#include <QPainter>
+
+ColorPicker::ColorPicker(QWidget *parent) : QWidget(parent) {
+  QHBoxLayout *layout = new QHBoxLayout(this);
+  layout->setMargin(0);
+  button = new QToolButton(this);
+  layout->addWidget(button);
+  this->setLayout(layout);
+
+  connect(button, &QToolButton::clicked, [=]() {
+    QColor color = QColorDialog::getColor(this->color_, this, tr("Choose a color"), QColorDialog::ShowAlphaChannel);
+    if (!color.isValid()) return;
+    this->setColor(color);
+  });
+  connect(this, &ColorPicker::colorChanged, this, &ColorPicker::updateButtonIcon);
+  this->updateButtonIcon();
+}
+
+QColor ColorPicker::color() const { return this->color_; }
+
+void ColorPicker::setColor(QColor color) {
+  if (this->color_ == color) return;
+  this->color_ = color;
+  emit colorChanged(color);
+}
+
+void ColorPicker::updateButtonIcon() {
+  QIcon transparencyIcon(":/transparent.png");
+  QPixmap pixmap = transparencyIcon.pixmap(24, 24);
+  QPainter painter(&pixmap);
+  painter.fillRect(pixmap.rect(), QBrush(this->color_));
+  button->setIcon(pixmap);
+}

--- a/Widgets/ColorPicker.h
+++ b/Widgets/ColorPicker.h
@@ -8,11 +8,15 @@ class ColorPicker : public QWidget {
   Q_OBJECT
 
   Q_PROPERTY(QColor color READ color WRITE setColor NOTIFY colorChanged USER true)
+  Q_PROPERTY(bool alphaEnabled READ alphaEnabled WRITE setAlphaEnabled)
+
  public:
   explicit ColorPicker(QWidget *parent = nullptr);
 
   QColor color() const;
-  void setColor(QColor);
+  void setColor(const QColor &);
+  bool alphaEnabled() const;
+  void setAlphaEnabled(bool enabled);
 
  signals:
   void colorChanged(QColor);
@@ -22,6 +26,7 @@ class ColorPicker : public QWidget {
 
  private:
   QColor color_;
+  bool alpha_enabled_;
 
   QToolButton *button;
 };

--- a/Widgets/ColorPicker.h
+++ b/Widgets/ColorPicker.h
@@ -1,0 +1,29 @@
+#ifndef COLORPICKER_H
+#define COLORPICKER_H
+
+#include <QToolButton>
+#include <QWidget>
+
+class ColorPicker : public QWidget {
+  Q_OBJECT
+
+  Q_PROPERTY(QColor color READ color WRITE setColor NOTIFY colorChanged USER true)
+ public:
+  explicit ColorPicker(QWidget *parent = nullptr);
+
+  QColor color() const;
+  void setColor(QColor);
+
+ signals:
+  void colorChanged(QColor);
+
+ private slots:
+  void updateButtonIcon();
+
+ private:
+  QColor color_;
+
+  QToolButton *button;
+};
+
+#endif  // COLORPICKER_H


### PR DESCRIPTION
Well, yeah, we need one of these so here it is. I obviously used a `Q_PROPERTY` to implement the user property of the widget so that it can be mapped to models with a widget mapper. It handles transparency just fine using the transparency pattern and drawing a filled rectangle with the color on top of that. Went ahead and promoted the one in the room editor to it.

![Room Grid Color Picking](https://user-images.githubusercontent.com/3212801/47249193-b654a080-d3de-11e8-9e1c-068180e3839a.png)
