### PR TITLE
Tree Model Drag & Drop Fixes

### DIFF
--- a/Editors/BaseEditor.h
+++ b/Editors/BaseEditor.h
@@ -6,16 +6,13 @@
 #include <QObject>
 #include <QWidget>
 
-static const QHash<int, int> ResTypeFields = {{TypeCase::kSprite, TreeNode::kSpriteFieldNumber},
-                                              {TypeCase::kSound, TreeNode::kSoundFieldNumber},
-                                              {TypeCase::kBackground, TreeNode::kBackgroundFieldNumber},
-                                              {TypeCase::kPath, TreeNode::kPathFieldNumber},
-                                              {TypeCase::kFont, TreeNode::kFontFieldNumber},
-                                              {TypeCase::kScript, TreeNode::kScriptFieldNumber},
-                                              {TypeCase::kTimeline, TreeNode::kTimelineFieldNumber},
-                                              {TypeCase::kObject, TreeNode::kObjectFieldNumber},
-                                              {TypeCase::kRoom, TreeNode::kRoomFieldNumber},
-                                              {TypeCase::kSettings, TreeNode::kSettingsFieldNumber}};
+static const QHash<int, int> ResTypeFields = {
+    {TypeCase::kFolder, TreeNode::kFolderFieldNumber},    {TypeCase::kSprite, TreeNode::kSpriteFieldNumber},
+    {TypeCase::kSound, TreeNode::kSoundFieldNumber},      {TypeCase::kBackground, TreeNode::kBackgroundFieldNumber},
+    {TypeCase::kPath, TreeNode::kPathFieldNumber},        {TypeCase::kFont, TreeNode::kFontFieldNumber},
+    {TypeCase::kScript, TreeNode::kScriptFieldNumber},    {TypeCase::kTimeline, TreeNode::kTimelineFieldNumber},
+    {TypeCase::kObject, TreeNode::kObjectFieldNumber},    {TypeCase::kRoom, TreeNode::kRoomFieldNumber},
+    {TypeCase::kSettings, TreeNode::kSettingsFieldNumber}};
 
 class BaseEditor : public QWidget {
   Q_OBJECT

--- a/Models/ResourceModelMap.cpp
+++ b/Models/ResourceModelMap.cpp
@@ -33,7 +33,8 @@ QString ResourceModelMap::CreateResourceName(TreeNode* node) {
   auto fieldNum = ResTypeFields[node->type_case()];
   const Descriptor* desc = node->GetDescriptor();
   const FieldDescriptor* field = desc->FindFieldByNumber(fieldNum);
-  return CreateResourceName(node->type_case(), QString::fromStdString(field->name()));
+  const QString fieldName = node->folder() ? "group" : QString::fromStdString(field->name());
+  return CreateResourceName(node->type_case(), fieldName);
 }
 
 QString ResourceModelMap::CreateResourceName(int type, const QString& typeName) {

--- a/Models/TreeModel.cpp
+++ b/Models/TreeModel.cpp
@@ -257,6 +257,7 @@ bool TreeModel::dropMimeData(const QMimeData *mimeData, Qt::DropAction action, i
       endMoveRows();
       ++row;
     } else {
+      if (node->folder()) continue;
       node = duplicateNode(*node);
       insert(parent, row++, node);
     }

--- a/Models/TreeModel.cpp
+++ b/Models/TreeModel.cpp
@@ -249,16 +249,17 @@ bool TreeModel::dropMimeData(const QMimeData *mimeData, Qt::DropAction action, i
       if (parentNode == oldParent && row > itemRow) --row;
 
       auto index = this->createIndex(itemRow, 0, node);
-      beginRemoveRows(index.parent(), itemRow, itemRow);
+      beginMoveRows(index.parent(), itemRow, itemRow, parent, row);
       auto oldRepeated = oldParent->mutable_child();
       oldRepeated->ExtractSubrange(itemRow, 1, nullptr);
-      parents.remove(node);
-      endRemoveRows();
+      RepeatedFieldInsert<buffers::TreeNode>(parentNode->mutable_child(), node, row);
+      parents[node] = parentNode;
+      endMoveRows();
+      ++row;
     } else {
       node = duplicateNode(*node);
+      insert(parent, row++, node);
     }
-
-    insert(parent, row++, node);
   }
 
   return true;


### PR DESCRIPTION
This is a very simple set of changes for plionz that should make the tree model a bit more efficient. 

Basically the idea is to move the rows for non-copy drag and drop, rather than remove them and reinsert them. This actually will correct any persistent model indexes obtained from the tree model since Qt internally updates their references automatically for us.

While I was in here I fixed crashes involved in drag-copy of tree groups too. In addition to fixing the underlying crash, me and polygonz decided on skipping the drag-copy of tree groups until `duplicateNode` is made recursive or we see a need to implement this functionality since GM's UI never supported it.