### PR TITLE
RGM Enable Syntax Highlight

### DIFF
--- a/RadialGM.pro
+++ b/RadialGM.pro
@@ -20,14 +20,14 @@ QMAKE_TARGET_PRODUCT = RadialGM IDE
 QMAKE_TARGET_DESCRIPTION = ENIGMA Development Environment
 QMAKE_TARGET_COPYRIGHT = "Copyright \\251 2007-2018 ENIGMA Dev Team"
 
-# Uncomment if you want QPlainTextEdit used in place of QScintilla
-CONFIG += rgm_disable_syntaxhighlight
+# Comment out if you want QPlainTextEdit used in place of QScintilla
+#CONFIG += rgm_enable_syntaxhighlight
 
-rgm_disable_syntaxhighlight {
-  SOURCES += Widgets/CodeWidgetPlain.cpp
-} else {
+rgm_enable_syntaxhighlight {
   SOURCES += Widgets/CodeWidgetScintilla.cpp
   CONFIG += qscintilla2
+} else {
+  SOURCES += Widgets/CodeWidgetPlain.cpp
 }
 
 # we do this even in release mode for "Editor Diagnostics"

--- a/RadialGM.pro
+++ b/RadialGM.pro
@@ -20,7 +20,7 @@ QMAKE_TARGET_PRODUCT = RadialGM IDE
 QMAKE_TARGET_DESCRIPTION = ENIGMA Development Environment
 QMAKE_TARGET_COPYRIGHT = "Copyright \\251 2007-2018 ENIGMA Dev Team"
 
-# Comment out if you want QPlainTextEdit used in place of QScintilla
+# Uncomment if you want QScintilla
 #CONFIG += rgm_enable_syntaxhighlight
 
 rgm_enable_syntaxhighlight {


### PR DESCRIPTION
Remember that fundies did not like how the CLI server option was called disabled and so he had it changed to enabled? Well, keeping in that tradition, I am inverting the RGM option for enabling scintilla. Now it's enable instead of disable (still disabled by default in the pro). This just means all of the options we provide across projects are semantically consistent.