### PR TITLE
Fix for Unknown Resource Conversion to Sprites

### DIFF
--- a/Models/ProtoModel.cpp
+++ b/Models/ProtoModel.cpp
@@ -25,9 +25,13 @@ ProtoModel::ProtoModel(Message *protobuf, QObject *parent)
         }
       } else {
         const google::protobuf::OneofDescriptor *oneof = field->containing_oneof();
-        if (oneof && refl->HasOneof(*protobuf, oneof)) {
-          field = refl->GetOneofFieldDescriptor(*protobuf, oneof);
-          if (field->cpp_type() != CppType::CPPTYPE_MESSAGE) continue;  // is prolly folder
+        if (oneof) {
+          if (refl->HasOneof(*protobuf, oneof)) {
+            field = refl->GetOneofFieldDescriptor(*protobuf, oneof);
+            if (field->cpp_type() != CppType::CPPTYPE_MESSAGE) continue;  // is prolly folder
+          } else {
+            continue;  // don't allocate if not set
+          }
         }
         ProtoModel *subModel = new ProtoModel(refl->MutableMessage(protobuf, field), this);
         messages[field->number()] = QVariant::fromValue(static_cast<void *>(subModel));


### PR DESCRIPTION
This fix here stops the IDE from converting unknown resources to sprites with an id of 0 which results in the id collision in #41.

I dug out the real cause of the regression. The `ResourceModelMap` that fundies created causes the type case of the help node to change from 0 (not set/unknown) to 2 (sprite) when it constructs a recursive map of the project model.

It causes this by allocating a message and then constructing a `ProtoModel` for the submessage of every tree node. The problem occurs because the tree node resource is a oneof field. Fundies does check that the field is a oneof and `HasOneof` but he was still calling `MutableMessage` even in the case that the oneof field was not actually set. `MutableMessage` will allocate and set the oneof field, regardless of whether it was actually previously set, and in this case since it doesn't know what type `0` is, it sets the oneof to the sprite type case.

The incorrect allocating of a sprite for the help node causes a crash when the tree model attempts to later lookup the sprite's subimages and generate a preview icon.