### PR TITLE
Tree Drag and Drop Move

### DIFF
--- a/Models/TreeModel.cpp
+++ b/Models/TreeModel.cpp
@@ -274,12 +274,10 @@ bool TreeModel::dropMimeData(const QMimeData *mimeData, Qt::DropAction action, i
       // count this row as having been moved from this parent
       if (parentNode != oldParent || row > itemRow) removedCount[oldParent]++;
 
-      // if moving the node within the same parent we need to adjust the row
-      // since its own removal will affect the row we reinsert it at
-      if (parentNode == oldParent && row > itemRow) --row;
-
       endMoveRows();
-      ++row;
+      // the insert row doesn't need incremented if we moved a node in the
+      // same parent from a row greater than we are inserting at
+      if (parentNode != oldParent || row < itemRow) ++row;
     } else {
       if (node->folder()) continue;
       node = duplicateNode(*node);


### PR DESCRIPTION
This is just a tiny tweak that I'm not sure if we should go with. It changes the drag and drop for the tree model so that if you drag and drop into the same parent it only does a move inside the repeated field instead of extracting and reinserting it, which is redundant when it's the same repeated field. I'm not sure if this is even an optimization, I think it might be, because the documentation says `ExtractSubrange` can have quadratic behavior but I don't know if there's also any deep copying going on.
https://developers.google.com/protocol-buffers/docs/reference/cpp/google.protobuf.repeated_field#RepeatedPtrField.ExtractSubrange.details