### PR TITLE
Script/Shader Editor Window Icon

### DIFF
--- a/Editors/ScriptEditor.cpp
+++ b/Editors/ScriptEditor.cpp
@@ -7,6 +7,7 @@ using namespace buffers::resources;
 
 ScriptEditor::ScriptEditor(MessageModel* model, QWidget* parent)
     : BaseEditor(model, parent), _codeEditor(new CodeEditor(this)) {
+  this->setWindowIcon(QIcon(":/resources/script.png"));
   QLayout* layout = new QVBoxLayout(this);
   layout->addWidget(_codeEditor);
   layout->setMargin(0);

--- a/Editors/ShaderEditor.cpp
+++ b/Editors/ShaderEditor.cpp
@@ -11,6 +11,7 @@ using namespace buffers::resources;
 
 ShaderEditor::ShaderEditor(MessageModel* model, QWidget* parent)
     : BaseEditor(model, parent), _codeEditor(new CodeEditor(this)) {
+  this->setWindowIcon(QIcon(":/resources/shader.png"));
   QLayout* layout = new QVBoxLayout(this);
   layout->addWidget(_codeEditor);
   layout->setMargin(0);


### PR DESCRIPTION
The reason these two didn't have their own window icons already is because they are reusing the same `CodeEditor.ui` form, which is totally acceptable. The alternative would be for us to create separate `ShaderEditor.ui` and `ScriptEditor.ui` forms that both embed the `CodeEditor.ui` like it's a custom widget. I have no particular preference myself.

I should mention that this relates to #137 keybinding preferences. In GMS2 the keybinding preferences are the same for the script and shader editors, likely because YoYo is doing a similar kind of abstraction internally for the editor they built.
https://docs2.yoyogames.com/source/_build/1_overview/2_quick_start/8_shortcuts.html
