### PR TITLE
Fix Main Window Settings Regression

### DIFF
--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -128,6 +128,7 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWi
     }
   });
 
+  this->readSettings();
   this->recentFiles = new RecentFiles(this, this->ui->menuRecent, this->ui->actionClearRecentMenu);
 
   ui->mdiArea->setBackground(QImage(":/banner.png"));


### PR DESCRIPTION
This fixes a regression I introduced in #63 by accidentally deleting the call to read the main window's settings. Polygonz caught it by mentioning that the maximized state of the window and its geometry was not persisting between sessions. I have inserted the call after the setup of the editor diagnostics, which is what I think caused me to accidentally remove it, that way if there are problems reading certain settings they can be logged to the editor diagnostics.