### PR TITLE
Cookie Monster Machine

### DIFF
--- a/Plugins/ServerPlugin.cpp
+++ b/Plugins/ServerPlugin.cpp
@@ -14,6 +14,7 @@ struct LolCookie {
   CallData* callData;
   virtual void fireoff() = 0;
   LolCookie(CallData* callData): callData(callData) {}
+  virtual ~LolCookie() {}
 };
 
 template <class T>
@@ -230,12 +231,10 @@ T* CompilerClient::ScheduleTask() {
 void CompilerClient::UpdateLoop(void* got_tag, bool ok) {
   if (!got_tag) return;
   auto cookie = static_cast<LolCookie*>(got_tag);
-  if (!ok) {
+  if (!ok)
     cookie->callData->finish();
-    delete cookie;
-    return;
-  }
-  cookie->fireoff();
+  else
+    cookie->fireoff();
   delete cookie;
 }
 

--- a/Plugins/ServerPlugin.h
+++ b/Plugins/ServerPlugin.h
@@ -27,18 +27,14 @@ using namespace grpc;
 using namespace buffers;
 using CompileMode = CompileRequest_CompileMode;
 
-enum AsyncState { DISCONNECTED = 0, READ = 1, WRITE = 2, CONNECT = 3, WRITES_DONE = 4, FINISH = 5 };
-
 class CallData : public QObject {
   Q_OBJECT
 
  public:
-  AsyncState state = DISCONNECTED;
   Status status;
   ClientContext context;
   virtual ~CallData();
   virtual void start() {}
-  virtual void operator()(const Status& status) = 0;
   virtual void finish() {}
 
  signals:


### PR DESCRIPTION
Throw out the state machine, tag all the RPCs with a cookie instance that has a callback and can directly perform the state transition when the event is returned.