### PR TITLE
MSYS2 Dash Azure Workaround

### DIFF
--- a/azure-jobs.yml
+++ b/azure-jobs.yml
@@ -61,7 +61,7 @@ jobs:
     
     - script: |
         set PATH=%CD:~0,2%\msys64\usr\bin;C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem
-        %CD:~0,2%\msys64\usr\bin\pacman --noconfirm -S dash
+        %CD:~0,2%\msys64\usr\bin\pacman --noconfirm -Syu dash
         %CD:~0,2%\msys64\usr\bin\pacman --noconfirm -Syyuu
       displayName: Update MSYS2
     

--- a/azure-jobs.yml
+++ b/azure-jobs.yml
@@ -61,7 +61,7 @@ jobs:
     
     - script: |
         set PATH=%CD:~0,2%\msys64\usr\bin;C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem
-        %CD:~0,2%\msys64\usr\bin\pacman --noconfirm -S dash
+        %CD:~0,2%\msys64\usr\bin\pacman --noconfirm -Rc dash
         %CD:~0,2%\msys64\usr\bin\pacman --noconfirm -Syu
         %CD:~0,2%\msys64\usr\bin\pacman --noconfirm -Syyuu
       displayName: Update MSYS2

--- a/azure-jobs.yml
+++ b/azure-jobs.yml
@@ -62,6 +62,7 @@ jobs:
     - script: |
         set PATH=%CD:~0,2%\msys64\usr\bin;C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem
         %CD:~0,2%\msys64\usr\bin\pacman --noconfirm -Sydd filesystem
+        %CD:~0,2%\msys64\usr\bin\pacman --noconfirm -Su
         %CD:~0,2%\msys64\usr\bin\pacman --noconfirm -Syyuu
       displayName: Update MSYS2
     

--- a/azure-jobs.yml
+++ b/azure-jobs.yml
@@ -61,8 +61,8 @@ jobs:
     
     - script: |
         set PATH=%CD:~0,2%\msys64\usr\bin;C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem
-        %CD:~0,2%\msys64\usr\bin\pacman --noconfirm -Sydd filesystem
-        %CD:~0,2%\msys64\usr\bin\pacman --noconfirm -Su
+        %CD:~0,2%\msys64\usr\bin\pacman --noconfirm -S dash
+        %CD:~0,2%\msys64\usr\bin\pacman --noconfirm -Syu
         %CD:~0,2%\msys64\usr\bin\pacman --noconfirm -Syyuu
       displayName: Update MSYS2
     

--- a/azure-jobs.yml
+++ b/azure-jobs.yml
@@ -61,6 +61,7 @@ jobs:
     
     - script: |
         set PATH=%CD:~0,2%\msys64\usr\bin;C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem
+        %CD:~0,2%\msys64\usr\bin\pacman --noconfirm -S dash
         %CD:~0,2%\msys64\usr\bin\pacman --noconfirm -Syyuu
       displayName: Update MSYS2
     

--- a/azure-jobs.yml
+++ b/azure-jobs.yml
@@ -61,7 +61,7 @@ jobs:
     
     - script: |
         set PATH=%CD:~0,2%\msys64\usr\bin;C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem
-        %CD:~0,2%\msys64\usr\bin\pacman --noconfirm -Syu dash
+        %CD:~0,2%\msys64\usr\bin\pacman --noconfirm -Sydd filesystem
         %CD:~0,2%\msys64\usr\bin\pacman --noconfirm -Syyuu
       displayName: Update MSYS2
     


### PR DESCRIPTION
This is a small workaround to fix the broken MinGW32 and MinGW64 builds on our Azure CI right now.

I tried the safer fix mentioned, but it didn't work, so I had to go with the filesystem hack.
https://github.com/msys2/MSYS2-packages/issues/2021

It's probably not worth merging this because anybody who does a fresh install of MSYS2 and then ENIGMA might have this problem anyway? @fundies ?