### PR TITLE
Simultaneous RPCs

### DIFF
--- a/Plugins/ServerPlugin.cpp
+++ b/Plugins/ServerPlugin.cpp
@@ -12,7 +12,7 @@
 namespace {
 
 inline std::chrono::system_clock::time_point future_deadline(size_t us) {
-	return (std::chrono::system_clock::now() + std::chrono::microseconds(us));
+  return (std::chrono::system_clock::now() + std::chrono::microseconds(us));
 }
 
 }  // anonymous namespace
@@ -21,279 +21,278 @@ CallData::~CallData() {}
 
 template <class T>
 struct AsyncReadWorker : public CallData {
-	T element;
-	std::unique_ptr<ClientAsyncReader<T>> stream;
+  T element;
+  std::unique_ptr<ClientAsyncReader<T>> stream;
 
-	virtual ~AsyncReadWorker() override {}
-	void operator()(const Status& /*status*/) override {
-		switch (state) {
-			case AsyncState::CONNECT: {
-				started();
-				state = AsyncState::READ;
-				stream->Read(&element, this);
-				break;
-			}
-			case AsyncState::READ: {
-				process(element);
-				state = AsyncState::READ;
-				stream->Read(&element, this);
-				break;
-			}
-			case AsyncState::FINISH: {
-				finished();
-				break;
-			}
-			default:
-				// TODO: Report error
-				break;
-		}
-	}
-	virtual void start() final {
-		state = AsyncState::CONNECT;
-		stream->StartCall(this);
-	}
-	virtual void finish() final {
-		state = AsyncState::FINISH;
-		stream->Finish(&status, this);
-	}
+  virtual ~AsyncReadWorker() override {}
+  void operator()(const Status& /*status*/) override {
+    switch (state) {
+      case AsyncState::CONNECT: {
+        started();
+        state = AsyncState::READ;
+        stream->Read(&element, this);
+        break;
+      }
+      case AsyncState::READ: {
+        process(element);
+        state = AsyncState::READ;
+        stream->Read(&element, this);
+        break;
+      }
+      case AsyncState::FINISH: {
+        finished();
+        break;
+      }
+      default:
+        // TODO: Report error
+        break;
+    }
+  }
+  virtual void start() final {
+    state = AsyncState::CONNECT;
+    stream->StartCall(this);
+  }
+  virtual void finish() final {
+    state = AsyncState::FINISH;
+    stream->Finish(&status, this);
+  }
 
-	virtual void started() {}
-	virtual void finished() {}
-	virtual void process(const T&) = 0;
+  virtual void started() {}
+  virtual void finished() {}
+  virtual void process(const T&) = 0;
 };
 
 template <class T>
 struct AsyncResponseReadWorker : public CallData {
-	T element;
-	std::unique_ptr<ClientAsyncResponseReader<T>> stream;
+  T element;
+  std::unique_ptr<ClientAsyncResponseReader<T>> stream;
 
-	virtual ~AsyncResponseReadWorker() override {}
-	void operator()(const Status& /*status*/) override {
-		switch (state) {
-			case AsyncState::FINISH: {
-				finished(element);
-				break;
-			}
-			default:
-				// TODO: Report error
-				break;
-		}
-	}
-	virtual void start() final {
-		stream->StartCall();
-		started();
-		state = AsyncState::FINISH;
-		stream->Finish(&element, &status, this);
-	}
-	virtual void finish() final {}
+  virtual ~AsyncResponseReadWorker() override {}
+  void operator()(const Status& /*status*/) override {
+    switch (state) {
+      case AsyncState::FINISH: {
+        finished(element);
+        break;
+      }
+      default:
+        // TODO: Report error
+        break;
+    }
+  }
+  virtual void start() final {
+    stream->StartCall();
+    started();
+    state = AsyncState::FINISH;
+    stream->Finish(&element, &status, this);
+  }
+  virtual void finish() final {}
 
-	virtual void started() {}
-	virtual void finished(const T&) {}
+  virtual void started() {}
+  virtual void finished(const T&) {}
 };
 
 struct ResourceReader : public AsyncReadWorker<Resource> {
-	virtual ~ResourceReader() {}
-	virtual void started() final { CodeWidget::prepareKeywordStore(); }
-	virtual void process(const Resource& resource) final {
-		const QString& name = QString::fromStdString(resource.name().c_str());
-		KeywordType type = KeywordType::UNKNOWN;
-		if (resource.is_function()) {
-			type = KeywordType::FUNCTION;
-			for (int i = 0; i < resource.overload_count(); ++i) {
-				QString overload = QString::fromStdString(resource.parameters(i));
-				const QStringRef signature = QStringRef(&overload, overload.indexOf("(") + 1, overload.lastIndexOf(")"));
-				CodeWidget::addCalltip(name, signature.toString(), type);
-			}
-		} else {
-			if (resource.is_global()) type = KeywordType::GLOBAL;
-			if (resource.is_type_name()) type = KeywordType::TYPE_NAME;
-			CodeWidget::addKeyword(name, type);
-		}
-		qDebug() << name;
-	}
-	virtual void finished() final { CodeWidget::finalizeKeywords(); }
+  virtual ~ResourceReader() {}
+  virtual void started() final { CodeWidget::prepareKeywordStore(); }
+  virtual void process(const Resource& resource) final {
+    const QString& name = QString::fromStdString(resource.name().c_str());
+    KeywordType type = KeywordType::UNKNOWN;
+    if (resource.is_function()) {
+      type = KeywordType::FUNCTION;
+      for (int i = 0; i < resource.overload_count(); ++i) {
+        QString overload = QString::fromStdString(resource.parameters(i));
+        const QStringRef signature = QStringRef(&overload, overload.indexOf("(") + 1, overload.lastIndexOf(")"));
+        CodeWidget::addCalltip(name, signature.toString(), type);
+      }
+    } else {
+      if (resource.is_global()) type = KeywordType::GLOBAL;
+      if (resource.is_type_name()) type = KeywordType::TYPE_NAME;
+      CodeWidget::addKeyword(name, type);
+    }
+    qDebug() << name;
+  }
+  virtual void finished() final { CodeWidget::finalizeKeywords(); }
 };
 
 struct SystemReader : public AsyncReadWorker<SystemType> {
-	virtual ~SystemReader() {}
-	virtual void process(const SystemType& system) final {
-		static auto& systemCache = MainWindow::systemCache;
-		const QString systemName = QString::fromStdString(system.name());
-		systemCache.append(system);
-		qDebug() << systemName;
-	}
+  virtual ~SystemReader() {}
+  virtual void process(const SystemType& system) final {
+    static auto& systemCache = MainWindow::systemCache;
+    const QString systemName = QString::fromStdString(system.name());
+    systemCache.append(system);
+    qDebug() << systemName;
+  }
 };
 
 struct CompileReader : public AsyncReadWorker<CompileReply> {
-	virtual ~CompileReader() {}
-	virtual void process(const CompileReply& reply) final {
-		for (auto log : reply.message()) {
-			emit LogOutput(log.message().c_str());
-		}
-	}
-	virtual void finished() final { emit CompileStatusChanged(true); }
+  virtual ~CompileReader() {}
+  virtual void process(const CompileReply& reply) final {
+    for (auto log : reply.message()) {
+      emit LogOutput(log.message().c_str());
+    }
+  }
+  virtual void finished() final { emit CompileStatusChanged(true); }
 };
 
 struct SyntaxCheckReader : public AsyncResponseReadWorker<SyntaxError> {
-	virtual ~SyntaxCheckReader() {}
-	virtual void finished(const SyntaxError&) final {}
+  virtual ~SyntaxCheckReader() {}
+  virtual void finished(const SyntaxError&) final {}
 };
 
 CompilerClient::~CompilerClient() {}
 
 CompilerClient::CompilerClient(std::shared_ptr<Channel> channel, MainWindow& mainWindow)
