### PR TITLE
Drag and Drop Path Sort

### DIFF
--- a/Models/TreeModel.cpp
+++ b/Models/TreeModel.cpp
@@ -174,7 +174,14 @@ QMimeData *TreeModel::mimeData(const QModelIndexList &indexes) const {
 
   // rows are moved starting with the lowest so we can create
   // unique names in the order of insertion
-  std::sort(nodes.begin(), nodes.end(), std::less<QModelIndex>());
+  using pathComparator = std::function<bool(const QModelIndex & a, const QModelIndex & b)>;
+  pathComparator compareIndexes =
+    [&compareIndexes](const QModelIndex & a, const QModelIndex & b) -> bool {
+      if (a.parent() == b.parent())
+        return a < b;
+      return compareIndexes(a.parent(),b.parent());
+    };
+  std::sort(nodes.begin(), nodes.end(), compareIndexes);
 
   stream << QCoreApplication::applicationPid();
   stream << nodes.count();

--- a/Models/TreeModel.cpp
+++ b/Models/TreeModel.cpp
@@ -177,9 +177,7 @@ QMimeData *TreeModel::mimeData(const QModelIndexList &indexes) const {
   using pathComparator = std::function<bool(const QModelIndex & a, const QModelIndex & b)>;
   pathComparator compareIndexes =
     [&compareIndexes](const QModelIndex & a, const QModelIndex & b) -> bool {
-      if (a.parent() == b.parent())
-        return a < b;
-      return compareIndexes(a.parent(),b.parent());
+      return a < b && compareIndexes(a.parent(),b.parent());
     };
   std::sort(nodes.begin(), nodes.end(), compareIndexes);
 


### PR DESCRIPTION
This is another small tweak I walked across in my research of the super model. Our sort in `mimeData()` acts as though all of the indexes we are dragging are of the same parent which causes them to become interspersed when dropped. I realized I could solve that with a custom comparator which this pull request does. I'm also still not sure why we sort during drag instead of drop, although I recall that being the way it was in the official Qt example. Master currently behaves like LateralGM and GM does not have multiple selection for the tree.

Anyway, create some paths and scripts in the subfolders and select them, then drag them to some other folder and drop. If you do this on master you will get the master behavior below. If you do this on this pull request you will get the pull behavior below.
**NOTE**: If you double click the drop folder, it will change the selection, clicking the expand arrow does not!
| Select | Master | Pull |
|--------|--------|------|
|![Select Paths & Scripts](https://user-images.githubusercontent.com/3212801/89083133-073c4b80-d35e-11ea-9829-5f9ff59e3376.png)|![Drop Paths & Scripts Master](https://user-images.githubusercontent.com/3212801/89083224-4f5b6e00-d35e-11ea-9b4c-58c77d418724.png)|![Drop Paths & Scripts Pull](https://user-images.githubusercontent.com/3212801/89091315-b2f19580-d376-11ea-98c3-f0d98e41d7a9.png)|