### PR TITLE
Asset View Clip

### DIFF
--- a/Widgets/AssetScrollAreaBackground.cpp
+++ b/Widgets/AssetScrollAreaBackground.cpp
@@ -184,6 +184,8 @@ void AssetScrollAreaBackground::paintEvent(QPaintEvent* /* event */) {
     _totalDrawOffset = GetCenterOffset() + _userDrawOffset;
 
     painter.save();
+    QRect clip(-this->pos(), ((QWidget*)this->parent())->size());
+    painter.setClipRect(clip);
     painter.translate(_totalDrawOffset);
     painter.scale(_currentZoom, _currentZoom);
     _assetView->Paint(painter);


### PR DESCRIPTION
Alright, now I've figured out how to set the clip to just the visible viewport of the scroll area, like we wanted. I use the asset view scroll area background's negated position to find the scroll offset of the visible viewport. I use the size of the asset view scroll area background's parent, which only includes scrollbars when they are visible, as the size of the clipping rectangle. I then apply this clip to the painter before it is passed to the asset view, in this case the room view.

I see no regressions with TKG's game Key to Success or with other games. Zooming appears to work correctly and I also double checked the clip by filling it as a red rectangle. I still recommend that maybe we try this out on a few other games first. Otherwise, we should be safe to use this clip to resolve #118 so that the room view knows the appropriate window of its spatial hash to query.