### PR TITLE
High DPI Fixes

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -17,6 +17,7 @@ int main(int argc, char *argv[]) {
   a.setApplicationName("RadialGM");
   a.setWindowIcon(QIcon(":/icon.ico"));
   a.setAttribute(Qt::AA_DisableWindowContextHelpButton);
+  a.setAttribute(Qt::AA_EnableHighDpiScaling);
 
   defaultStyle = a.style()->objectName();
 


### PR DESCRIPTION
Splitting this out from polygonz changes so I can talk about it. With my 2k monitor, I am not seeing any difference with or without the setting applied, but polygonz claims to and Rusky backs him stating the screenshots which showed it fixing the problem for polygonz.

For now, I just want to allow polygonz to enable the setting permanently and see no need for a preference yet. Later, if somebody has an issue, we can look at adding a three-button radio group or two checkboxes. One will force the high DPI to be enabled, and one will force it to be disabled, since there are Qt settings for both. I see no need for the preference because Rusky has told me the Windows Compatibility DPI override should override it if the user really needs to disable DPI for some reason.

What confuses me is that Qt claims to be DPI aware by default now. So polygonz shouldn't have needed this setting applied, but perhaps they just have a varying definition of _high_ DPI, which doesn't include my 2k monitor but includes polygonz 4k TV.

https://doc.qt.io/qt-5/highdpi.html

>Qt applications by default are Per-Monitor DPI Aware on Windows 8.1 or System-DPI Aware on older versions of Windows.