### PR TITLE
Fix Release Build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -188,7 +188,7 @@ target_link_libraries(${EXE} PRIVATE "$<IF:$<CONFIG:Debug>,${LIB_PROTO_D},${LIB_
 find_library(LIB_GRPC_UNSECURE NAMES grpc++_unsecure)
 find_library(LIB_GRPC NAMES grpc)
 find_library(LIB_GPR NAMES gpr)
-target_link_libraries(${EXE} PRIVATE ${LIB_GPR} ${LIB_GRPC} ${LIB_GRPC_UNSECURE})
+target_link_libraries(${EXE} PRIVATE ${LIB_GRPC_UNSECURE})
 
 # Find Protobuf
 include(FindProtobuf)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -188,7 +188,7 @@ target_link_libraries(${EXE} PRIVATE "$<IF:$<CONFIG:Debug>,${LIB_PROTO_D},${LIB_
 find_library(LIB_GRPC_UNSECURE NAMES grpc++_unsecure)
 find_library(LIB_GRPC NAMES grpc)
 find_library(LIB_GPR NAMES gpr)
-find_library(LIB_ARES NAMES ares)
+find_library(LIB_ARES NAMES cares)
 target_link_libraries(${EXE} PRIVATE ${LIB_ARES} ${LIB_GPR} ${LIB_GRPC} ${LIB_GRPC_UNSECURE})
 
 # Find Protobuf

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -188,8 +188,8 @@ target_link_libraries(${EXE} PRIVATE "$<IF:$<CONFIG:Debug>,${LIB_PROTO_D},${LIB_
 find_library(LIB_GRPC_UNSECURE NAMES grpc++_unsecure)
 find_library(LIB_GRPC NAMES grpc)
 find_library(LIB_GPR NAMES gpr)
-find_library(LIB_ARES NAMES cares)
-target_link_libraries(${EXE} PRIVATE ${LIB_ARES} ${LIB_GPR} ${LIB_GRPC} ${LIB_GRPC_UNSECURE})
+find_library(LIB_ADDRESS_SORTING NAMES address_sorting)
+target_link_libraries(${EXE} PRIVATE ${LIB_ADDRESS_SORTING} ${LIB_GPR} ${LIB_GRPC} ${LIB_GRPC_UNSECURE})
 
 # Find Protobuf
 include(FindProtobuf)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -188,7 +188,8 @@ target_link_libraries(${EXE} PRIVATE "$<IF:$<CONFIG:Debug>,${LIB_PROTO_D},${LIB_
 find_library(LIB_GRPC_UNSECURE NAMES grpc++_unsecure)
 find_library(LIB_GRPC NAMES grpc)
 find_library(LIB_GPR NAMES gpr)
-target_link_libraries(${EXE} PRIVATE ${LIB_GRPC_UNSECURE} ${LIB_GRPC} ${LIB_GPR} )
+find_library(LIB_ARES NAMES ares)
+target_link_libraries(${EXE} PRIVATE ${LIB_ARES} ${LIB_GPR} ${LIB_GRPC} ${LIB_GRPC_UNSECURE})
 
 # Find Protobuf
 include(FindProtobuf)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -184,20 +184,20 @@ find_library(LIB_PROTO_D NAMES Protocolsd PATHS ${ENIGMA_DIR})
 find_library(LIB_PROTO NAMES Protocols PATHS ${ENIGMA_DIR})
 target_link_libraries(${EXE} PRIVATE "$<IF:$<CONFIG:Debug>,${LIB_PROTO_D},${LIB_PROTO}>")
 
-# Find OpenSSL
-find_package(OpenSSL REQUIRED)
-target_link_libraries(${EXE} PRIVATE OpenSSL::SSL OpenSSL::Crypto)
-
 # Find GRPC
 find_library(LIB_GRPC_UNSECURE NAMES grpc++_unsecure)
 find_library(LIB_GRPC NAMES grpc)
 find_library(LIB_GPR NAMES gpr)
-target_link_libraries(${EXE} PRIVATE ${LIB_GPR} ${LIB_GRPC} ${LIB_GRPC_UNSECURE})
+target_link_libraries(${EXE} PRIVATE ${LIB_GRPC_UNSECURE} ${LIB_GRPC} ${LIB_GPR} )
 
 # Find Protobuf
 include(FindProtobuf)
 include_directories(${Protobuf_INCLUDE_DIRS})
 target_link_libraries(${EXE} PRIVATE ${Protobuf_LIBRARIES})
+
+# Find OpenSSL
+find_package(OpenSSL REQUIRED)
+target_link_libraries(${EXE} PRIVATE OpenSSL::SSL OpenSSL::Crypto)
 
 # Find Qt
 find_package(Qt5 COMPONENTS Core Widgets Gui PrintSupport REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -188,7 +188,7 @@ target_link_libraries(${EXE} PRIVATE "$<IF:$<CONFIG:Debug>,${LIB_PROTO_D},${LIB_
 find_library(LIB_GRPC_UNSECURE NAMES grpc++_unsecure)
 find_library(LIB_GRPC NAMES grpc)
 find_library(LIB_GPR NAMES gpr)
-target_link_libraries(${EXE} PRIVATE ${LIB_GRPC_UNSECURE})
+target_link_libraries(${EXE} PRIVATE ${LIB_GPR} ${LIB_GRPC_UNSECURE})
 
 # Find Protobuf
 include(FindProtobuf)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -188,8 +188,9 @@ target_link_libraries(${EXE} PRIVATE "$<IF:$<CONFIG:Debug>,${LIB_PROTO_D},${LIB_
 find_library(LIB_GRPC_UNSECURE NAMES grpc++_unsecure)
 find_library(LIB_GRPC NAMES grpc)
 find_library(LIB_GPR NAMES gpr)
+find_library(LIB_CARES NAMES cares)
 find_library(LIB_ADDRESS_SORTING NAMES address_sorting)
-target_link_libraries(${EXE} PRIVATE ${LIB_ADDRESS_SORTING} ${LIB_GPR} ${LIB_GRPC} ${LIB_GRPC_UNSECURE})
+target_link_libraries(${EXE} PRIVATE ${LIB_CARES} ${LIB_ADDRESS_SORTING} ${LIB_GPR} ${LIB_GRPC} ${LIB_GRPC_UNSECURE})
 
 # Find Protobuf
 include(FindProtobuf)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -184,20 +184,20 @@ find_library(LIB_PROTO_D NAMES Protocolsd PATHS ${ENIGMA_DIR})
 find_library(LIB_PROTO NAMES Protocols PATHS ${ENIGMA_DIR})
 target_link_libraries(${EXE} PRIVATE "$<IF:$<CONFIG:Debug>,${LIB_PROTO_D},${LIB_PROTO}>")
 
+# Find OpenSSL
+find_package(OpenSSL REQUIRED)
+target_link_libraries(${EXE} PRIVATE OpenSSL::SSL OpenSSL::Crypto)
+
 # Find GRPC
 find_library(LIB_GRPC_UNSECURE NAMES grpc++_unsecure)
 find_library(LIB_GRPC NAMES grpc)
 find_library(LIB_GPR NAMES gpr)
-target_link_libraries(${EXE} PRIVATE ${LIB_GPR} ${LIB_GRPC_UNSECURE})
+target_link_libraries(${EXE} PRIVATE ${LIB_GPR} ${LIB_GRPC} ${LIB_GRPC_UNSECURE})
 
 # Find Protobuf
 include(FindProtobuf)
 include_directories(${Protobuf_INCLUDE_DIRS})
 target_link_libraries(${EXE} PRIVATE ${Protobuf_LIBRARIES})
-
-# Find OpenSSL
-find_package(OpenSSL REQUIRED)
-target_link_libraries(${EXE} PRIVATE OpenSSL::SSL OpenSSL::Crypto)
 
 # Find Qt
 find_package(Qt5 COMPONENTS Core Widgets Gui PrintSupport REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,10 +186,9 @@ target_link_libraries(${EXE} PRIVATE "$<IF:$<CONFIG:Debug>,${LIB_PROTO_D},${LIB_
 
 # Find GRPC
 find_library(LIB_GRPC_UNSECURE NAMES grpc++_unsecure)
-find_library(LIB_GRPC_CRONET NAMES grpc_cronet)
 find_library(LIB_GRPC NAMES grpc)
 find_library(LIB_GPR NAMES gpr)
-target_link_libraries(${EXE} PRIVATE ${LIB_GPR} ${LIB_GRPC} ${LIB_GRPC_UNSECURE} ${LIB_GRPC_CRONET})
+target_link_libraries(${EXE} PRIVATE ${LIB_GPR} ${LIB_GRPC} ${LIB_GRPC_UNSECURE})
 
 # Find Protobuf
 include(FindProtobuf)


### PR DESCRIPTION
I'm getting errors when trying to use the static RGM release in my enigma-dev setup that has emake built with the server. It seems to be rejecting localhost connection.
```
$ ./RadialGM-Win32-Release-x64.exe
E0505 15:38:43.277000000  6244 resolver_registry.cc:80] don't know how to resolve 'localhost:37818' or 'dns:///localhost:37818'
E0505 15:38:43.277000000  6244 resolver_registry.cc:80] don't know how to resolve 'dns:///localhost:37818' or 'dns:///dns:///localhost:37818'
E0505 15:38:43.277000000  6244 channel.cc:99] channel stack builder failed: {"created":"@1557085123.277000000","description":"resolver creation failed","file":"C:\Tools\vcpkg\buildtrees\grpc\src\v1.19.1-81627204c3\src\core\ext\filters\client_channel\request_routing.cc","file_line":546}
```
I read that this may be caused by CRONET, so I removed it, and realized what we needed was `cares.lib` and `addressing_sorting.lib`. With this change, RGM and the emake server communicate just fine! 👍 
