### PR TITLE
Asset View Painter Clip

### DIFF
--- a/Widgets/AssetScrollAreaBackground.cpp
+++ b/Widgets/AssetScrollAreaBackground.cpp
@@ -185,6 +185,7 @@ void AssetScrollAreaBackground::paintEvent(QPaintEvent* /* event */) {
 
     painter.save();
     painter.translate(_totalDrawOffset);
+    painter.setClipRect(_assetView->rect());
     painter.scale(_currentZoom, _currentZoom);
     _assetView->Paint(painter);
     painter.restore();


### PR DESCRIPTION
This is my first step in understanding how to set an appropriate clip. I have discovered that the clip is effected by the current transform, including scale and translation, of the painter at the time it is set.

What this pull request does is have `AssetScrollAreaBackground` apply the appropriate clip, at the right time, of the bounds of the `AssetView` it is directing to paint, to the painter it provides. I have tested very carefully TKG's game Key to Success and do not see any regressions in the painting of the room this way. The rooms paint correctly at all zoom levels.

Essentially, we apply the asset view's rect as the clip just after translating to the offset within the background scroll area. Since that rect has coordinates (0,0) always, the translation puts the clip at the appropriate offset. However, the size of the rect is already prescaled by the zoom, so we want to apply that clip _before_ we set apply the scale transform. That ends up giving us a nice clip rect right over the asset view.

The only issue with passing the clip this way is that instances won't be drawn outside the room view, which is not going to work for us. So we either need to have the room view unset its clip and stash or pass this clip some other way.