### PR TITLE
Tree Folder DPI Fix

### DIFF
--- a/Models/TreeModel.cpp
+++ b/Models/TreeModel.cpp
@@ -82,7 +82,7 @@ QVariant TreeModel::data(const QModelIndex &index, int role) const {
 
     const QIcon &icon = it->second;
     if (item->type_case() == TypeCase::kFolder && item->child_size() <= 0) {
-      return icon.pixmap(icon.availableSizes().first(), QIcon::Disabled);
+      return QIcon(icon.pixmap(icon.availableSizes().first(), QIcon::Disabled));
     }
     return icon;
   } else if (role == Qt::EditRole || role == Qt::DisplayRole) {


### PR DESCRIPTION
This is my attempt to work around #96 since Qt closed my bug report. I wrap the disabled folder pixmap in a QIcon, which does scaling, so that this model returns nothing but QIcons. The alternative would be to change all of the uses of QIcon to QPixmap, and return only pixmaps, but pixmaps are not scaled automatically. The other alternative is we write our own tree view delegate that actually fixes the Qt bug report I filed.

To me this seems like a fine work around, I'm just bothered by the tree having icons smaller than toolbars and other UI elements.

| Before                                                                                                                         | After                                                                                                                          |
|--------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
| ![Tree Varying Icon Size](https://user-images.githubusercontent.com/3212801/78505089-1a883300-773f-11ea-9d74-4d9281e1d326.png) | ![Tree Uniform Icon Size](https://user-images.githubusercontent.com/3212801/78505110-3b508880-773f-11ea-9e55-79c3ed771fd5.png) |