-		: QObject(&mainWindow), stub(Compiler::NewStub(channel)), mainWindow(mainWindow) {}
+    : QObject(&mainWindow), stub(Compiler::NewStub(channel)), mainWindow(mainWindow) {}
 
 void CompilerClient::CompileBuffer(Game* game, CompileMode mode, std::string name) {
-	emit CompileStatusChanged();
+  emit CompileStatusChanged();
 
-	auto* callData = ScheduleTask<CompileReader>();
-	CompileRequest request;
+  auto* callData = ScheduleTask<CompileReader>();
+  CompileRequest request;
 
-	request.mutable_game()->CopyFrom(*game);
-	request.set_name(name);
-	request.set_mode(mode);
+  request.mutable_game()->CopyFrom(*game);
+  request.set_name(name);
+  request.set_mode(mode);
 
-	auto worker = dynamic_cast<AsyncReadWorker<CompileReply>*>(callData);
-	worker->stream = stub->PrepareAsyncCompileBuffer(&worker->context, request, &cq);
-	callData->start();
+  auto worker = dynamic_cast<AsyncReadWorker<CompileReply>*>(callData);
+  worker->stream = stub->PrepareAsyncCompileBuffer(&worker->context, request, &cq);
+  callData->start();
 }
 
 void CompilerClient::CompileBuffer(Game* game, CompileMode mode) {
-	QTemporaryFile* t = new QTemporaryFile(QDir::temp().filePath("enigmaXXXXXX"), &mainWindow);
-	if (!t->open()) return;
-	t->close();
-	CompileBuffer(game, mode, (t->fileName() + ".exe").toStdString());
+  QTemporaryFile* t = new QTemporaryFile(QDir::temp().filePath("enigmaXXXXXX"), &mainWindow);
+  if (!t->open()) return;
+  t->close();
+  CompileBuffer(game, mode, (t->fileName() + ".exe").toStdString());
 }
 
 void CompilerClient::GetResources() {
-	auto* callData = ScheduleTask<ResourceReader>();
-	Empty emptyRequest;
+  auto* callData = ScheduleTask<ResourceReader>();
+  Empty emptyRequest;
 
-	auto worker = dynamic_cast<AsyncReadWorker<Resource>*>(callData);
-	worker->stream = stub->PrepareAsyncGetResources(&worker->context, emptyRequest, &cq);
-	callData->start();
+  auto worker = dynamic_cast<AsyncReadWorker<Resource>*>(callData);
+  worker->stream = stub->PrepareAsyncGetResources(&worker->context, emptyRequest, &cq);
+  callData->start();
 }
 
 void CompilerClient::GetSystems() {
-	auto* callData = ScheduleTask<SystemReader>();
-	Empty emptyRequest;
+  auto* callData = ScheduleTask<SystemReader>();
+  Empty emptyRequest;
 
-	auto worker = dynamic_cast<AsyncReadWorker<SystemType>*>(callData);
-	worker->stream = stub->PrepareAsyncGetSystems(&worker->context, emptyRequest, &cq);
-	callData->start();
+  auto worker = dynamic_cast<AsyncReadWorker<SystemType>*>(callData);
+  worker->stream = stub->PrepareAsyncGetSystems(&worker->context, emptyRequest, &cq);
+  callData->start();
 }
 
 void CompilerClient::SetDefinitions(std::string code, std::string yaml) {
-	auto* callData = ScheduleTask<SyntaxCheckReader>();
-	SetDefinitionsRequest definitionsRequest;
+  auto* callData = ScheduleTask<SyntaxCheckReader>();
+  SetDefinitionsRequest definitionsRequest;
 
-	definitionsRequest.set_code(code);
-	definitionsRequest.set_yaml(yaml);
+  definitionsRequest.set_code(code);
+  definitionsRequest.set_yaml(yaml);
 
-	auto worker = dynamic_cast<AsyncResponseReadWorker<SyntaxError>*>(callData);
-	worker->stream = stub->PrepareAsyncSetDefinitions(&worker->context, definitionsRequest, &cq);
-	callData->start();
+  auto worker = dynamic_cast<AsyncResponseReadWorker<SyntaxError>*>(callData);
+  worker->stream = stub->PrepareAsyncSetDefinitions(&worker->context, definitionsRequest, &cq);
+  callData->start();
 }
 
 void CompilerClient::SetCurrentConfig(const resources::Settings& settings) {
-	auto* callData = ScheduleTask<AsyncResponseReadWorker<Empty>>();
-	SetCurrentConfigRequest setConfigRequest;
-	setConfigRequest.mutable_settings()->CopyFrom(settings);
+  auto* callData = ScheduleTask<AsyncResponseReadWorker<Empty>>();
+  SetCurrentConfigRequest setConfigRequest;
+  setConfigRequest.mutable_settings()->CopyFrom(settings);
 
-	auto worker = dynamic_cast<AsyncResponseReadWorker<Empty>*>(callData);
-	worker->stream = stub->PrepareAsyncSetCurrentConfig(&worker->context, setConfigRequest, &cq);
-	callData->start();
+  auto worker = dynamic_cast<AsyncResponseReadWorker<Empty>*>(callData);
+  worker->stream = stub->PrepareAsyncSetCurrentConfig(&worker->context, setConfigRequest, &cq);
+  callData->start();
 }
 
 void CompilerClient::SyntaxCheck() {
-	auto* callData = ScheduleTask<SyntaxCheckReader>();
-	SyntaxCheckRequest syntaxCheckRequest;
+  auto* callData = ScheduleTask<SyntaxCheckReader>();
+  SyntaxCheckRequest syntaxCheckRequest;
 
-	auto worker = dynamic_cast<AsyncResponseReadWorker<SyntaxError>*>(callData);
-	worker->stream = stub->PrepareAsyncSyntaxCheck(&worker->context, syntaxCheckRequest, &cq);
-	callData->start();
+  auto worker = dynamic_cast<AsyncResponseReadWorker<SyntaxError>*>(callData);
+  worker->stream = stub->PrepareAsyncSyntaxCheck(&worker->context, syntaxCheckRequest, &cq);
+  callData->start();
 }
 
 template <typename T>
 T* CompilerClient::ScheduleTask() {
-	auto callData = new T();
-	connect(callData, &CallData::LogOutput, this, &CompilerClient::LogOutput);
-	connect(callData, &CallData::CompileStatusChanged, this, &CompilerClient::CompileStatusChanged);
-	return callData;
+  auto callData = new T();
+  connect(callData, &CallData::LogOutput, this, &CompilerClient::LogOutput);
+  connect(callData, &CallData::CompileStatusChanged, this, &CompilerClient::CompileStatusChanged);
+  return callData;
 }
 
 void CompilerClient::UpdateLoop() {
-	void* got_tag = nullptr;
-	bool ok = false;
+  void* got_tag = nullptr;
+  bool ok = false;
 
-	auto asyncStatus = cq.AsyncNext(&got_tag, &ok, future_deadline(0));
-	auto callData = static_cast<CallData*>(got_tag);
-	if (callData && callData->state != AsyncState::DISCONNECTED && !ok) {
-		callData->finish();
-		return;
-	}
-	// yield to application main event loop
-	if (asyncStatus != CompletionQueue::NextStatus::GOT_EVENT || !got_tag) return;
+  auto asyncStatus = cq.AsyncNext(&got_tag, &ok, future_deadline(0));
+  auto callData = static_cast<CallData*>(got_tag);
+  if (callData && callData->state != AsyncState::DISCONNECTED && !ok) {
+    callData->finish();
+    return;
+  }
+  // yield to application main event loop
+  if (asyncStatus != CompletionQueue::NextStatus::GOT_EVENT || !got_tag) return;
 
-	(*callData)(callData->status);
-	if (callData->state == AsyncState::FINISH) {
-		delete callData;
-	}
+  (*callData)(callData->status);
+  if (callData->state == AsyncState::FINISH) {
+    delete callData;
+  }
 }
 
 ServerPlugin::ServerPlugin(MainWindow& mainWindow) : RGMPlugin(mainWindow) {
-	// create a new child process for us to launch an emake server
-	process = new QProcess(this);
+  // create a new child process for us to launch an emake server
+  process = new QProcess(this);
 
-	// look for an executable file that looks like emake in some common directories
-	QList<QString> searchPaths = {QDir::currentPath(), "./enigma-dev", "../RadialGM/Submodules/enigma-dev"};
-	QFileInfo emakeFileInfo(QFile("emake"));
-	foreach (auto path, searchPaths) {
-		const QDir dir(path);
-		QDir::Filters filters = QDir::Filter::Executable | QDir::Filter::Files;
-		// we use a wildcard because we want it to find emake.exe on Windows
-		auto entryList = dir.entryInfoList(QStringList({"emake","emake.exe"}), filters, QDir::SortFlag::NoSort);
-		if (!entryList.empty()) {
-			emakeFileInfo = entryList.first();
-			break;
-		}
-	}
+  // look for an executable file that looks like emake in some common directories
+  QList<QString> searchPaths = {QDir::currentPath(), "./enigma-dev", "../RadialGM/Submodules/enigma-dev"};
+  QFileInfo emakeFileInfo(QFile("emake"));
+  foreach (auto path, searchPaths) {
+    const QDir dir(path);
+    QDir::Filters filters = QDir::Filter::Executable | QDir::Filter::Files;
+    // we use a wildcard because we want it to find emake.exe on Windows
+    auto entryList = dir.entryInfoList(QStringList({"emake","emake.exe"}), filters, QDir::SortFlag::NoSort);
+    if (!entryList.empty()) {
+      emakeFileInfo = entryList.first();
+      break;
+    }
+  }
 
-	// use the closest matching emake file we found and launch it in a child process
-	qDebug() << emakeFileInfo.absoluteFilePath();
-	process->setWorkingDirectory(emakeFileInfo.absolutePath());
-	QString program = emakeFileInfo.fileName();
-	QStringList arguments;
-	arguments << "--server"
-						<< "-e"
-						<< "Paths"
-						<< "-r"
-						<< "--quiet";
+  // use the closest matching emake file we found and launch it in a child process
+  qDebug() << emakeFileInfo.absoluteFilePath();
+  process->setWorkingDirectory(emakeFileInfo.absolutePath());
+  QString program = emakeFileInfo.fileName();
+  QStringList arguments;
+  arguments << "--server"
+            << "-e"
+            << "Paths"
+            << "-r"
+            << "--quiet";
 
-	process->start(program, arguments);
-	process->waitForStarted();
+  process->start(program, arguments);
+  process->waitForStarted();
 
-	// construct the channel and connect to the server running in the process
-	// Note: gRPC is too dumb to resolve localhost on linux
-	std::shared_ptr<Channel> channel = CreateChannel("127.0.0.1:37818", InsecureChannelCredentials());
-	compilerClient = new CompilerClient(channel, mainWindow);
-	connect(compilerClient, &CompilerClient::CompileStatusChanged, this, &RGMPlugin::CompileStatusChanged);
-	// hookup emake's output to our plugin's output signals so it redirects to the
-	// main output dock widget (thread safe and don't block the main event loop!)
-	connect(compilerClient, &CompilerClient::LogOutput, this, &RGMPlugin::LogOutput);
+  // construct the channel and connect to the server running in the process
+  // Note: gRPC is too dumb to resolve localhost on linux
+  std::shared_ptr<Channel> channel = CreateChannel("127.0.0.1:37818", InsecureChannelCredentials());
+  compilerClient = new CompilerClient(channel, mainWindow);
+  connect(compilerClient, &CompilerClient::CompileStatusChanged, this, &RGMPlugin::CompileStatusChanged);
+  // hookup emake's output to our plugin's output signals so it redirects to the
+  // main output dock widget (thread safe and don't block the main event loop!)
+  connect(compilerClient, &CompilerClient::LogOutput, this, &RGMPlugin::LogOutput);
 
-	// use a timer to process async grpc events at regular intervals
-	// without us needing any threading or blocking the main thread
-	QTimer* timer = new QTimer(this);
-	connect(timer, &QTimer::timeout, compilerClient, &CompilerClient::UpdateLoop);
-	// timer delay larger than one so we don't hog the CPU core
-	timer->start(1);
+  // use a timer to process async grpc events at regular intervals
+  // without us needing any threading or blocking the main thread
+  QTimer* timer = new QTimer(this);
+  connect(timer, &QTimer::timeout, compilerClient, &CompilerClient::UpdateLoop);
+  // timer delay larger than one so we don't hog the CPU core
+  timer->start(1);
 
-	// update initial keyword set and systems
-	compilerClient->GetResources();
-	compilerClient->GetSystems();
-
+  // update initial keyword set and systems
+  compilerClient->GetResources();
+  compilerClient->GetSystems();
 }
 
 ServerPlugin::~ServerPlugin() { process->close(); }
