### PR TITLE
Default Model Values

### DIFF
--- a/Components/Logger.h
+++ b/Components/Logger.h
@@ -37,10 +37,18 @@ T operator,(T x, const LogAndReturn&) {
   } else                 \
     return LogAndReturn::Void(), LogAndReturn(qWarning()) << "Check `" #cond "` failed."
 
-// check and log the condition, but continue on failure
+// check and log the condition
 #define R_ASSESS(cond) \
   if (cond) {          \
   } else               \
     LogAndReturn(qWarning()) << "Check `" #cond "` failed."
+
+// check and log the condition, but continue on failure
+#define R_ASSESS_C(cond)                                     \
+  if (cond) {                                                \
+  } else {                                                   \
+    LogAndReturn(qWarning()) << "Check `" #cond "` failed."; \
+    continue;                                                \
+  }
 
 #endif  // LOGGER_H

--- a/Models/MessageModel.cpp
+++ b/Models/MessageModel.cpp
@@ -91,7 +91,7 @@ QVariant MessageModel::Data(int row, int column) const {
   return data(this->index(row, column, QModelIndex()), Qt::DisplayRole);
 }
 
-template<bool HasField>
+template<bool NO_DEFAULT>
 QVariant MessageModel::dataInternal(const QModelIndex &index, int role) const {
   R_EXPECT(index.isValid(), QVariant()) << "Supplied index was invalid:" << index;
   if (role != Qt::DisplayRole && role != Qt::EditRole && role != Qt::DecorationRole) return QVariant();
@@ -132,7 +132,7 @@ QVariant MessageModel::dataInternal(const QModelIndex &index, int role) const {
   }
 
   // If the field has't been initialized return an invalid QVariant. (see QVariant.isValid())
-  if (HasField && !refl->HasField(*_protobuf, field)) return QVariant();
+  if (NO_DEFAULT && !refl->HasField(*_protobuf, field)) return QVariant();
 
   switch (field->cpp_type()) {
     case CppType::CPPTYPE_MESSAGE: R_EXPECT(false, QVariant()) << "The requested field " << index << " is a message";

--- a/Models/MessageModel.cpp
+++ b/Models/MessageModel.cpp
@@ -99,7 +99,7 @@ QVariant MessageModel::data(const QModelIndex &index, int role) const {
   const Reflection *refl = _protobuf->GetReflection();
   const FieldDescriptor *field = desc->FindFieldByNumber(index.row());
 
-  if (!field) return ret; // TODO: Wipe out table hack below.
+  if (!field) return ret; // TODO: Wipe out table hack below in dataOrDefault.
 
   // If the field has't been initialized return an invalid QVariant. (see QVariant.isValid())
   if (!refl->HasField(*_protobuf, field)) return QVariant();

--- a/Models/MessageModel.h
+++ b/Models/MessageModel.h
@@ -8,6 +8,10 @@
 // Model representing a protobuf message
 class MessageModel : public ProtoModel {
   Q_OBJECT
+
+  template<bool HasField>
+  QVariant dataInternal(const QModelIndex &index, int role) const;
+
  public:
   MessageModel(ProtoModel *parent, Message *protobuf);
   MessageModel(QObject *parent, Message *protobuf);

--- a/Models/MessageModel.h
+++ b/Models/MessageModel.h
@@ -46,8 +46,8 @@ class MessageModel : public ProtoModel {
   virtual int rowCount(const QModelIndex &parent = QModelIndex()) const override;
   virtual int columnCount(const QModelIndex &parent = QModelIndex()) const override;
   virtual bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::DisplayRole) override;
-  virtual QVariant data(const QModelIndex &index, int role) const override;
-  virtual QVariant dataOrDefault(const QModelIndex &index, int role) const;
+  virtual QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
+  virtual QVariant dataOrDefault(const QModelIndex &index, int role = Qt::DisplayRole) const;
   virtual QModelIndex parent(const QModelIndex &index) const override;
   virtual QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
   virtual QModelIndex index(int row, int column = 0, const QModelIndex &parent = QModelIndex()) const override;

--- a/Models/MessageModel.h
+++ b/Models/MessageModel.h
@@ -43,6 +43,7 @@ class MessageModel : public ProtoModel {
   virtual int columnCount(const QModelIndex &parent = QModelIndex()) const override;
   virtual bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::DisplayRole) override;
   virtual QVariant data(const QModelIndex &index, int role) const override;
+  virtual QVariant dataOrDefault(const QModelIndex &index, int role) const;
   virtual QModelIndex parent(const QModelIndex &index) const override;
   virtual QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
   virtual QModelIndex index(int row, int column = 0, const QModelIndex &parent = QModelIndex()) const override;

--- a/Models/MessageModel.h
+++ b/Models/MessageModel.h
@@ -9,7 +9,7 @@
 class MessageModel : public ProtoModel {
   Q_OBJECT
 
-  template<bool HasField>
+  template<bool NO_DEFAULT>
   QVariant dataInternal(const QModelIndex &index, int role) const;
 
  public:

--- a/Models/RepeatedMessageModel.cpp
+++ b/Models/RepeatedMessageModel.cpp
@@ -41,5 +41,7 @@ bool RepeatedMessageModel::setData(const QModelIndex &index, const QVariant &val
 }
 
 QVariant RepeatedMessageModel::data(const QModelIndex &index, int role) const {
+  // protobuf field number with 0 is impossible, use as sentinel to get model itself
+  if (index.column() == 0) return QVariant::fromValue(_subModels[index.row()]);
   return _subModels[index.row()]->data(_subModels[index.row()]->index(index.column()), role);
 }

--- a/Models/RepeatedMessageModel.cpp
+++ b/Models/RepeatedMessageModel.cpp
@@ -1,3 +1,4 @@
+#include "Components/Logger.h"
 #include "RepeatedMessageModel.h"
 #include "MessageModel.h"
 
@@ -26,9 +27,15 @@ void RepeatedMessageModel::Clear() {
   _subModels.clear();
 }
 
-QVariant RepeatedMessageModel::Data(int row, int column) const { return _subModels[row]->Data(column); }
+QVariant RepeatedMessageModel::Data(int row, int column) const {
+  R_EXPECT(row >= 0 && row < _subModels.size(), QVariant()) <<
+    "Supplied row was out of bounds:" << row;
+  return _subModels[row]->Data(column);
+}
 
 bool RepeatedMessageModel::SetData(const QVariant &value, int row, int column) {
+  R_EXPECT(row >= 0 && row < _subModels.size(), false) <<
+    "Supplied row was out of bounds:" << row;
   return _subModels[row]->SetData(value, column);
 }
 
@@ -37,11 +44,18 @@ int RepeatedMessageModel::columnCount(const QModelIndex & /*parent*/) const {
 }
 
 bool RepeatedMessageModel::setData(const QModelIndex &index, const QVariant &value, int role) {
+  R_EXPECT(index.row() >= 0 && index.row() < _subModels.size(), false) <<
+    "Supplied row was out of bounds:" << index.row();
   return _subModels[index.row()]->setData(_subModels[index.row()]->index(index.column()), value, role);
 }
 
 QVariant RepeatedMessageModel::data(const QModelIndex &index, int role) const {
+  R_EXPECT(index.row() >= 0 && index.row() < _subModels.size(), QVariant()) <<
+    "Supplied row was out of bounds:" << index.row();
   // protobuf field number with 0 is impossible, use as sentinel to get model itself
-  if (index.column() == 0) return QVariant::fromValue(_subModels[index.row()]);
+  if (index.column() == 0) {
+    R_EXPECT(index.isValid(), QVariant()) << "Supplied index was invalid:" << index;
+    return QVariant::fromValue(_subModels[index.row()]);
+  }
   return _subModels[index.row()]->data(_subModels[index.row()]->index(index.column()), role);
 }

--- a/Models/RepeatedMessageModel.cpp
+++ b/Models/RepeatedMessageModel.cpp
@@ -52,10 +52,10 @@ bool RepeatedMessageModel::setData(const QModelIndex &index, const QVariant &val
 QVariant RepeatedMessageModel::data(const QModelIndex &index, int role) const {
   R_EXPECT(index.row() >= 0 && index.row() < _subModels.size(), QVariant()) <<
     "Supplied row was out of bounds:" << index.row();
+
   // protobuf field number with 0 is impossible, use as sentinel to get model itself
-  if (index.column() == 0) {
-    R_EXPECT(index.isValid(), QVariant()) << "Supplied index was invalid:" << index;
+  if (index.column() == 0)
     return QVariant::fromValue(_subModels[index.row()]);
-  }
+
   return _subModels[index.row()]->data(_subModels[index.row()]->index(index.column()), role);
 }

--- a/Widgets/PathView.cpp
+++ b/Widgets/PathView.cpp
@@ -1,6 +1,8 @@
 #include "PathView.h"
 #include "Models/RepeatedMessageModel.h"
 
+#include <QPainterPath>
+
 PathView::PathView(AssetScrollAreaBackground *parent) : RoomView(parent) {}
 
 // Perform cubic bezier interpolation

--- a/Widgets/RoomView.cpp
+++ b/Widgets/RoomView.cpp
@@ -189,17 +189,18 @@ void RoomView::paintInstances(QPainter& painter) {
     QPixmap pixmap = ArtManager::GetCachedPixmap(imgFile);
     if (pixmap.isNull()) continue;
 
+    MessageModel* inst = _sortedInstances->data(_sortedInstances->index(row, 0)).value<MessageModel*>();
     QVariant x = _sortedInstances->data(_sortedInstances->index(row, Room::Instance::kXFieldNumber));
     QVariant y = _sortedInstances->data(_sortedInstances->index(row, Room::Instance::kYFieldNumber));
-    QVariant xScale = _sortedInstances->data(_sortedInstances->index(row, Room::Instance::kXscaleFieldNumber));
-    QVariant yScale = _sortedInstances->data(_sortedInstances->index(row, Room::Instance::kYscaleFieldNumber));
-    QVariant rot = _sortedInstances->data(_sortedInstances->index(row, Room::Instance::kRotationFieldNumber));
+    QVariant xScale = inst->dataOrDefault(inst->index(Room::Instance::kXscaleFieldNumber), Qt::DisplayRole);
+    QVariant yScale = inst->dataOrDefault(inst->index(Room::Instance::kYscaleFieldNumber), Qt::DisplayRole);
+    QVariant rot = inst->dataOrDefault(inst->index(Room::Instance::kRotationFieldNumber), Qt::DisplayRole);
 
     QRectF dest(0, 0, w, h);
     QRectF src(0, 0, w, h);
     const QTransform transform = painter.transform();
     painter.translate(x.toInt(), y.toInt());
-    painter.scale(xScale.isValid() ? xScale.toFloat() : 1, yScale.isValid() ? yScale.toFloat() : 1);
+    painter.scale(xScale.toFloat(), yScale.toFloat());
     painter.rotate(rot.toFloat());
     painter.translate(-xoff, -yoff);
     painter.drawPixmap(dest, pixmap, src);

--- a/Widgets/RoomView.cpp
+++ b/Widgets/RoomView.cpp
@@ -87,7 +87,7 @@ void RoomView::paintTiles(QPainter& painter) {
     if (!bkg) continue;
 
     MessageModel* tile = _sortedTiles->data(_sortedTiles->index(row, 0)).value<MessageModel*>();
-    R_ASSESS(tile);
+    R_ASSESS_C(tile);
     int x = _sortedTiles->data(_sortedTiles->index(row, Room::Tile::kXFieldNumber)).toInt();
     int y = _sortedTiles->data(_sortedTiles->index(row, Room::Tile::kYFieldNumber)).toInt();
     int xOff = _sortedTiles->data(_sortedTiles->index(row, Room::Tile::kXoffsetFieldNumber)).toInt();
@@ -190,7 +190,7 @@ void RoomView::paintInstances(QPainter& painter) {
     if (pixmap.isNull()) continue;
 
     MessageModel* inst = _sortedInstances->data(_sortedInstances->index(row, 0)).value<MessageModel*>();
-    R_ASSESS(inst);
+    R_ASSESS_C(inst);
     QVariant x = _sortedInstances->data(_sortedInstances->index(row, Room::Instance::kXFieldNumber));
     QVariant y = _sortedInstances->data(_sortedInstances->index(row, Room::Instance::kYFieldNumber));
     QVariant xScale = inst->dataOrDefault(inst->index(Room::Instance::kXscaleFieldNumber), Qt::DisplayRole);

--- a/Widgets/RoomView.cpp
+++ b/Widgets/RoomView.cpp
@@ -85,6 +85,7 @@ void RoomView::paintTiles(QPainter& painter) {
     bkg = bkg->GetSubModel<MessageModel*>(TreeNode::kBackgroundFieldNumber);
     if (!bkg) continue;
 
+    MessageModel* tile = _sortedTiles->data(_sortedTiles->index(row, 0)).value<MessageModel*>();
     int x = _sortedTiles->data(_sortedTiles->index(row, Room::Tile::kXFieldNumber)).toInt();
     int y = _sortedTiles->data(_sortedTiles->index(row, Room::Tile::kYFieldNumber)).toInt();
     int xOff = _sortedTiles->data(_sortedTiles->index(row, Room::Tile::kXoffsetFieldNumber)).toInt();
@@ -92,11 +93,8 @@ void RoomView::paintTiles(QPainter& painter) {
     int w = _sortedTiles->data(_sortedTiles->index(row, Room::Tile::kWidthFieldNumber)).toInt();
     int h = _sortedTiles->data(_sortedTiles->index(row, Room::Tile::kHeightFieldNumber)).toInt();
 
-    QVariant xScale = _sortedTiles->data(_sortedTiles->index(row, Room::Tile::kXscaleFieldNumber));
-    QVariant yScale = _sortedTiles->data(_sortedTiles->index(row, Room::Tile::kYscaleFieldNumber));
-
-    if (xScale.isNull()) xScale.setValue(1);
-    if (yScale.isNull()) yScale.setValue(1);
+    QVariant xScale = tile->dataOrDefault(tile->index(Room::Tile::kXscaleFieldNumber), Qt::DisplayRole);
+    QVariant yScale = tile->dataOrDefault(tile->index(Room::Tile::kYscaleFieldNumber), Qt::DisplayRole);
 
     QString imgFile = bkg->Data(Background::kImageFieldNumber).toString();
     QPixmap pixmap = ArtManager::GetCachedPixmap(imgFile);

--- a/Widgets/RoomView.cpp
+++ b/Widgets/RoomView.cpp
@@ -1,5 +1,6 @@
 #include "RoomView.h"
 #include "Components/ArtManager.h"
+#include "Components/Logger.h"
 #include "MainWindow.h"
 #include "Models/MessageModel.h"
 #include "Models/RepeatedMessageModel.h"
@@ -86,6 +87,7 @@ void RoomView::paintTiles(QPainter& painter) {
     if (!bkg) continue;
 
     MessageModel* tile = _sortedTiles->data(_sortedTiles->index(row, 0)).value<MessageModel*>();
+    R_ASSESS(tile);
     int x = _sortedTiles->data(_sortedTiles->index(row, Room::Tile::kXFieldNumber)).toInt();
     int y = _sortedTiles->data(_sortedTiles->index(row, Room::Tile::kYFieldNumber)).toInt();
     int xOff = _sortedTiles->data(_sortedTiles->index(row, Room::Tile::kXoffsetFieldNumber)).toInt();
@@ -188,6 +190,7 @@ void RoomView::paintInstances(QPainter& painter) {
     if (pixmap.isNull()) continue;
 
     MessageModel* inst = _sortedInstances->data(_sortedInstances->index(row, 0)).value<MessageModel*>();
+    R_ASSESS(inst);
     QVariant x = _sortedInstances->data(_sortedInstances->index(row, Room::Instance::kXFieldNumber));
     QVariant y = _sortedInstances->data(_sortedInstances->index(row, Room::Instance::kYFieldNumber));
     QVariant xScale = inst->dataOrDefault(inst->index(Room::Instance::kXscaleFieldNumber), Qt::DisplayRole);

--- a/Widgets/RoomView.cpp
+++ b/Widgets/RoomView.cpp
@@ -95,8 +95,8 @@ void RoomView::paintTiles(QPainter& painter) {
     int w = _sortedTiles->data(_sortedTiles->index(row, Room::Tile::kWidthFieldNumber)).toInt();
     int h = _sortedTiles->data(_sortedTiles->index(row, Room::Tile::kHeightFieldNumber)).toInt();
 
-    QVariant xScale = tile->dataOrDefault(tile->index(Room::Tile::kXscaleFieldNumber), Qt::DisplayRole);
-    QVariant yScale = tile->dataOrDefault(tile->index(Room::Tile::kYscaleFieldNumber), Qt::DisplayRole);
+    QVariant xScale = tile->dataOrDefault(tile->index(Room::Tile::kXscaleFieldNumber));
+    QVariant yScale = tile->dataOrDefault(tile->index(Room::Tile::kYscaleFieldNumber));
 
     QString imgFile = bkg->Data(Background::kImageFieldNumber).toString();
     QPixmap pixmap = ArtManager::GetCachedPixmap(imgFile);
@@ -193,9 +193,9 @@ void RoomView::paintInstances(QPainter& painter) {
     R_ASSESS_C(inst);
     QVariant x = _sortedInstances->data(_sortedInstances->index(row, Room::Instance::kXFieldNumber));
     QVariant y = _sortedInstances->data(_sortedInstances->index(row, Room::Instance::kYFieldNumber));
-    QVariant xScale = inst->dataOrDefault(inst->index(Room::Instance::kXscaleFieldNumber), Qt::DisplayRole);
-    QVariant yScale = inst->dataOrDefault(inst->index(Room::Instance::kYscaleFieldNumber), Qt::DisplayRole);
-    QVariant rot = inst->dataOrDefault(inst->index(Room::Instance::kRotationFieldNumber), Qt::DisplayRole);
+    QVariant xScale = inst->dataOrDefault(inst->index(Room::Instance::kXscaleFieldNumber));
+    QVariant yScale = inst->dataOrDefault(inst->index(Room::Instance::kYscaleFieldNumber));
+    QVariant rot = inst->dataOrDefault(inst->index(Room::Instance::kRotationFieldNumber));
 
     QRectF dest(0, 0, w, h);
     QRectF src(0, 0, w, h);


### PR DESCRIPTION
This is how Josh would like to resolve #122 by making it explicit when you are ok accepting the default value from the model. I had to also allow column 0 as a special sentinel for `RepeatedMessageModel` to return a pointer to the requested model so that I have an actual way to call `dataOrDefault` on repeated messages. The hack avoids the complication of having to add `dataOrDefault` on all the higher level models and interfaces, such as the sort filter proxy model.