### PR TITLE
Add Tree Node Crash Fix

### DIFF
--- a/Models/TreeModel.cpp
+++ b/Models/TreeModel.cpp
@@ -131,7 +131,7 @@ int TreeModel::rowCount(const QModelIndex &parent) const {
 
 void TreeModel::addNode(buffers::TreeNode *child, buffers::TreeNode *parent) {
   auto rootIndex = QModelIndex();
-  emit beginInsertRows(rootIndex, parent->child_size(), parent->child_size());
+  emit beginInsertRows(rootIndex, parent->child_size() - 1, parent->child_size() - 1);
   parents[child] = parent;
   emit endInsertRows();
 }


### PR DESCRIPTION
This fixes a crash that can be reproduced by creating a room and then an object. The logic mistake I made was in `TreeModel::addNode` where the child size is one larger than the index of the row I want to insert into the tree. The reason is because the child is already added to the parent by way of `TreeNode::add_child` which is called in `MainWindow::CreateResource` before `addNode` is even called.

I will need to be extra careful when I do the tree drag and drop.