@@ -303,12 +302,12 @@ void ServerPlugin::Run() { compilerClient->CompileBuffer(mainWindow.Game(), Comp
 void ServerPlugin::Debug() { compilerClient->CompileBuffer(mainWindow.Game(), CompileRequest::DEBUG); };
 
 void ServerPlugin::CreateExecutable() {
-	const QString& fileName =
-			QFileDialog::getSaveFileName(&mainWindow, tr("Create Executable"), "", tr("Executable (*.exe);;All Files (*)"));
-	if (!fileName.isEmpty())
-		compilerClient->CompileBuffer(mainWindow.Game(), CompileRequest::COMPILE, fileName.toStdString());
+  const QString& fileName =
+      QFileDialog::getSaveFileName(&mainWindow, tr("Create Executable"), "", tr("Executable (*.exe);;All Files (*)"));
+  if (!fileName.isEmpty())
+    compilerClient->CompileBuffer(mainWindow.Game(), CompileRequest::COMPILE, fileName.toStdString());
 };
 
 void ServerPlugin::SetCurrentConfig(const resources::Settings& settings) {
-	compilerClient->SetCurrentConfig(settings);
+  compilerClient->SetCurrentConfig(settings);
 };

--- a/Plugins/ServerPlugin.cpp
+++ b/Plugins/ServerPlugin.cpp
@@ -12,11 +12,11 @@
 namespace {
 
 inline std::chrono::system_clock::time_point future_deadline(size_t us) {
-  return (std::chrono::system_clock::now() + std::chrono::microseconds(us));
+	return (std::chrono::system_clock::now() + std::chrono::microseconds(us));
 }
 
-void* tag(int i) { return reinterpret_cast<void*>(static_cast<intptr_t>(i)); }
-int detag(void* p) { return static_cast<int>(reinterpret_cast<intptr_t>(p)); }
+//void* tag(int i) { return reinterpret_cast<void*>(static_cast<intptr_t>(i)); }
+//int detag(void* p) { return static_cast<int>(reinterpret_cast<intptr_t>(p)); }
 
 }  // anonymous namespace
 
@@ -24,272 +24,278 @@ CallData::~CallData() {}
 
 template <class T>
 struct AsyncReadWorker : public CallData {
-  T element;
-  std::unique_ptr<ClientAsyncReader<T>> stream;
+	T element;
+	std::unique_ptr<ClientAsyncReader<T>> stream;
 
-  virtual ~AsyncReadWorker() override {}
-  void operator()(const AsyncState state, const Status& /*status*/) override {
-    switch (state) {
-      case AsyncState::CONNECT: {
-        started();
-        stream->Read(&element, tag(AsyncState::READ));
-        break;
-      }
-      case AsyncState::READ: {
-        process(element);
-        stream->Read(&element, tag(AsyncState::READ));
-        break;
-      }
-      case AsyncState::FINISH: {
-        finished();
-        break;
-      }
-      default:
-        // TODO: Report error
-        break;
-    }
-  }
-  virtual void start() final { stream->StartCall(tag(AsyncState::CONNECT)); }
-  virtual void finish() final { stream->Finish(&status, tag(AsyncState::FINISH)); }
+	virtual ~AsyncReadWorker() override {}
+	void operator()(const Status& /*status*/) override {
+		switch (state) {
+			case AsyncState::CONNECT: {
+				started();
+				state = AsyncState::READ;
+				stream->Read(&element, this);
+				break;
+			}
+			case AsyncState::READ: {
+				process(element);
+				state = AsyncState::READ;
+				stream->Read(&element, this);
+				break;
+			}
+			case AsyncState::FINISH: {
+				finished();
+				break;
+			}
+			default:
+				// TODO: Report error
+				break;
+		}
+	}
+	virtual void start() final {
+		state = AsyncState::CONNECT;
+		stream->StartCall(this);
+	}
+	virtual void finish() final {
+		state = AsyncState::FINISH;
+		stream->Finish(&status, this);
+	}
 
-  virtual void started() {}
-  virtual void finished() {}
-  virtual void process(const T&) = 0;
+	virtual void started() {}
+	virtual void finished() {}
+	virtual void process(const T&) = 0;
 };
 
 template <class T>
 struct AsyncResponseReadWorker : public CallData {
-  T element;
-  std::unique_ptr<ClientAsyncResponseReader<T>> stream;
+	T element;
+	std::unique_ptr<ClientAsyncResponseReader<T>> stream;
 
-  virtual ~AsyncResponseReadWorker() override {}
-  void operator()(const AsyncState state, const Status& /*status*/) override {
-    switch (state) {
-      case AsyncState::FINISH: {
-        finished(element);
-        break;
-      }
-      default:
-        // TODO: Report error
-        break;
-    }
-  }
-  virtual void start() final {
-    stream->StartCall();
-    started();
-    stream->Finish(&element, &status, tag(AsyncState::FINISH));
-  }
-  virtual void finish() final {}
+	virtual ~AsyncResponseReadWorker() override {}
+	void operator()(const Status& /*status*/) override {
+		switch (state) {
+			case AsyncState::FINISH: {
+				finished(element);
+				break;
+			}
+			default:
+				// TODO: Report error
+				break;
+		}
+	}
+	virtual void start() final {
+		stream->StartCall();
+		started();
+		state = AsyncState::FINISH;
+		stream->Finish(&element, &status, this);
+	}
+	virtual void finish() final {}
 
-  virtual void started() {}
-  virtual void finished(const T&) {}
+	virtual void started() {}
+	virtual void finished(const T&) {}
 };
 
 struct ResourceReader : public AsyncReadWorker<Resource> {
-  virtual ~ResourceReader() {}
-  virtual void started() final { CodeWidget::prepareKeywordStore(); }
-  virtual void process(const Resource& resource) final {
-    const QString& name = QString::fromStdString(resource.name().c_str());
-    KeywordType type = KeywordType::UNKNOWN;
-    if (resource.is_function()) {
-      type = KeywordType::FUNCTION;
-      for (int i = 0; i < resource.overload_count(); ++i) {
-        QString overload = QString::fromStdString(resource.parameters(i));
-        const QStringRef signature = QStringRef(&overload, overload.indexOf("(") + 1, overload.lastIndexOf(")"));
-        CodeWidget::addCalltip(name, signature.toString(), type);
-      }
-    } else {
-      if (resource.is_global()) type = KeywordType::GLOBAL;
-      if (resource.is_type_name()) type = KeywordType::TYPE_NAME;
-      CodeWidget::addKeyword(name, type);
-    }
-  }
-  virtual void finished() final { CodeWidget::finalizeKeywords(); }
+	virtual ~ResourceReader() {}
+	virtual void started() final { CodeWidget::prepareKeywordStore(); }
+	virtual void process(const Resource& resource) final {
+		const QString& name = QString::fromStdString(resource.name().c_str());
+		KeywordType type = KeywordType::UNKNOWN;
+		if (resource.is_function()) {
+			type = KeywordType::FUNCTION;
+			for (int i = 0; i < resource.overload_count(); ++i) {
+				QString overload = QString::fromStdString(resource.parameters(i));
+				const QStringRef signature = QStringRef(&overload, overload.indexOf("(") + 1, overload.lastIndexOf(")"));
+				CodeWidget::addCalltip(name, signature.toString(), type);
+			}
+		} else {
+			if (resource.is_global()) type = KeywordType::GLOBAL;
+			if (resource.is_type_name()) type = KeywordType::TYPE_NAME;
+			CodeWidget::addKeyword(name, type);
+		}
+		qDebug() << name;
+	}
+	virtual void finished() final { CodeWidget::finalizeKeywords(); }
 };
 
 struct SystemReader : public AsyncReadWorker<SystemType> {
-  virtual ~SystemReader() {}
-  virtual void process(const SystemType& system) final {
-    static auto& systemCache = MainWindow::systemCache;
-    const QString systemName = QString::fromStdString(system.name());
-    systemCache.append(system);
-  }
+	virtual ~SystemReader() {}
+	virtual void process(const SystemType& system) final {
+		static auto& systemCache = MainWindow::systemCache;
+		const QString systemName = QString::fromStdString(system.name());
+		systemCache.append(system);
+		qDebug() << systemName;
+	}
 };
 
 struct CompileReader : public AsyncReadWorker<CompileReply> {
-  virtual ~CompileReader() {}
-  virtual void process(const CompileReply& reply) final {
-    for (auto log : reply.message()) {
-      emit LogOutput(log.message().c_str());
-    }
-  }
-  virtual void finished() final { emit CompileStatusChanged(true); }
+	virtual ~CompileReader() {}
+	virtual void process(const CompileReply& reply) final {
+		for (auto log : reply.message()) {
+			emit LogOutput(log.message().c_str());
+		}
+	}
+	virtual void finished() final { emit CompileStatusChanged(true); }
 };
 
 struct SyntaxCheckReader : public AsyncResponseReadWorker<SyntaxError> {
-  virtual ~SyntaxCheckReader() {}
-  virtual void finished(const SyntaxError&) final {}
+	virtual ~SyntaxCheckReader() {}
+	virtual void finished(const SyntaxError&) final {}
 };
 
 CompilerClient::~CompilerClient() {}
 
 CompilerClient::CompilerClient(std::shared_ptr<Channel> channel, MainWindow& mainWindow)
-    : QObject(&mainWindow), stub(Compiler::NewStub(channel)), mainWindow(mainWindow) {}
+		: QObject(&mainWindow), stub(Compiler::NewStub(channel)), mainWindow(mainWindow) {}
 
 void CompilerClient::CompileBuffer(Game* game, CompileMode mode, std::string name) {
-  emit CompileStatusChanged();
+	emit CompileStatusChanged();
 
-  auto* callData = ScheduleTask<CompileReader>();
-  CompileRequest request;
+	auto* callData = ScheduleTask<CompileReader>();
+	CompileRequest request;
 
-  request.mutable_game()->CopyFrom(*game);
-  request.set_name(name);
-  request.set_mode(mode);
+	request.mutable_game()->CopyFrom(*game);
+	request.set_name(name);
+	request.set_mode(mode);
 
-  auto worker = dynamic_cast<AsyncReadWorker<CompileReply>*>(callData);
-  worker->stream = stub->PrepareAsyncCompileBuffer(&worker->context, request, &cq);
+	auto worker = dynamic_cast<AsyncReadWorker<CompileReply>*>(callData);
+	worker->stream = stub->PrepareAsyncCompileBuffer(&worker->context, request, &cq);
+	callData->start();
 }
 
 void CompilerClient::CompileBuffer(Game* game, CompileMode mode) {
-  QTemporaryFile* t = new QTemporaryFile(QDir::temp().filePath("enigmaXXXXXX"), &mainWindow);
-  if (!t->open()) return;
-  t->close();
-  CompileBuffer(game, mode, (t->fileName() + ".exe").toStdString());
+	QTemporaryFile* t = new QTemporaryFile(QDir::temp().filePath("enigmaXXXXXX"), &mainWindow);
+	if (!t->open()) return;
+	t->close();
+	CompileBuffer(game, mode, (t->fileName() + ".exe").toStdString());
 }
 
 void CompilerClient::GetResources() {
-  auto* callData = ScheduleTask<ResourceReader>();
-  Empty emptyRequest;
+	auto* callData = ScheduleTask<ResourceReader>();
+	Empty emptyRequest;
 
-  auto worker = dynamic_cast<AsyncReadWorker<Resource>*>(callData);
-  worker->stream = stub->PrepareAsyncGetResources(&worker->context, emptyRequest, &cq);
+	auto worker = dynamic_cast<AsyncReadWorker<Resource>*>(callData);
+	worker->stream = stub->PrepareAsyncGetResources(&worker->context, emptyRequest, &cq);
+	callData->start();
 }
 
 void CompilerClient::GetSystems() {
-  auto* callData = ScheduleTask<SystemReader>();
-  Empty emptyRequest;
+	auto* callData = ScheduleTask<SystemReader>();
+	Empty emptyRequest;
 
-  auto worker = dynamic_cast<AsyncReadWorker<SystemType>*>(callData);
-  worker->stream = stub->PrepareAsyncGetSystems(&worker->context, emptyRequest, &cq);
+	auto worker = dynamic_cast<AsyncReadWorker<SystemType>*>(callData);
+	worker->stream = stub->PrepareAsyncGetSystems(&worker->context, emptyRequest, &cq);
+	callData->start();
 }
 
 void CompilerClient::SetDefinitions(std::string code, std::string yaml) {
-  auto* callData = ScheduleTask<SyntaxCheckReader>();
-  SetDefinitionsRequest definitionsRequest;
+	auto* callData = ScheduleTask<SyntaxCheckReader>();
+	SetDefinitionsRequest definitionsRequest;
 
-  definitionsRequest.set_code(code);
-  definitionsRequest.set_yaml(yaml);
+	definitionsRequest.set_code(code);
+	definitionsRequest.set_yaml(yaml);
 
-  auto worker = dynamic_cast<AsyncResponseReadWorker<SyntaxError>*>(callData);
-  worker->stream = stub->PrepareAsyncSetDefinitions(&worker->context, definitionsRequest, &cq);
+	auto worker = dynamic_cast<AsyncResponseReadWorker<SyntaxError>*>(callData);
+	worker->stream = stub->PrepareAsyncSetDefinitions(&worker->context, definitionsRequest, &cq);
+	callData->start();
 }
 
 void CompilerClient::SetCurrentConfig(const resources::Settings& settings) {
-  auto* callData = ScheduleTask<AsyncResponseReadWorker<Empty>>();
-  SetCurrentConfigRequest setConfigRequest;
-  setConfigRequest.mutable_settings()->CopyFrom(settings);
+	auto* callData = ScheduleTask<AsyncResponseReadWorker<Empty>>();
+	SetCurrentConfigRequest setConfigRequest;
+	setConfigRequest.mutable_settings()->CopyFrom(settings);
 
-  auto worker = dynamic_cast<AsyncResponseReadWorker<Empty>*>(callData);
-  worker->stream = stub->PrepareAsyncSetCurrentConfig(&worker->context, setConfigRequest, &cq);
+	auto worker = dynamic_cast<AsyncResponseReadWorker<Empty>*>(callData);
+	worker->stream = stub->PrepareAsyncSetCurrentConfig(&worker->context, setConfigRequest, &cq);
+	callData->start();
 }
 
 void CompilerClient::SyntaxCheck() {
-  auto* callData = ScheduleTask<SyntaxCheckReader>();
-  SyntaxCheckRequest syntaxCheckRequest;
+	auto* callData = ScheduleTask<SyntaxCheckReader>();
+	SyntaxCheckRequest syntaxCheckRequest;
 
-  auto worker = dynamic_cast<AsyncResponseReadWorker<SyntaxError>*>(callData);
-  worker->stream = stub->PrepareAsyncSyntaxCheck(&worker->context, syntaxCheckRequest, &cq);
+	auto worker = dynamic_cast<AsyncResponseReadWorker<SyntaxError>*>(callData);
+	worker->stream = stub->PrepareAsyncSyntaxCheck(&worker->context, syntaxCheckRequest, &cq);
+	callData->start();
 }
 
 template <typename T>
 T* CompilerClient::ScheduleTask() {
-  std::unique_ptr<T> callData(new T());
-  tasks.push(std::move(callData));
-  return (T*)tasks.back().get();
+	auto callData = new T();
+	connect(callData, &CallData::LogOutput, this, &CompilerClient::LogOutput);
+	connect(callData, &CallData::CompileStatusChanged, this, &CompilerClient::CompileStatusChanged);
+	return callData;
 }
 
 void CompilerClient::UpdateLoop() {
-  static bool started = false;
-  void* got_tag = nullptr;
-  bool ok = false;
+	void* got_tag = nullptr;
+	bool ok = false;
 
-  if (this->tasks.empty()) return;
-  auto* task = this->tasks.front().get();
-  if (!started) {
-    connect(task, &CallData::LogOutput, this, &CompilerClient::LogOutput);
-    connect(task, &CallData::CompileStatusChanged, this, &CompilerClient::CompileStatusChanged);
-    task->start();
-    started = true;
-  }
-  auto asyncStatus = cq.AsyncNext(&got_tag, &ok, future_deadline(0));
-  auto state = static_cast<AsyncState>(detag(got_tag));
-  if (state != AsyncState::DISCONNECTED && !ok) {
-    task->finish();
-    return;
-  }
-  // yield to application main event loop
-  if (asyncStatus != CompletionQueue::NextStatus::GOT_EVENT || !got_tag) return;
+	auto asyncStatus = cq.AsyncNext(&got_tag, &ok, future_deadline(0));
+	auto callData = static_cast<CallData*>(got_tag);
+	if (callData && callData->state != AsyncState::DISCONNECTED && !ok) {
+		callData->finish();
+		return;
+	}
+	// yield to application main event loop
+	if (asyncStatus != CompletionQueue::NextStatus::GOT_EVENT || !got_tag) return;
 
-  (*task)(state, task->status);
-  if (state == AsyncState::FINISH) {
-    // go to the next task
-    tasks.pop();
-    // next task needs to be started
-    started = false;
-  }
+	(*callData)(callData->status);
+	if (callData->state == AsyncState::FINISH) {
+		delete callData;
+	}
 }
 
 ServerPlugin::ServerPlugin(MainWindow& mainWindow) : RGMPlugin(mainWindow) {
-  // create a new child process for us to launch an emake server
-  process = new QProcess(this);
+	// create a new child process for us to launch an emake server
+	process = new QProcess(this);
 
-  // look for an executable file that looks like emake in some common directories
-  QList<QString> searchPaths = {QDir::currentPath(), "./enigma-dev", "../RadialGM/Submodules/enigma-dev"};
-  QFileInfo emakeFileInfo(QFile("emake"));
-  foreach (auto path, searchPaths) {
-    const QDir dir(path);
-    QDir::Filters filters = QDir::Filter::Executable | QDir::Filter::Files;
-    // we use a wildcard because we want it to find emake.exe on Windows
-    auto entryList = dir.entryInfoList(QStringList({"emake","emake.exe"}), filters, QDir::SortFlag::NoSort);
-    if (!entryList.empty()) {
-      emakeFileInfo = entryList.first();
-      break;
-    }
-  }
+	// look for an executable file that looks like emake in some common directories
+	QList<QString> searchPaths = {QDir::currentPath(), "./enigma-dev", "../RadialGM/Submodules/enigma-dev"};
+	QFileInfo emakeFileInfo(QFile("emake"));
+	foreach (auto path, searchPaths) {
+		const QDir dir(path);
+		QDir::Filters filters = QDir::Filter::Executable | QDir::Filter::Files;
+		// we use a wildcard because we want it to find emake.exe on Windows
+		auto entryList = dir.entryInfoList(QStringList({"emake","emake.exe"}), filters, QDir::SortFlag::NoSort);
+		if (!entryList.empty()) {
+			emakeFileInfo = entryList.first();
+			break;
+		}
+	}
 
-  // use the closest matching emake file we found and launch it in a child process
-  qDebug() << emakeFileInfo.absoluteFilePath();
-  process->setWorkingDirectory(emakeFileInfo.absolutePath());
-  QString program = emakeFileInfo.fileName();
-  QStringList arguments;
-  arguments << "--server"
-            << "-e"
-            << "Paths"
-            << "-r"
-            << "--quiet";
+	// use the closest matching emake file we found and launch it in a child process
+	qDebug() << emakeFileInfo.absoluteFilePath();
+	process->setWorkingDirectory(emakeFileInfo.absolutePath());
+	QString program = emakeFileInfo.fileName();
+	QStringList arguments;
+	arguments << "--server"
+						<< "-e"
+						<< "Paths"
+						<< "-r"
+						<< "--quiet";
 
-  process->start(program, arguments);
-  process->waitForStarted();
+	process->start(program, arguments);
+	process->waitForStarted();
 
-  // construct the channel and connect to the server running in the process
-  // Note: gRPC is too dumb to resolve localhost on linux
-  std::shared_ptr<Channel> channel = CreateChannel("127.0.0.1:37818", InsecureChannelCredentials());
-  compilerClient = new CompilerClient(channel, mainWindow);
-  connect(compilerClient, &CompilerClient::CompileStatusChanged, this, &RGMPlugin::CompileStatusChanged);
-  // hookup emake's output to our plugin's output signals so it redirects to the
-  // main output dock widget (thread safe and don't block the main event loop!)
-  connect(compilerClient, &CompilerClient::LogOutput, this, &RGMPlugin::LogOutput);
+	// construct the channel and connect to the server running in the process
+	// Note: gRPC is too dumb to resolve localhost on linux
+	std::shared_ptr<Channel> channel = CreateChannel("127.0.0.1:37818", InsecureChannelCredentials());
+	compilerClient = new CompilerClient(channel, mainWindow);
+	connect(compilerClient, &CompilerClient::CompileStatusChanged, this, &RGMPlugin::CompileStatusChanged);
+	// hookup emake's output to our plugin's output signals so it redirects to the
+	// main output dock widget (thread safe and don't block the main event loop!)
+	connect(compilerClient, &CompilerClient::LogOutput, this, &RGMPlugin::LogOutput);
 
-  // use a timer to process async grpc events at regular intervals
-  // without us needing any threading or blocking the main thread
-  QTimer* timer = new QTimer(this);
-  connect(timer, &QTimer::timeout, compilerClient, &CompilerClient::UpdateLoop);
-  // timer delay larger than one so we don't hog the CPU core
-  timer->start(1);
+	// use a timer to process async grpc events at regular intervals
+	// without us needing any threading or blocking the main thread
+	QTimer* timer = new QTimer(this);
+	connect(timer, &QTimer::timeout, compilerClient, &CompilerClient::UpdateLoop);
+	// timer delay larger than one so we don't hog the CPU core
+	timer->start(1);
 
-  // update initial keyword set and systems
-  compilerClient->GetResources();
-  compilerClient->GetSystems();
+	// update initial keyword set and systems
+	compilerClient->GetResources();
+	compilerClient->GetSystems();
 
 }
 
@@ -300,12 +306,12 @@ void ServerPlugin::Run() { compilerClient->CompileBuffer(mainWindow.Game(), Comp
 void ServerPlugin::Debug() { compilerClient->CompileBuffer(mainWindow.Game(), CompileRequest::DEBUG); };
 
 void ServerPlugin::CreateExecutable() {
-  const QString& fileName =
-      QFileDialog::getSaveFileName(&mainWindow, tr("Create Executable"), "", tr("Executable (*.exe);;All Files (*)"));
-  if (!fileName.isEmpty())
-    compilerClient->CompileBuffer(mainWindow.Game(), CompileRequest::COMPILE, fileName.toStdString());
+	const QString& fileName =
+			QFileDialog::getSaveFileName(&mainWindow, tr("Create Executable"), "", tr("Executable (*.exe);;All Files (*)"));
+	if (!fileName.isEmpty())
+		compilerClient->CompileBuffer(mainWindow.Game(), CompileRequest::COMPILE, fileName.toStdString());
 };
 
 void ServerPlugin::SetCurrentConfig(const resources::Settings& settings) {
-  compilerClient->SetCurrentConfig(settings);
+	compilerClient->SetCurrentConfig(settings);
 };

--- a/Plugins/ServerPlugin.cpp
+++ b/Plugins/ServerPlugin.cpp
@@ -15,9 +15,6 @@ inline std::chrono::system_clock::time_point future_deadline(size_t us) {
 	return (std::chrono::system_clock::now() + std::chrono::microseconds(us));
 }
 
-//void* tag(int i) { return reinterpret_cast<void*>(static_cast<intptr_t>(i)); }
-//int detag(void* p) { return static_cast<int>(reinterpret_cast<intptr_t>(p)); }
-
 }  // anonymous namespace
 
 CallData::~CallData() {}

--- a/Plugins/ServerPlugin.cpp
+++ b/Plugins/ServerPlugin.cpp
@@ -109,7 +109,6 @@ struct ResourceReader : public AsyncReadWorker<Resource> {
       if (resource.is_type_name()) type = KeywordType::TYPE_NAME;
       CodeWidget::addKeyword(name, type);
     }
-    qDebug() << name;
   }
   virtual void finished() final { CodeWidget::finalizeKeywords(); }
 };
@@ -120,7 +119,6 @@ struct SystemReader : public AsyncReadWorker<SystemType> {
     static auto& systemCache = MainWindow::systemCache;
     const QString systemName = QString::fromStdString(system.name());
     systemCache.append(system);
-    qDebug() << systemName;
   }
 };
 

