### PR TITLE
Tree Row Move Abstraction

### DIFF
--- a/Models/TreeModel.h
+++ b/Models/TreeModel.h
@@ -29,6 +29,8 @@ class TreeModel : public QAbstractItemModel {
   QModelIndex parent(const QModelIndex &index) const override;
   int rowCount(const QModelIndex &parent = QModelIndex()) const override;
   int columnCount(const QModelIndex &parent = QModelIndex()) const override;
+  bool moveRows(const QModelIndex &sourceParent, int sourceRow, int count,
+                const QModelIndex &destinationParent, int destinationChild) override;
 
   Qt::DropActions supportedDropActions() const override;
   QStringList mimeTypes() const override;


### PR DESCRIPTION
I had an idea that we could abstract the row moving logic from the drop handling into its own function. I see now that this is why `QAbstractItemModel` has a moveRow which just calls moveRows by default. While this is immediately more code, it could save us code down the road by reusing this move logic for other stuff.
https://doc.qt.io/qt-5/qabstractitemmodel.html#moveRow
https://doc.qt.io/qt-5/qabstractitemmodel.html#moveRows
Also it may be performing multiple row moves more efficiently since it does not devolve into the quadratic worst case of `ExtractSubrange` according to protobuf documentation.
https://developers.google.com/protocol-buffers/docs/reference/cpp/google.protobuf.repeated_field#RepeatedPtrField.ExtractSubrange.details
