### PR TITLE
Assets Modularization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ set(CMAKE_AUTOUIC_SEARCH_PATHS "${CMAKE_CURRENT_SOURCE_DIR}/Dialogs")
 
 # Include ENIGMA things
 set(ENIGMA_DIR ${CMAKE_CURRENT_SOURCE_DIR}/Submodules/enigma-dev)
-include_directories("${ENIGMA_DIR}/CommandLine/protos" "${ENIGMA_DIR}/CommandLine/libEGM" "${ENIGMA_DIR}/shared/bettersystem")
+include_directories("${ENIGMA_DIR}/CommandLine/protos" "${ENIGMA_DIR}/CommandLine/libEGM" "${ENIGMA_DIR}/CommandLine/libAssets")
 
 # Populate a CMake variable with the sources
 set(RGM_SOURCES

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ set(CMAKE_AUTOUIC_SEARCH_PATHS "${CMAKE_CURRENT_SOURCE_DIR}/Dialogs")
 
 # Include ENIGMA things
 set(ENIGMA_DIR ${CMAKE_CURRENT_SOURCE_DIR}/Submodules/enigma-dev)
-include_directories("${ENIGMA_DIR}/CommandLine/protos" "${ENIGMA_DIR}/CommandLine/libEGM")
+include_directories("${ENIGMA_DIR}/CommandLine/protos" "${ENIGMA_DIR}/CommandLine/libEGM" "${ENIGMA_DIR}/shared/bettersystem")
 
 # Populate a CMake variable with the sources
 set(RGM_SOURCES
@@ -177,6 +177,13 @@ find_library(LIB_EGM_D NAMES EGMd PATHS ${ENIGMA_DIR})
 # Release
 find_library(LIB_EGM NAMES EGM PATHS ${ENIGMA_DIR})
 target_link_libraries(${EXE} PRIVATE "$<IF:$<CONFIG:Debug>,${LIB_EGM_D},${LIB_EGM}>")
+
+# Find libAssets
+# Debug
+find_library(LIB_ASSETS_D NAMES Assetsd PATHS ${ENIGMA_DIR})
+# Release
+find_library(LIB_ASSETS NAMES Assets PATHS ${ENIGMA_DIR})
+target_link_libraries(${EXE} PRIVATE "$<IF:$<CONFIG:Debug>,${LIB_ASSETS_D},${LIB_ASSETS}>")
 
 # Find libProtocols
 # Debug

--- a/Plugins/ServerPlugin.h
+++ b/Plugins/ServerPlugin.h
@@ -71,6 +71,8 @@ class CompilerClient : public QObject {
 
   template <typename T>
   T* ScheduleTask();
+  template <typename T>
+  T* ScheduleTask(T*);
 
   std::unique_ptr<Compiler::Stub> stub;
   MainWindow& mainWindow;

--- a/RadialGM.pro
+++ b/RadialGM.pro
@@ -43,6 +43,7 @@ DEFINES += QT_DEPRECATED_WARNINGS
 
 INCLUDEPATH += /usr/include/qt/ \
                $$PWD/Submodules/enigma-dev/CommandLine/libEGM/ \
+               $$PWD/Submodules/enigma-dev/CommandLine/libAssets/ \
                $$PWD/Submodules/enigma-dev/CommandLine/protos \
                $$PWD/Submodules/enigma-dev/CommandLine/protos/codegen
 LIBS += -L$$PWD/Submodules/enigma-dev/CommandLine/libEGM/ \
@@ -51,6 +52,7 @@ LIBS += -L$$PWD/Submodules/enigma-dev/CommandLine/libEGM/ \
         -Wl,--rpath=$$PWD/Submodules/enigma-dev/ \
         -L$$PWD/Submodules/enigma-dev/ \
         -lProtocols \
+        -lAssets \
         -lpugixml \
         -lgrpc++
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -63,6 +63,10 @@ build_script:
   - mkdir build && cd build
   - cmake -G "%GENERATOR%" -DCMAKE_BUILD_TYPE="%BUILD_TYPE%" -DPROTOBUF_IMPORT_DIRS="%VCPKG_DIR%\installed\%TRIPLET_NAME%\include" -DVCPKG_TARGET_TRIPLET=%TRIPLET_NAME% -DCMAKE_TOOLCHAIN_FILE="%VCPKG_DIR%\scripts\buildsystems\vcpkg.cmake" ..
   - cmake --build . --target install --config "%BUILD_TYPE%"
+  - cd %APPVEYOR_BUILD_FOLDER%\Submodules\enigma-dev\CommandLine\libAssets
+  - mkdir build && cd build
+  - cmake -G "%GENERATOR%" -DCMAKE_BUILD_TYPE="%BUILD_TYPE%" -DVCPKG_TARGET_TRIPLET=%TRIPLET_NAME% -DCMAKE_TOOLCHAIN_FILE="%VCPKG_DIR%\scripts\buildsystems\vcpkg.cmake" ..
+  - cmake --build . --target install --config "%BUILD_TYPE%"
   - cd %APPVEYOR_BUILD_FOLDER%\Submodules\enigma-dev\CommandLine\libEGM
   - mkdir build && cd build
   - cmake -G "%GENERATOR%" -DCMAKE_BUILD_TYPE="%BUILD_TYPE%" -DVCPKG_TARGET_TRIPLET=%TRIPLET_NAME% -DCMAKE_TOOLCHAIN_FILE="%VCPKG_DIR%\scripts\buildsystems\vcpkg.cmake" ..


### PR DESCRIPTION
This pull request just updates RGM to use the new `libAssets` to write assets to the game and then launch it. It should be merged at the same time the enigma-dev equivalent pull request is merged. 
https://github.com/enigma-dev/enigma-dev/pull/1432

### Summary of Changes
* Changed the `CMakeLists` to static link `libAssets` and to add its directory to the include dirs.
* Changed the `RadialGM.pro` to link to `libAssets` and to add its directory to the include dirs.
* Changed the `CompileReader::CompileReader` constructor to accept a reference to the `CompileRequest` so that it can refer to it in the `finished()` state. 
* Added an overload for `CompilerClient::ScheduleTask` so that you can specify an already constructed task.
* Updated the AppVeyor build so that it builds `libAssets` for it to be statically linked.
* Updated the enigma-dev submodule to point to the `libassets` branch that has the changes necessary for this pull request.