--- a/Plugins/ServerPlugin.h
+++ b/Plugins/ServerPlugin.h
@@ -4,7 +4,7 @@
 #include "RGMPlugin.h"
 
 #ifndef _WIN32_WINNT
-	#define _WIN32_WINNT 0x0600  // at least windows vista required for grpc
+  #define _WIN32_WINNT 0x0600  // at least windows vista required for grpc
 #endif
 
 #include "server.grpc.pb.h"
@@ -30,70 +30,70 @@ using CompileMode = CompileRequest_CompileMode;
 enum AsyncState { DISCONNECTED = 0, READ = 1, WRITE = 2, CONNECT = 3, WRITES_DONE = 4, FINISH = 5 };
 
 class CallData : public QObject {
-	Q_OBJECT
+  Q_OBJECT
 
  public:
-	AsyncState state = DISCONNECTED;
-	Status status;
-	ClientContext context;
-	virtual ~CallData();
-	virtual void start() {}
-	virtual void operator()(const Status& status) = 0;
-	virtual void finish() {}
+  AsyncState state = DISCONNECTED;
+  Status status;
+  ClientContext context;
+  virtual ~CallData();
+  virtual void start() {}
+  virtual void operator()(const Status& status) = 0;
+  virtual void finish() {}
 
  signals:
-	void CompileStatusChanged(bool finished = false);
-	void LogOutput(const QString& output);
+  void CompileStatusChanged(bool finished = false);
+  void LogOutput(const QString& output);
 };
 
 class CompilerClient : public QObject {
-	Q_OBJECT
+  Q_OBJECT
 
  public:
-	explicit CompilerClient(std::shared_ptr<Channel> channel, MainWindow& mainWindow);
-	~CompilerClient() override;
-	void CompileBuffer(Game* game, CompileMode mode, std::string name);
-	void CompileBuffer(Game* game, CompileMode mode);
-	void GetResources();
-	void GetSystems();
-	void GetOutput();
-	void SetDefinitions(std::string code, std::string yaml);
-	void SetCurrentConfig(const resources::Settings& settings);
-	void SyntaxCheck();
+  explicit CompilerClient(std::shared_ptr<Channel> channel, MainWindow& mainWindow);
+  ~CompilerClient() override;
+  void CompileBuffer(Game* game, CompileMode mode, std::string name);
+  void CompileBuffer(Game* game, CompileMode mode);
+  void GetResources();
+  void GetSystems();
+  void GetOutput();
+  void SetDefinitions(std::string code, std::string yaml);
+  void SetCurrentConfig(const resources::Settings& settings);
+  void SyntaxCheck();
 
  signals:
-	void CompileStatusChanged(bool finished = false);
-	void LogOutput(const QString& output);
+  void CompileStatusChanged(bool finished = false);
+  void LogOutput(const QString& output);
 
  public slots:
-	void UpdateLoop();
+  void UpdateLoop();
 
  private:
-	CompletionQueue cq;
+  CompletionQueue cq;
 
-	template <typename T>
-	T* ScheduleTask();
+  template <typename T>
+  T* ScheduleTask();
 
-	std::unique_ptr<Compiler::Stub> stub;
-	MainWindow& mainWindow;
+  std::unique_ptr<Compiler::Stub> stub;
+  MainWindow& mainWindow;
 };
 
 class ServerPlugin : public RGMPlugin {
-	Q_OBJECT
+  Q_OBJECT
 
  public:
-	ServerPlugin(MainWindow& mainWindow);
-	~ServerPlugin() override;
+  ServerPlugin(MainWindow& mainWindow);
+  ~ServerPlugin() override;
 
  public slots:
-	void Run() override;
-	void Debug() override;
-	void CreateExecutable() override;
-	void SetCurrentConfig(const buffers::resources::Settings& settings) override;
+  void Run() override;
+  void Debug() override;
+  void CreateExecutable() override;
+  void SetCurrentConfig(const buffers::resources::Settings& settings) override;
 
  private:
-	QProcess* process;
-	CompilerClient* compilerClient;
+  QProcess* process;
+  CompilerClient* compilerClient;
 };
 
 #endif  // PLUGINSERVER_H

