### PR TITLE
Azure Enable GRPC for Win32

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -161,8 +161,8 @@ endif()
 
 if (RGM_ENABLE_GRPC_SERVER)
   add_definitions(-DRGM_SERVER_ENABLED)
-  set(RGM_SOURCES ${RGM_SOURCES} Plugins/ServerPlugin.cpp PARENT_SCOPE)
-  set(RGM_HEADERS ${RGM_HEADERS} Plugins/ServerPlugin.h PARENT_SCOPE)
+  set(RGM_SOURCES ${RGM_SOURCES} Plugins/ServerPlugin.cpp)
+  set(RGM_HEADERS ${RGM_HEADERS} Plugins/ServerPlugin.h)
 endif()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.11)
 
-option(RGM_ENABLE_GRPC_SERVER "Enable the GRPC client plugin for compilation and code analysis." OFF "WIN32" ON)
+cmake_dependent_option(RGM_ENABLE_GRPC_SERVER "Enable the GRPC client plugin for compilation and code analysis." OFF "WIN32" ON)
 
 if (CMAKE_BUILD_TYPE MATCHES "Debug")
   set(EXE "RadialGM-Debug")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.11)
 
 include(CMakeDependentOption)
-cmake_dependent_option(RGM_ENABLE_GRPC_SERVER "Enable the GRPC client plugin for compilation and code analysis." OFF "WIN32" ON)
+cmake_dependent_option(RGM_ENABLE_GRPC_SERVER "Enable the GRPC client plugin for compilation and code analysis." ON "WIN32" OFF)
 
 if (CMAKE_BUILD_TYPE MATCHES "Debug")
   set(EXE "RadialGM-Debug")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.11)
 
-option(RGM_ENABLE_GRPC_SERVER "Enable the GRPC client plugin for compilation and code analysis." ON)
+option(RGM_ENABLE_GRPC_SERVER "Enable the GRPC client plugin for compilation and code analysis." OFF "WIN32" ON)
 
 if (CMAKE_BUILD_TYPE MATCHES "Debug")
   set(EXE "RadialGM-Debug")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.11)
 
-option(RGM_ENABLE_GRPC_SERVER "Enable the GRPC client plugin for compilation and code analysis." OFF)
+option(RGM_ENABLE_GRPC_SERVER "Enable the GRPC client plugin for compilation and code analysis." ON)
 
 if (CMAKE_BUILD_TYPE MATCHES "Debug")
   set(EXE "RadialGM-Debug")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 3.11)
 
+include(CMakeDependentOption)
 cmake_dependent_option(RGM_ENABLE_GRPC_SERVER "Enable the GRPC client plugin for compilation and code analysis." OFF "WIN32" ON)
 
 if (CMAKE_BUILD_TYPE MATCHES "Debug")


### PR DESCRIPTION
Enable GRPC client for the Azure build on Win32.
https://cmake.org/cmake/help/latest/module/CMakeDependentOption.html#module:CMakeDependentOption
Also fix the option itself by removing PARENT_SCOPE, which was actually setting the variable a scope above the current scope and thus causing it to not actually build the server plugin.
https://cmake.org/cmake/help/v3.3/command/set.html

I tested the artifact produced from this build and it does indeed have the GRPC client built in. However, when launched from MSYS2 it doesn't seem to launch emake like my local build does. Although, if emake is manually launched, the Azure artifact will still communicate with it.

That just means this pull request is correct and we just need to work out yet how we expect people to launch this thing.