### PR TITLE
Missing emake Crash Fix

### DIFF
--- a/Plugins/ServerPlugin.cpp
+++ b/Plugins/ServerPlugin.cpp
@@ -244,7 +244,7 @@ ServerPlugin::ServerPlugin(MainWindow& mainWindow) : RGMPlugin(mainWindow) {
   process = new QProcess(this);
 
   // look for an executable file that looks like emake in some common directories
-  QList<QString> searchPaths = {QDir::currentPath(), "../RadialGM/Submodules/enigma-dev"};
+  QList<QString> searchPaths = {QDir::currentPath(), "./enigma-dev", "../RadialGM/Submodules/enigma-dev"};
   QFileInfo emakeFileInfo(QFile("emake"));
   foreach (auto path, searchPaths) {
     const QDir dir(path);

--- a/Widgets/CodeWidgetScintilla.cpp
+++ b/Widgets/CodeWidgetScintilla.cpp
@@ -39,16 +39,21 @@ void CodeWidget::prepareKeywordStore() {
 }
 
 void CodeWidget::addKeyword(const QString& keyword, KeywordType type) {
+  if (!sciApis) return;
   QString fmt = keyword + QObject::tr("?%0").arg(type);
   sciApis->add(fmt);
 }
 
 void CodeWidget::addCalltip(const QString& keyword, const QString& calltip, KeywordType type) {
+  if (!sciApis) return;
   QString fmt = keyword + QObject::tr("?%0(%1)").arg(type).arg(calltip);
   sciApis->add(fmt);
 }
 
-void CodeWidget::finalizeKeywords() { sciApis->prepare(); }
+void CodeWidget::finalizeKeywords() {
+  if (!sciApis) return;
+  sciApis->prepare();
+}
 
 CodeWidget::CodeWidget(QWidget* parent) : QWidget(parent), font(QFont("Courier", 10)) {
   prepare_scintilla_apis();


### PR DESCRIPTION
I have already noticed and people have already mentioned the latest RGM crashes a few seconds after open if emake is not found. This is because the ResourceReader has its `finished()` called without its `started()` ever being called in the case that emake is not found. The `CodeWidget::finalizeKeywords` is where the crash occurs because `CodeWidget::prepareKeywordStore` was not called to allocate and prepare `sciApis` to be used.

This change fixes the crash by making all of the keyword API just be a noop if `sciApis` wasn't allocated. I've also additionally added another directory where emake can be found, an `enigma-dev` folder directly next to the RGM executable.