### PR TITLE
Fix Tree Model Crashes for Missing Previews

### DIFF
--- a/Models/TreeModel.cpp
+++ b/Models/TreeModel.cpp
@@ -51,23 +51,19 @@ QVariant TreeModel::data(const QModelIndex &index, int role) const {
     if (item->type_case() == TypeCase::kSprite) {
       if (item->sprite().subimages_size() <= 0) return QVariant();
       QString spr = QString::fromStdString(item->sprite().subimages(0));
-      if (!spr.isEmpty()) return ArtManager::GetIcon(spr);
-      return QVariant();
+      return spr.isEmpty() ? QVariant() : ArtManager::GetIcon(spr);
     }
 
     if (item->type_case() == TypeCase::kBackground) {
       QString bkg = QString::fromStdString(item->background().image());
-      if (!bkg.isEmpty()) return ArtManager::GetIcon(bkg);
-      return QVariant();
+      return bkg.isEmpty() ? QVariant() : ArtManager::GetIcon(bkg);
     }
 
     if (item->type_case() == TypeCase::kObject) {
       const ProtoModel *sprModel = GetObjectSprite(item->name());
-      if (sprModel != nullptr) {
-        QString spr = sprModel->GetString(Sprite::kSubimagesFieldNumber, 0);
-        if (!spr.isEmpty()) return ArtManager::GetIcon(spr);
-      }
-      return QVariant();
+      if (sprModel == nullptr) return QVariant();
+      QString spr = sprModel->GetString(Sprite::kSubimagesFieldNumber, 0);
+      return spr.isEmpty() ? QVariant() : ArtManager::GetIcon(spr);
     }
 
     const QIcon &icon = it->second;

--- a/Models/TreeModel.cpp
+++ b/Models/TreeModel.cpp
@@ -49,13 +49,16 @@ QVariant TreeModel::data(const QModelIndex &index, int role) const {
     if (it == iconMap.end()) return ArtManager::GetIcon("info");
 
     if (item->type_case() == TypeCase::kSprite) {
+      if (item->sprite().subimages_size() <= 0) return QVariant();
       QString spr = QString::fromStdString(item->sprite().subimages(0));
       if (!spr.isEmpty()) return ArtManager::GetIcon(spr);
+      return QVariant();
     }
 
     if (item->type_case() == TypeCase::kBackground) {
       QString bkg = QString::fromStdString(item->background().image());
       if (!bkg.isEmpty()) return ArtManager::GetIcon(bkg);
+      return QVariant();
     }
 
     if (item->type_case() == TypeCase::kObject) {
@@ -64,6 +67,7 @@ QVariant TreeModel::data(const QModelIndex &index, int role) const {
         QString spr = sprModel->GetString(Sprite::kSubimagesFieldNumber, 0);
         if (!spr.isEmpty()) return ArtManager::GetIcon(spr);
       }
+      return QVariant();
     }
 
     const QIcon &icon = it->second;


### PR DESCRIPTION
This fixes the actual crash in #41 and needs to be done regardless. Primarily, sprites with no subimages should not crash the IDE.

Currently, the change here behaves differently than GM and LGM. By returning an invalid `QVariant` when the sprite/object/background icon can not be obtained (e.g, sprite with no subimages) this essentially means we return no icon. The label of the tree item is then shifted left with no placement for the icon. This is not the same as returning an empty/translucent icon of a fixed size like GM always did and continues to do in GMS2.

However, I feel that having the empty icon could be confusing, because it looks as if the resource just has an empty icon, which is not quite the same (e.g, an object that doesn't have a sprite). But anyway, I can certainly change this aspect of it later, to be more like GM, but I'd like some input on how people feel about that and for now just having it not crash is better.