### PR TITLE
Window Menu MDI Icons

### DIFF
--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -273,7 +273,8 @@ void MainWindow::updateWindowMenu() {
     QString text = tr("%1 %2").arg(numberString).arg(windowTitle);
 
     QAction *action = _ui->menuWindow->addAction(
-        text, mdiSubWindow, [this, mdiSubWindow]() { _ui->mdiArea->setActiveSubWindow(mdiSubWindow); });
+        mdiSubWindow->windowIcon(), text, mdiSubWindow,
+          [this, mdiSubWindow]() { _ui->mdiArea->setActiveSubWindow(mdiSubWindow); });
     windowActions.append(action);
     action->setCheckable(true);
     action->setChecked(mdiSubWindow == _ui->mdiArea->activeSubWindow());


### PR DESCRIPTION
I just noticed this was different from LGM so I decided to tweak it. Interestingly, all versions of GM before GMSv1.4 did not even have this menu. Even when GMSv1.4 finally added it, they didn't use the MDI subwindow icons like LGM did. Obviously the icons help to easily pick out the windows from the list. Later I would like sprites/backgrounds/objects to actually use the same icon as the tree node too.

| Master | Pull |
|--------|------|
|![Master MDI Window Checkboxes](https://user-images.githubusercontent.com/3212801/88857994-484d2800-d1c5-11ea-958f-d0713f9c5044.png)|![Pull Request MDI Icons](https://user-images.githubusercontent.com/3212801/88857968-3bc8cf80-d1c5-11ea-9405-5a5dec682c07.png)|