### PR TITLE
Fix Toggle Diagnostics Action Check

### DIFF
--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -42,13 +42,15 @@ static QTextEdit *diagnosticTextEdit = nullptr;
 static QAction *toggleDiagnosticsAction = nullptr;
 
 void diagnosticHandler(QtMsgType type, const QMessageLogContext &context, const QString &msg) {
-  if (toggleDiagnosticsAction && !toggleDiagnosticsAction->isChecked()) {
-    toggleDiagnosticsAction->setIcon(QIcon(":/actions/log-debug.png"));
-    toggleDiagnosticsAction->setToolTip(
-        QT_TR_NOOP("The editor encountered issues which have been logged in the diagnostics output."));
+  if (toggleDiagnosticsAction) {
+    if (!toggleDiagnosticsAction->isChecked()) {
+      toggleDiagnosticsAction->setIcon(QIcon(":/actions/log-debug.png"));
+      toggleDiagnosticsAction->setToolTip(
+          QT_TR_NOOP("The editor encountered issues which have been logged in the diagnostics output."));
+    }
   } else {
     // this should never happen!
-    // NOTE: if we used R_EXPECT_V here it would be recursive
+    // NOTE: if we used R_EXPECT_V here it would be infinite recursion
     std::cerr << "Critical: Diagnostics toggle button does not exist!" << std::endl;
   }
 


### PR DESCRIPTION
Because I combined the condition of whether the action exists with whether it's not checked, I had it erroneously reporting that the toggle button didn't exist sometimes. The simple and correct solution was to just move the condition for whether the action is checked inside the outer condition for whether the action exists or not.