### PR TITLE
Proto Model Reflection Cache

### DIFF
--- a/Models/ProtoModel.cpp
+++ b/Models/ProtoModel.cpp
@@ -6,12 +6,14 @@
 
 #include "Components/Logger.h"
 
-ProtoModel::ProtoModel(QObject *parent, Message *protobuf) : ProtoModel(static_cast<ProtoModel *>(nullptr), protobuf) {
+ProtoModel::ProtoModel(QObject *parent, Message *protobuf) :
+  ProtoModel(static_cast<ProtoModel *>(nullptr), protobuf) {
   QObject::setParent(parent);
 }
 
 ProtoModel::ProtoModel(ProtoModel *parent, Message *protobuf)
-    : QAbstractItemModel(parent), _dirty(false), _protobuf(protobuf), _parentModel(parent) {
+    : QAbstractItemModel(parent), _dirty(false), _protobuf(protobuf), _parentModel(parent),
+      _desc(protobuf->GetDescriptor()), _refl(protobuf->GetReflection()) {
   connect(this, &ProtoModel::DataChanged, this,
           [this](const QModelIndex &topLeft, const QModelIndex &bottomRight,
                  const QVariant & /*oldValue*/ = QVariant(0), const QVector<int> &roles = QVector<int>()) {

--- a/Models/ProtoModel.h
+++ b/Models/ProtoModel.h
@@ -108,6 +108,8 @@ class ProtoModel : public QAbstractItemModel {
   bool _dirty;
   Message *_protobuf;
   ProtoModel *_parentModel;
+  const Descriptor *_desc;
+  const Reflection *_refl;
 };
 
 #endif

--- a/Models/RepeatedMessageModel.cpp
+++ b/Models/RepeatedMessageModel.cpp
@@ -5,9 +5,8 @@
 RepeatedMessageModel::RepeatedMessageModel(ProtoModel *parent, Message *message, const FieldDescriptor *field)
     : RepeatedModel<Message>(parent, message, field,
                              message->GetReflection()->GetMutableRepeatedFieldRef<Message>(message, field)) {
-  const Reflection *refl = _protobuf->GetReflection();
-  for (int j = 0; j < refl->FieldSize(*_protobuf, field); j++) {
-    _subModels.append(new MessageModel(parent, refl->MutableRepeatedMessage(_protobuf, field, j)));
+  for (int j = 0; j < _refl->FieldSize(*_protobuf, field); j++) {
+    _subModels.append(new MessageModel(parent, _refl->MutableRepeatedMessage(_protobuf, field, j)));
   }
 }
 


### PR DESCRIPTION
This is the first step in optimizing #132 by caching the reflector and descriptors used by the proto based models. I think we will need to do additional testing and benchmarking to ensure that we can do this safely.

I have found from the documentation already that seems it should be appropriate to cache the reflection object so long as we don't violate any of the specific rules it mentions. My analysis is that we certainly don't, because we are obviously never using a reflection object on a message whose type is not compatible.
https://developers.google.com/protocol-buffers/docs/reference/cpp/google.protobuf.message#Reflection