### PR TITLE
Cached Pixmap Crash Fix

### DIFF
--- a/Components/ArtManager.cpp
+++ b/Components/ArtManager.cpp
@@ -30,6 +30,7 @@ const QIcon& ArtManager::GetIcon(const QString& name) {
 const QBrush& ArtManager::GetTransparenyBrush() { return transparenyBrush; }
 
 const QPixmap& ArtManager::GetCachedPixmap(const QString& name) {
+  //TODO: FIX DIS
   QPixmap pm;
   if (!QPixmapCache::find(name, &pm)) {
     pm.load(name);

--- a/Components/ArtManager.cpp
+++ b/Components/ArtManager.cpp
@@ -30,8 +30,7 @@ const QIcon& ArtManager::GetIcon(const QString& name) {
 const QBrush& ArtManager::GetTransparenyBrush() { return transparenyBrush; }
 
 const QPixmap& ArtManager::GetCachedPixmap(const QString& name) {
-  //TODO: FIX DIS
-  QPixmap pm;
+  static QPixmap pm;
   if (!QPixmapCache::find(name, &pm)) {
     pm.load(name);
     QPixmapCache::insert(name, pm);


### PR DESCRIPTION
Ok, so I learned a hard lesson today. For a few months I have been confusing temporaries with locals. It is _never_ ok to return a reference to a local variable! Constant qualification only extends the lifetime of _temporary_ objects, not local variables. Simple solution here was to just make the invalid pixmap returned by cached pixmap a static local. This seems to fix crashes for me in the room editor when there are objects with no sprite.