--- a/Plugins/ServerPlugin.h
+++ b/Plugins/ServerPlugin.h
@@ -4,7 +4,7 @@
 #include "RGMPlugin.h"
 
 #ifndef _WIN32_WINNT
-  #define _WIN32_WINNT 0x0600  // at least windows vista required for grpc
+	#define _WIN32_WINNT 0x0600  // at least windows vista required for grpc
 #endif
 
 #include "server.grpc.pb.h"
@@ -30,70 +30,70 @@ using CompileMode = CompileRequest_CompileMode;
 enum AsyncState { DISCONNECTED = 0, READ = 1, WRITE = 2, CONNECT = 3, WRITES_DONE = 4, FINISH = 5 };
 
 class CallData : public QObject {
-  Q_OBJECT
+	Q_OBJECT
 
  public:
-  Status status;
-  ClientContext context;
-  virtual ~CallData();
-  virtual void start() {}
-  virtual void operator()(const AsyncState state, const Status& status) = 0;
-  virtual void finish() {}
+	AsyncState state = DISCONNECTED;
+	Status status;
+	ClientContext context;
+	virtual ~CallData();
+	virtual void start() {}
+	virtual void operator()(const Status& status) = 0;
+	virtual void finish() {}
 
  signals:
-  void CompileStatusChanged(bool finished = false);
-  void LogOutput(const QString& output);
+	void CompileStatusChanged(bool finished = false);
+	void LogOutput(const QString& output);
 };
 
 class CompilerClient : public QObject {
-  Q_OBJECT
+	Q_OBJECT
 
  public:
-  explicit CompilerClient(std::shared_ptr<Channel> channel, MainWindow& mainWindow);
-  ~CompilerClient() override;
-  void CompileBuffer(Game* game, CompileMode mode, std::string name);
-  void CompileBuffer(Game* game, CompileMode mode);
-  void GetResources();
-  void GetSystems();
-  void GetOutput();
-  void SetDefinitions(std::string code, std::string yaml);
-  void SetCurrentConfig(const resources::Settings& settings);
-  void SyntaxCheck();
+	explicit CompilerClient(std::shared_ptr<Channel> channel, MainWindow& mainWindow);
+	~CompilerClient() override;
+	void CompileBuffer(Game* game, CompileMode mode, std::string name);
+	void CompileBuffer(Game* game, CompileMode mode);
+	void GetResources();
+	void GetSystems();
+	void GetOutput();
+	void SetDefinitions(std::string code, std::string yaml);
+	void SetCurrentConfig(const resources::Settings& settings);
+	void SyntaxCheck();
 
  signals:
-  void CompileStatusChanged(bool finished = false);
-  void LogOutput(const QString& output);
+	void CompileStatusChanged(bool finished = false);
+	void LogOutput(const QString& output);
 
  public slots:
-  void UpdateLoop();
+	void UpdateLoop();
 
  private:
-  CompletionQueue cq;
-  std::queue<std::unique_ptr<CallData>> tasks;
+	CompletionQueue cq;
 
-  template <typename T>
-  T* ScheduleTask();
+	template <typename T>
+	T* ScheduleTask();
 
-  std::unique_ptr<Compiler::Stub> stub;
-  MainWindow& mainWindow;
+	std::unique_ptr<Compiler::Stub> stub;
+	MainWindow& mainWindow;
 };
 
 class ServerPlugin : public RGMPlugin {
-  Q_OBJECT
+	Q_OBJECT
 
  public:
-  ServerPlugin(MainWindow& mainWindow);
-  ~ServerPlugin() override;
+	ServerPlugin(MainWindow& mainWindow);
+	~ServerPlugin() override;
 
  public slots:
-  void Run() override;
-  void Debug() override;
-  void CreateExecutable() override;
-  void SetCurrentConfig(const buffers::resources::Settings& settings) override;
+	void Run() override;
+	void Debug() override;
+	void CreateExecutable() override;
+	void SetCurrentConfig(const buffers::resources::Settings& settings) override;
 
  private:
-  QProcess* process;
-  CompilerClient* compilerClient;
+	QProcess* process;
+	CompilerClient* compilerClient;
 };
 
 #endif  // PLUGINSERVER_H


