### PR TITLE
Update ENIGMA Submodule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ ui_*.h
 *.qmlc
 *.jsc
 *build-*
+*.stackdump
 
 # Qt unit tests
 target_wrapper.*


### PR DESCRIPTION
Lots of problems today with helping daz and Bloodseeker build for Windows and Linux respectively. Some of the problems were caused by the submodule falling behind and losing fixes Josh made to prevent `JavaStruct.h` pollution into the protos. Also with the newer Qt Creator, it decided to give me some `*.stackdump` file we obviously don't want to be committing, so I've added that to ignore.