### PR TITLE
Update Shared Settings File Version

### DIFF
--- a/RadialGM.pro.shared
+++ b/RadialGM.pro.shared
@@ -3,7 +3,7 @@
 <qtcreator>
     <data>
         <variable>ProjectExplorer.Project.Updater.FileVersion</variable>
-        <value type="int">10</value>
+        <value type="int">21</value>
     </data>
     <data>
         <variable>ProjectExplorer.Project.EditorSettings</variable>


### PR DESCRIPTION
This is to make that warning go away when opening the project in the latest Qt Creator. It occurs because the `FileVersion` is different in the shared settings from the one in the user settings Qt Creator generates.
https://doc.qt.io/qtcreator/creator-sharing-project-settings.html

![Shared Settings File Version Warning](https://user-images.githubusercontent.com/3212801/59572601-4cc78780-907c-11e9-9e1d-d10d3fcf0cf1.png)

It's ok for us to do this as it will still work for people with older Qt Creator versions. They will get the same warning. This just means that people with the latest Qt Creator don't have to deal with the warning. So, in general, it's ok for us to regularly update this `FileVersion` to avoid the warning. I tested to confirm by setting the FileVersion older like it was, and setting it newer than my installed Qt Creator.