### PR DESCRIPTION
The basic idea with this pull request is to allow us to actually process multiple RPCs at once. Although I had already switched us to the async API, we were not actually async before!

I was using the state of each call's state machine as the tag, which made it impossible to identify which call was receiving an event. So the idea I had here was to use the pointer of the call as the tag so our main loop knows which call to process the event for.
https://grpc.github.io/grpc/cpp/classgrpc__impl_1_1_client_async_reader.html#a97a711a7b063bd053c7f9f9eb43e927e

To do this without breaking the state machine, I had to have the state machine initiate its state transition before making any of the calls. In example, you'll see that start immediately sets the state to connect before starting the call using this call's pointer as the unique identifying tag.

This is also the solution used by the second official GRPC async client example.
https://github.com/grpc/grpc/blob/694f491e06b3503952ca5053c98493cf48af43c1/examples/cpp/helloworld/greeter_async_client2.cc#L69

This solution is also used in some other QPS async client Google hosts.
https://github.com/grpc/grpc/blob/694f491e06b3503952ca5053c98493cf48af43c1/test/cpp/qps/client_async.cc#L47

At any rate this seems to have actually worked and we are now getting replies for multiple RPCs interleaved.
```
Debug in ../RadialGM/Plugins/ServerPlugin.cpp:126 aka virtual void SystemReader::process(const buffers::SystemType&):
    "Audio"
Debug in ../RadialGM/Plugins/ServerPlugin.cpp:115 aka virtual void ResourceReader::process(const buffers::Resource&):
    "<anonymous-enum-00000036>"
Debug in ../RadialGM/Plugins/ServerPlugin.cpp:126 aka virtual void SystemReader::process(const buffers::SystemType&):
    "Collision"
```