### PR TITLE
Fix Crash When Opening Unknown Resources

### DIFF
--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -132,8 +132,8 @@ void MainWindow::openSubWindow(buffers::TreeNode *item) {
                                 {TypeCase::kSettings, EditorFactory<SettingsEditor>}});
 
   auto swIt = subWindows.find(item);
-  QMdiSubWindow *subWindow = (swIt == subWindows.end()) ? nullptr : *swIt;
-  if (subWindow == nullptr) {
+  QMdiSubWindow *subWindow = *swIt;
+  if (swIt == subWindows.end() || !subWindow) {
     auto factoryFunction = factoryMap.find(item->type_case());
     if (factoryFunction == factoryMap.end()) return;  // no registered editor
 

--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -132,8 +132,8 @@ void MainWindow::openSubWindow(buffers::TreeNode *item) {
                                 {TypeCase::kSettings, EditorFactory<SettingsEditor>}});
 
   auto swIt = subWindows.find(item);
-  QMdiSubWindow *subWindow = nullptr;
-  if (swIt == subWindows.end() || subWindow == nullptr) {
+  QMdiSubWindow *subWindow = (swIt == subWindows.end()) ? nullptr : *swIt;
+  if (subWindow == nullptr) {
     auto factoryFunction = factoryMap.find(item->type_case());
     if (factoryFunction == factoryMap.end()) return;  // no registered editor
 
@@ -151,8 +151,6 @@ void MainWindow::openSubWindow(buffers::TreeNode *item) {
 
     subWindow->setWindowIcon(subWindow->widget()->windowIcon());
     subWindow->setWindowTitle(QString::fromStdString(item->name()));
-  } else {
-    subWindow = *swIt;
   }
 
   subWindow->show();

--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -131,8 +131,9 @@ void MainWindow::openSubWindow(buffers::TreeNode *item) {
                                 {TypeCase::kRoom, EditorFactory<RoomEditor>},
                                 {TypeCase::kSettings, EditorFactory<SettingsEditor>}});
 
-  auto subWindow = subWindows[item];
-  if (!subWindows.contains(item) || subWindow == nullptr) {
+  auto swIt = subWindows.find(item);
+  QMdiSubWindow *subWindow = nullptr;
+  if (swIt == subWindows.end() || subWindow == nullptr) {
     auto factoryFunction = factoryMap.find(item->type_case());
     if (factoryFunction == factoryMap.end()) return;  // no registered editor
 
@@ -150,6 +151,8 @@ void MainWindow::openSubWindow(buffers::TreeNode *item) {
 
     subWindow->setWindowIcon(subWindow->widget()->windowIcon());
     subWindow->setWindowTitle(QString::fromStdString(item->name()));
+  } else {
+    subWindow = *swIt;
   }
 
   subWindow->show();

--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -132,8 +132,8 @@ void MainWindow::openSubWindow(buffers::TreeNode *item) {
                                 {TypeCase::kSettings, EditorFactory<SettingsEditor>}});
 
   auto swIt = subWindows.find(item);
-  QMdiSubWindow *subWindow = *swIt;
-  if (swIt == subWindows.end() || !subWindow) {
+  QMdiSubWindow *subWindow;
+  if (swIt == subWindows.end() || !*swIt) {
     auto factoryFunction = factoryMap.find(item->type_case());
     if (factoryFunction == factoryMap.end()) return;  // no registered editor
 
@@ -151,6 +151,8 @@ void MainWindow::openSubWindow(buffers::TreeNode *item) {
 
     subWindow->setWindowIcon(subWindow->widget()->windowIcon());
     subWindow->setWindowTitle(QString::fromStdString(item->name()));
+  } else {
+    subWindow = *swIt;
   }
 
   subWindow->show();


### PR DESCRIPTION
This was a minor logic mistake that I made. I used the subscript operator `[]` to check if a subwindow was already added for a given tree node. This was not what I actually intended, because the subscript operator will insert the item if it's not present. The other place that the subscript operator is still used was intentional.

1) Attempt to open an unknown resource by double clicking, like the help/info node
2) Select the help/info tree node with a single left click and then press F2 to rename it
3) After renaming the item the crash occurs

This basically fixes a crash that occurs when trying to open unknown resources (those with type case not set). One such resource at the moment in the help node I've been addressing in other ways. Regardless of whether we want to keep help/info as a resource, this change still needs to be made for safety. This basically means opening an unknown resource is a noop.