### PR TITLE
Restore GRPC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.11)
 
+option(RGM_ENABLE_GRPC_SERVER "Enable the GRPC client plugin for compilation and code analysis." OFF)
+
 if (CMAKE_BUILD_TYPE MATCHES "Debug")
   set(EXE "RadialGM-Debug")
 else()
@@ -31,7 +33,6 @@ include_directories("${CMAKE_BINARY_DIR}/Submodules/enigma-dev/CommandLine/libEG
 # Populate a CMake variable with the sources
 set(RGM_SOURCES
     Plugins/RGMPlugin.cpp
-    Plugins/ServerPlugin.cpp
     main.cpp
     MainWindow.cpp
     Dialogs/PreferencesDialog.cpp
@@ -77,7 +78,6 @@ set(RGM_SOURCES
 )
 
 set(RGM_HEADERS
-    Plugins/ServerPlugin.h
     Plugins/RGMPlugin.h
     MainWindow.h
     main.h
@@ -158,6 +158,13 @@ if (NOT LIB_QSCINTILLA)
 else()
     set(EDITOR_SOURCES Widgets/CodeWidgetScintilla.cpp)
 endif()
+
+if (RGM_ENABLE_GRPC_SERVER)
+  add_definitions(-DRGM_SERVER_ENABLED)
+  set(RGM_SOURCES ${RGM_SOURCES} Plugins/ServerPlugin.cpp PARENT_SCOPE)
+  set(RGM_HEADERS ${RGM_HEADERS} Plugins/ServerPlugin.h PARENT_SCOPE)
+endif()
+
 
 set(CMAKE_INSTALL_RPATH "${ENIGMA_DIR}")
 

--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -125,6 +125,7 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), _ui(new Ui::MainW
   this->_recentFiles = new RecentFiles(this, this->_ui->menuRecent, this->_ui->actionClearRecentMenu);
 
   _ui->mdiArea->setBackground(QImage(":/banner.png"));
+  connect(_ui->mdiArea, &QMdiArea::subWindowActivated, this, &MainWindow::MDIWindowChanged);
   connect(_ui->menuWindow, &QMenu::aboutToShow, this, &MainWindow::updateWindowMenu);
 
   auto settingsButton = static_cast<QToolButton *>(_ui->mainToolBar->widgetForAction(_ui->actionSettings));
@@ -132,6 +133,7 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), _ui(new Ui::MainW
   settingsButton->setToolButtonStyle(Qt::ToolButtonStyle::ToolButtonTextBesideIcon);
   _ui->actionSettings->setMenu(_ui->menuChangeGameSettings);
 
+#ifdef RGM_SERVER_ENABLED
   RGMPlugin *pluginServer = new ServerPlugin(*this);
   auto outputTextBrowser = this->_ui->outputTextBrowser;
   connect(pluginServer, &RGMPlugin::LogOutput, outputTextBrowser, &QTextBrowser::append);
@@ -145,8 +147,7 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), _ui(new Ui::MainW
   connect(_ui->actionRun, &QAction::triggered, pluginServer, &RGMPlugin::Run);
   connect(_ui->actionDebug, &QAction::triggered, pluginServer, &RGMPlugin::Debug);
   connect(_ui->actionCreateExecutable, &QAction::triggered, pluginServer, &RGMPlugin::CreateExecutable);
-
-  connect(_ui->mdiArea, &QMdiArea::subWindowActivated, this, &MainWindow::MDIWindowChanged);
+#endif
 
   openNewProject();
 }

--- a/Plugins/ServerPlugin.cpp
+++ b/Plugins/ServerPlugin.cpp
@@ -240,11 +240,6 @@ void CompilerClient::UpdateLoop() {
 }
 
 ServerPlugin::ServerPlugin(MainWindow& mainWindow) : RGMPlugin(mainWindow) {
-  /* 
-  
-    FIXME: gRPC currently causes infinite hang on linux and segfault on MinGW
-    disabling until fixed. Uncomment all methods below when fixed.
-
   // create a new child process for us to launch an emake server
   process = new QProcess(this);
 
@@ -255,7 +250,7 @@ ServerPlugin::ServerPlugin(MainWindow& mainWindow) : RGMPlugin(mainWindow) {
     const QDir dir(path);
     QDir::Filters filters = QDir::Filter::Executable | QDir::Filter::Files;
     // we use a wildcard because we want it to find emake.exe on Windows
-    auto entryList = dir.entryInfoList(QStringList("emake*"), filters, QDir::SortFlag::NoSort);
+    auto entryList = dir.entryInfoList(QStringList({"emake","emake.exe"}), filters, QDir::SortFlag::NoSort);
     if (!entryList.empty()) {
       emakeFileInfo = entryList.first();
       break;
@@ -263,6 +258,7 @@ ServerPlugin::ServerPlugin(MainWindow& mainWindow) : RGMPlugin(mainWindow) {
   }
 
   // use the closest matching emake file we found and launch it in a child process
+  qDebug() << emakeFileInfo.fileName();
   process->setWorkingDirectory(emakeFileInfo.absolutePath());
   QString program = emakeFileInfo.fileName();
   QStringList arguments;
@@ -287,27 +283,28 @@ ServerPlugin::ServerPlugin(MainWindow& mainWindow) : RGMPlugin(mainWindow) {
   // without us needing any threading or blocking the main thread
   QTimer* timer = new QTimer(this);
   connect(timer, &QTimer::timeout, compilerClient, &CompilerClient::UpdateLoop);
-  timer->start();
+  // timer delay larger than one so we don't hog the CPU core
+  timer->start(1);
 
   // update initial keyword set and systems
   compilerClient->GetResources();
   compilerClient->GetSystems();
-  */
+
 }
 
-ServerPlugin::~ServerPlugin() { /*process->close();*/ }
+ServerPlugin::~ServerPlugin() { process->close(); }
 
-void ServerPlugin::Run() { /*compilerClient->CompileBuffer(mainWindow.Game(), CompileRequest::RUN);*/ };
+void ServerPlugin::Run() { compilerClient->CompileBuffer(mainWindow.Game(), CompileRequest::RUN); };
 
-void ServerPlugin::Debug() { /*compilerClient->CompileBuffer(mainWindow.Game(), CompileRequest::DEBUG);*/ };
+void ServerPlugin::Debug() { compilerClient->CompileBuffer(mainWindow.Game(), CompileRequest::DEBUG); };
 
 void ServerPlugin::CreateExecutable() {
-  /*const QString& fileName =
+  const QString& fileName =
       QFileDialog::getSaveFileName(&mainWindow, tr("Create Executable"), "", tr("Executable (*.exe);;All Files (*)"));
   if (!fileName.isEmpty())
-    compilerClient->CompileBuffer(mainWindow.Game(), CompileRequest::COMPILE, fileName.toStdString());*/
+    compilerClient->CompileBuffer(mainWindow.Game(), CompileRequest::COMPILE, fileName.toStdString());
 };
 
 void ServerPlugin::SetCurrentConfig(const resources::Settings& settings) {
-  /*compilerClient->SetCurrentConfig(settings);*/
+  compilerClient->SetCurrentConfig(settings);
 };

--- a/Plugins/ServerPlugin.cpp
+++ b/Plugins/ServerPlugin.cpp
@@ -258,7 +258,7 @@ ServerPlugin::ServerPlugin(MainWindow& mainWindow) : RGMPlugin(mainWindow) {
   }
 
   // use the closest matching emake file we found and launch it in a child process
-  qDebug() << emakeFileInfo.fileName();
+  qDebug() << emakeFileInfo.absoluteFilePath();
   process->setWorkingDirectory(emakeFileInfo.absolutePath());
   QString program = emakeFileInfo.fileName();
   QStringList arguments;

--- a/RadialGM.pro
+++ b/RadialGM.pro
@@ -18,7 +18,7 @@ VERSION = 0.0.0.0
 QMAKE_TARGET_COMPANY = ENIGMA Dev Team
 QMAKE_TARGET_PRODUCT = RadialGM IDE
 QMAKE_TARGET_DESCRIPTION = ENIGMA Development Environment
-QMAKE_TARGET_COPYRIGHT = "Copyright \\251 2007-2018 ENIGMA Dev Team"
+QMAKE_TARGET_COPYRIGHT = "Copyright \\251 2007-2020 ENIGMA Dev Team"
 
 # Uncomment if you want QPlainTextEdit used in place of QScintilla
 CONFIG += rgm_disable_syntaxhighlight
@@ -28,6 +28,15 @@ rgm_disable_syntaxhighlight {
 } else {
   SOURCES += Widgets/CodeWidgetScintilla.cpp
   CONFIG += qscintilla2
+}
+
+# Comment out if you do not want the GRPC plugin
+#CONFIG += rgm_enable_grpc_server
+
+rgm_enable_grpc_server {
+  DEFINES += RGM_SERVER_ENABLED
+  SOURCES += Plugins/ServerPlugin.cpp
+  HEADERS += Plugins/ServerPlugin.h
 }
 
 # we do this even in release mode for "Editor Diagnostics"
@@ -92,7 +101,6 @@ SOURCES += \
     Models/ImmediateMapper.cpp \
     Components/Utility.cpp \
     Plugins/RGMPlugin.cpp \
-    Plugins/ServerPlugin.cpp \
     Components/RecentFiles.cpp \
     Editors/CodeEditor.cpp \
     Editors/ScriptEditor.cpp \
@@ -137,7 +145,6 @@ HEADERS += \
     Models/ImmediateMapper.h \
     Components/Utility.h \
     Plugins/RGMPlugin.h \
-    Plugins/ServerPlugin.h \
     Components/RecentFiles.h \
     Widgets/SpriteSubimageListView.h \
     Widgets/SpriteView.h \

--- a/RadialGM.pro
+++ b/RadialGM.pro
@@ -30,7 +30,7 @@ rgm_enable_syntaxhighlight {
   SOURCES += Widgets/CodeWidgetPlain.cpp
 }
 
-# Comment out if you do not want the GRPC plugin
+# Uncomment if you want compilation & code analysis
 #CONFIG += rgm_enable_grpc_server
 
 rgm_enable_grpc_server {


### PR DESCRIPTION
This is just the start of my GRPC fixes that I've been discussing. First, I am enabling the server plugin again. Then I fixed the file search pattern to whitelist "emake" and "emake.exe" so that "emake-tests.exe" is no longer matched. I went with this for now because I see Qt only accepts globs, not actual regexes, so the regex Josh gave me won't work yet. Next, I changed the timer delay to 1ms to prevent the plugin from hogging 100% of a CPU core. Finally, I added `rgm_enable_grpc_server` config option (disabled by default) in both the pro file and the CMakeLists to make it easier to turn the GRPC server on and off, and so I can keep working on it without undoing fundies commenting out my code.