### PR TITLE
Fix QScintilla2 CMake Issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,7 +64,6 @@ set(RGM_SOURCES
     Editors/SpriteEditor.cpp
     Editors/BaseEditor.cpp
     Editors/RoomEditor.cpp
-    Widgets/CodeWidgetPlain.cpp
     Widgets/AssetView.cpp
     Widgets/CodeWidget.cpp
     Widgets/BackgroundView.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,18 +195,8 @@ foreach(CompilerFlag ${CompilerFlags})
 endforeach()
 
 if (LIB_QSCINTILLA)
-    find_path(QSCINTILLA_INCLUDE_DIR
-        NAMES Qsci/qsciglobal.h
-        PATHS
-        "${_qsci_fw}/Headers"
-        ${Qt5Core_INCLUDE_DIRS}
-        "${QT_INCLUDE_DIR}"
-        /usr/local/include
-        /usr/include
-        PATH_SUFFIXES qt
-    )
-    message("QScintilla found. Headers: ${QSCINTILLA_INCLUDE_DIR}")
-    include_directories(${QSCINTILLA_INCLUDE_DIR})
+    message(STATUS "QScintilla found. Headers: ${QSCINTILLA_INCLUDE_DIR}")
+    add_definitions(-DQSCINTILLA_DLL)
     target_link_libraries(${EXE} PRIVATE ${LIB_QSCINTILLA})
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,7 +152,7 @@ set(RGM_RC
 )
 
 # Check for QScintilla
-find_library(LIB_QSCINTILLA NAMES qscintilla2)
+find_library(LIB_QSCINTILLA NAMES qscintilla2 qscintilla2_qt5 qscintilla2-qt5 qt5scintilla2 libqscintilla2_qt5.so libqscintilla2.so libqscintilla2.a qscintilla2.lib)
 if (NOT LIB_QSCINTILLA)
     set(EDITOR_SOURCES Widgets/CodeWidgetPlain.cpp)
 else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,7 +195,7 @@ foreach(CompilerFlag ${CompilerFlags})
 endforeach()
 
 if (LIB_QSCINTILLA)
-    message(STATUS "QScintilla found. Headers: ${QSCINTILLA_INCLUDE_DIR}")
+    message(STATUS "Found QScintilla: ${LIB_QSCINTILLA}")
     add_definitions(-DQSCINTILLA_DLL)
     target_link_libraries(${EXE} PRIVATE ${LIB_QSCINTILLA})
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,7 +195,18 @@ foreach(CompilerFlag ${CompilerFlags})
 endforeach()
 
 if (LIB_QSCINTILLA)
-    target_link_libraries(${EXE} PUBLIC ${LIB_QSCINTILLA})
+  FIND_PATH(QSCINTILLA_INCLUDE_DIR
+    NAMES Qsci/qsciglobal.h
+    PATHS
+      "${_qsci_fw}/Headers"
+      ${Qt5Core_INCLUDE_DIRS}
+      "${QT_INCLUDE_DIR}"
+      /usr/local/include
+      /usr/include
+    PATH_SUFFIXES qt
+    )
+    include_directories(${EXE} PRIVATE ${QSCINTILLA_INCLUDE_DIR})
+    target_link_libraries(${EXE} PRIVATE ${LIB_QSCINTILLA})
 endif()
 
 # Find PugiXML

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,7 +195,7 @@ foreach(CompilerFlag ${CompilerFlags})
 endforeach()
 
 if (LIB_QSCINTILLA)
-    target_link_libraries(${EXE} PRIVATE ${LIB_QSCINTILLA})
+    target_link_libraries(${EXE} PUBLIC ${LIB_QSCINTILLA})
 endif()
 
 # Find PugiXML

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,17 +195,18 @@ foreach(CompilerFlag ${CompilerFlags})
 endforeach()
 
 if (LIB_QSCINTILLA)
-  FIND_PATH(QSCINTILLA_INCLUDE_DIR
-    NAMES Qsci/qsciglobal.h
-    PATHS
-      "${_qsci_fw}/Headers"
-      ${Qt5Core_INCLUDE_DIRS}
-      "${QT_INCLUDE_DIR}"
-      /usr/local/include
-      /usr/include
-    PATH_SUFFIXES qt
+    find_path(QSCINTILLA_INCLUDE_DIR
+        NAMES Qsci/qsciglobal.h
+        PATHS
+        "${_qsci_fw}/Headers"
+        ${Qt5Core_INCLUDE_DIRS}
+        "${QT_INCLUDE_DIR}"
+        /usr/local/include
+        /usr/include
+        PATH_SUFFIXES qt
     )
-    include_directories(${EXE} PRIVATE ${QSCINTILLA_INCLUDE_DIR})
+    message("QScintilla found. Headers: ${QSCINTILLA_INCLUDE_DIR}")
+    include_directories(${QSCINTILLA_INCLUDE_DIR})
     target_link_libraries(${EXE} PRIVATE ${LIB_QSCINTILLA})
 endif()
 


### PR DESCRIPTION
It's `qscintilla2_qt5.dll` for me in MinGW64 and thus Azure so I added that plus a bunch of other possibilities from a find qscintilla CMakeLists I found online. Then it was able to find the dll, link it, and fundies installer copied it.

I had to remove `CodeWidgetPlain.cpp` from the sources list because fundies forgot to when he added the find library for qscintilla2 condition. Once I made it find the dll, we were getting multiple definition errors from linking both code widgets until I did this.

Finally, I had to investigate why line numbers were not working and the editor diagnostics was reporting "signal not found in QsciScintilla" in the log window. It turns out that `-DQSCINTILLA_DLL` is what happens when you `CONFIG += qscintilla2` in the qmake pro. That definition is needed to tell QScintilla we are using it as a _shared_ library, otherwise it thinks we are using it as a _static_ library.

And I added a neat little message in here to show that we found QScintilla and where we found it. The result of this is the Azure artifact in this pull request seems to use QScintilla and it has line numbers.

![Azure Artifact QScintilla Working](https://user-images.githubusercontent.com/3212801/76188032-6d58e400-61ad-11ea-9476-f71998f55ada.png)
