### PR TITLE
Editor Mapper

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,7 @@ set(RGM_SOURCES
     Models/ImmediateMapper.cpp
     Models/ResourceModelMap.cpp
     Models/TreeModel.cpp
+    Models/EditorMapper.cpp
     Editors/ObjectEditor.cpp
     Editors/PathEditor.cpp
     Editors/CodeEditor.cpp
@@ -117,6 +118,7 @@ set(RGM_HEADERS
     Models/RepeatedMessageModel.h
     Models/ProtoModel.h
     Models/RepeatedModel.h
+    Models/EditorMapper.h
     Editors/FontEditor.h
     Editors/PathEditor.h
     Editors/SpriteEditor.h

--- a/Editors/BackgroundEditor.cpp
+++ b/Editors/BackgroundEditor.cpp
@@ -51,7 +51,7 @@ void BackgroundEditor::dataChanged(const QModelIndex& topLeft, const QModelIndex
 void BackgroundEditor::RebindSubModels() {
   _backgroundModel = _model->GetSubModel<MessageModel*>(TreeNode::kBackgroundFieldNumber);
   _ui->imagePreviewBackground->SetAssetView(_ui->backgroundView);
-  //TODO:_ui->backgroundView->SetResourceModel(_resMapper->GetModel());
+  _ui->backgroundView->SetResourceModel(_backgroundModel);
   BaseEditor::RebindSubModels();
 }
 

--- a/Editors/BackgroundEditor.cpp
+++ b/Editors/BackgroundEditor.cpp
@@ -21,16 +21,21 @@ BackgroundEditor::BackgroundEditor(MessageModel* model, QWidget* parent)
 
   connect(_ui->actionSave, &QAction::triggered, this, &BaseEditor::OnSave);
 
-  _resMapper->addMapping(_ui->smoothCheckBox, Background::kSmoothEdgesFieldNumber);
-  _resMapper->addMapping(_ui->preloadCheckBox, Background::kPreloadFieldNumber);
-  _resMapper->addMapping(_ui->tilesetGroupBox, Background::kUseAsTilesetFieldNumber);
-  _resMapper->addMapping(_ui->tileWidthSpinBox, Background::kTileWidthFieldNumber);
-  _resMapper->addMapping(_ui->tileHeightSpinBox, Background::kTileHeightFieldNumber);
-  _resMapper->addMapping(_ui->horizontalOffsetSpinBox, Background::kHorizontalOffsetFieldNumber);
-  _resMapper->addMapping(_ui->verticalOffsetSpinBox, Background::kVerticalOffsetFieldNumber);
-  _resMapper->addMapping(_ui->horizontalSpacingSpinBox, Background::kHorizontalSpacingFieldNumber);
-  _resMapper->addMapping(_ui->verticalSpacingSpinBox, Background::kVerticalSpacingFieldNumber);
-  _resMapper->toFirst();
+  //TODO: _mapper->mapName(_ui->nameEdit);
+  _mapper->pushResource();
+
+  _mapper->mapField(Background::kSmoothEdgesFieldNumber, _ui->smoothCheckBox);
+  _mapper->mapField(Background::kPreloadFieldNumber, _ui->preloadCheckBox);
+  _mapper->mapField(Background::kUseAsTilesetFieldNumber, _ui->tilesetGroupBox);
+  _mapper->mapField(Background::kTileWidthFieldNumber, _ui->tileWidthSpinBox);
+  _mapper->mapField(Background::kTileHeightFieldNumber, _ui->tileHeightSpinBox);
+  _mapper->mapField(Background::kHorizontalOffsetFieldNumber, _ui->horizontalOffsetSpinBox);
+  _mapper->mapField(Background::kVerticalOffsetFieldNumber, _ui->verticalOffsetSpinBox);
+  _mapper->mapField(Background::kHorizontalSpacingFieldNumber, _ui->horizontalSpacingSpinBox);
+  _mapper->mapField(Background::kVerticalSpacingFieldNumber, _ui->verticalSpacingSpinBox);
+  _mapper->mapField(Background::kImageFieldNumber, _ui->backgroundView);
+
+  _mapper->load();
 
   RebindSubModels();
 }
@@ -46,7 +51,7 @@ void BackgroundEditor::dataChanged(const QModelIndex& topLeft, const QModelIndex
 void BackgroundEditor::RebindSubModels() {
   _backgroundModel = _model->GetSubModel<MessageModel*>(TreeNode::kBackgroundFieldNumber);
   _ui->imagePreviewBackground->SetAssetView(_ui->backgroundView);
-  _ui->backgroundView->SetResourceModel(_resMapper->GetModel());
+  //TODO:_ui->backgroundView->SetResourceModel(_resMapper->GetModel());
   BaseEditor::RebindSubModels();
 }
 

--- a/Editors/BackgroundEditor.cpp
+++ b/Editors/BackgroundEditor.cpp
@@ -22,7 +22,7 @@ BackgroundEditor::BackgroundEditor(MessageModel* model, QWidget* parent)
   connect(_ui->actionSave, &QAction::triggered, this, &BaseEditor::OnSave);
 
   //TODO: _mapper->mapName(_ui->nameEdit);
-  _mapper->pushResource();
+  _mapper->pushAsset();
 
   _mapper->mapField(Background::kSmoothEdgesFieldNumber, _ui->smoothCheckBox);
   _mapper->mapField(Background::kPreloadFieldNumber, _ui->preloadCheckBox);

--- a/Editors/BaseEditor.h
+++ b/Editors/BaseEditor.h
@@ -2,7 +2,6 @@
 #define BASEEDTIOR_H
 
 #include "Models/MessageModel.h"
-#include "Models/ModelMapper.h"
 #include "Models/EditorMapper.h"
 
 #include <QObject>
@@ -39,8 +38,7 @@ class BaseEditor : public QWidget {
  protected:
   virtual void closeEvent(QCloseEvent *event) override;
 
-  ModelMapper *_nodeMapper;
-  ModelMapper *_resMapper;
+  EditorMapper *_mapper;
   MessageModel *_model;
   bool _hasFocus = false;
 };

--- a/Editors/BaseEditor.h
+++ b/Editors/BaseEditor.h
@@ -3,6 +3,7 @@
 
 #include "Models/MessageModel.h"
 #include "Models/ModelMapper.h"
+#include "Models/EditorMapper.h"
 
 #include <QObject>
 #include <QWidget>

--- a/Editors/FontEditor.cpp
+++ b/Editors/FontEditor.cpp
@@ -18,11 +18,15 @@ ABCDEFGHIJKLMNOPQRSTUVWXYZ\n\
 ~!@#$%^&*()_+{}|:\"<>?`-=[];\',./\n\
 The quick brown fox jumps over the lazy dog.");
 
-  _nodeMapper->addMapping(_ui->nameEdit, TreeNode::kNameFieldNumber);
-  _resMapper->addMapping(_ui->fontComboBox, Font::kFontNameFieldNumber);
-  _resMapper->addMapping(_ui->sizeSpinBox, Font::kSizeFieldNumber);
-  _resMapper->addMapping(_ui->boldCheckBox, Font::kBoldFieldNumber);
-  _resMapper->addMapping(_ui->italicCheckBox, Font::kItalicFieldNumber);
+  _mapper->mapName(_ui->nameEdit);
+  _mapper->pushResource();
+
+  _mapper->mapField(Font::kFontNameFieldNumber, _ui->fontComboBox);
+  _mapper->mapField(Font::kSizeFieldNumber, _ui->sizeSpinBox);
+  _mapper->mapField(Font::kBoldFieldNumber, _ui->boldCheckBox);
+  _mapper->mapField(Font::kItalicFieldNumber, _ui->italicCheckBox);
+
+  _mapper->load();
 
   RebindSubModels();
 }

--- a/Editors/FontEditor.cpp
+++ b/Editors/FontEditor.cpp
@@ -19,7 +19,7 @@ ABCDEFGHIJKLMNOPQRSTUVWXYZ\n\
 The quick brown fox jumps over the lazy dog.");
 
   _mapper->mapName(_ui->nameEdit);
-  _mapper->pushResource();
+  _mapper->pushAsset();
 
   _mapper->mapField(Font::kFontNameFieldNumber, _ui->fontComboBox);
   _mapper->mapField(Font::kSizeFieldNumber, _ui->sizeSpinBox);

--- a/Editors/PathEditor.cpp
+++ b/Editors/PathEditor.cpp
@@ -87,7 +87,6 @@ PathEditor::PathEditor(MessageModel* model, QWidget* parent) : BaseEditor(model,
   connect(this, &BaseEditor::FocusGained, [this]() { _ui->pathPreviewBackground->SetParentHasFocus(true); });
   connect(this, &BaseEditor::FocusLost, [this]() { _ui->pathPreviewBackground->SetParentHasFocus(false); });
 
-  EditorMapper *_mapper = new EditorMapper(model, this);
   _mapper->mapName(_ui->nameEdit);
   _mapper->pushResource();
 

--- a/Editors/PathEditor.cpp
+++ b/Editors/PathEditor.cpp
@@ -88,7 +88,7 @@ PathEditor::PathEditor(MessageModel* model, QWidget* parent) : BaseEditor(model,
   connect(this, &BaseEditor::FocusLost, [this]() { _ui->pathPreviewBackground->SetParentHasFocus(false); });
 
   _mapper->mapName(_ui->nameEdit);
-  _mapper->pushResource();
+  _mapper->pushAsset();
 
   _mapper->mapField(Path::kSmoothFieldNumber, _ui->smoothCheckBox);
   _mapper->mapField(Path::kClosedFieldNumber, _ui->closedCheckBox);

--- a/Editors/PathEditor.cpp
+++ b/Editors/PathEditor.cpp
@@ -87,13 +87,17 @@ PathEditor::PathEditor(MessageModel* model, QWidget* parent) : BaseEditor(model,
   connect(this, &BaseEditor::FocusGained, [this]() { _ui->pathPreviewBackground->SetParentHasFocus(true); });
   connect(this, &BaseEditor::FocusLost, [this]() { _ui->pathPreviewBackground->SetParentHasFocus(false); });
 
-  _nodeMapper->addMapping(_ui->nameEdit, TreeNode::kNameFieldNumber);
+  EditorMapper *_mapper = new EditorMapper(model, this);
+  _mapper->mapName(_ui->nameEdit);
+  _mapper->pushResource();
 
-  _resMapper->addMapping(_ui->smoothCheckBox, Path::kSmoothFieldNumber);
-  _resMapper->addMapping(_ui->closedCheckBox, Path::kClosedFieldNumber);
-  _resMapper->addMapping(_ui->precisionSpinBox, Path::kPrecisionFieldNumber);
-  _resMapper->addMapping(xSnap, Path::kHsnapFieldNumber);
-  _resMapper->addMapping(ySnap, Path::kVsnapFieldNumber);
+  _mapper->mapField(Path::kSmoothFieldNumber, _ui->smoothCheckBox);
+  _mapper->mapField(Path::kClosedFieldNumber, _ui->closedCheckBox);
+  _mapper->mapField(Path::kPrecisionFieldNumber, _ui->precisionSpinBox);
+  _mapper->mapField(Path::kHsnapFieldNumber, xSnap);
+  _mapper->mapField(Path::kVsnapFieldNumber, ySnap);
+
+  _mapper->load();
 
   RebindSubModels();
 }

--- a/Editors/RoomEditor.cpp
+++ b/Editors/RoomEditor.cpp
@@ -37,7 +37,7 @@ RoomEditor::RoomEditor(MessageModel* model, QWidget* parent) : BaseEditor(model,
   _mapper->mapField(Room::kEnableViewsFieldNumber, _ui->enableViewsCheckBox);
   _mapper->mapField(Room::kClearViewBackgroundFieldNumber, _ui->clearViewportCheckBox);
 
-  //TODO: FIX GROUP
+  _mapper->pushView(Room::kViewsFieldNumber, _ui->currentViewComboBox->view());
   _mapper->mapField(View::kVisibleFieldNumber, _ui->viewVisibleCheckBox);
 
   _mapper->mapField(View::kXviewFieldNumber, _ui->cameraXSpinBox);
@@ -54,7 +54,7 @@ RoomEditor::RoomEditor(MessageModel* model, QWidget* parent) : BaseEditor(model,
   _mapper->mapField(View::kVborderFieldNumber, _ui->followingVBorderSpinBox);
   _mapper->mapField(View::kHspeedFieldNumber, _ui->followingHSpeedSpinBox);
   _mapper->mapField(View::kVspeedFieldNumber, _ui->followingVSpeedSpinBox);
-  //_mapper->popField();
+  _mapper->popField();
 
   _mapper->load();
 
@@ -66,9 +66,6 @@ RoomEditor::RoomEditor(MessageModel* model, QWidget* parent) : BaseEditor(model,
   _ui->objectSelectButton->setMenu(objMenu);
 
   connect(objMenu, &QMenu::triggered, this, &RoomEditor::SelectedObjectChanged);
-
-  connect(_ui->currentViewComboBox, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
-          [=](int index) { _viewMapper->setCurrentIndex(index); });
 
   cursorPositionLabel = new QLabel();
   connect(_ui->roomPreviewBackground, &AssetScrollAreaBackground::MouseMoved, [=](int x, int y) {
@@ -126,9 +123,6 @@ void RoomEditor::RebindSubModels() {
   }
 
   _ui->tilesListView->header()->swapSections(Room::Tile::kNameFieldNumber, Room::Tile::kBackgroundNameFieldNumber);
-
-  RepeatedMessageModel* vm = _roomModel->GetSubModel<RepeatedMessageModel*>(Room::kViewsFieldNumber);
-  _viewMapper->setModel(vm);
 
   connect(_ui->instancesListView->selectionModel(), &QItemSelectionModel::selectionChanged,
           [=](const QItemSelection& selected, const QItemSelection& /*deselected*/) {

--- a/Editors/RoomEditor.cpp
+++ b/Editors/RoomEditor.cpp
@@ -24,38 +24,39 @@ RoomEditor::RoomEditor(MessageModel* model, QWidget* parent) : BaseEditor(model,
 
   _ui->roomPreviewBackground->SetAssetView(_ui->roomView);
 
-  _nodeMapper->addMapping(_ui->roomName, TreeNode::kNameFieldNumber);
-  _nodeMapper->toFirst();
+  _mapper->mapName(_ui->roomName);
+  _mapper->pushResource();
 
-  _resMapper->addMapping(_ui->speedSpinBox, Room::kSpeedFieldNumber);
-  _resMapper->addMapping(_ui->widthSpinBox, Room::kWidthFieldNumber);
-  _resMapper->addMapping(_ui->heightSpinBox, Room::kHeightFieldNumber);
-  _resMapper->addMapping(_ui->clearCheckBox, Room::kClearDisplayBufferFieldNumber);
-  _resMapper->addMapping(_ui->persistentCheckBox, Room::kPersistentFieldNumber);
-  _resMapper->addMapping(_ui->captionLineEdit, Room::kCaptionFieldNumber);
+  _mapper->mapField(Room::kSpeedFieldNumber, _ui->speedSpinBox);
+  _mapper->mapField(Room::kWidthFieldNumber, _ui->widthSpinBox);
+  _mapper->mapField(Room::kHeightFieldNumber, _ui->heightSpinBox);
+  _mapper->mapField(Room::kClearDisplayBufferFieldNumber, _ui->clearCheckBox);
+  _mapper->mapField(Room::kPersistentFieldNumber, _ui->persistentCheckBox);
+  _mapper->mapField(Room::kCaptionFieldNumber, _ui->captionLineEdit);
 
-  _resMapper->addMapping(_ui->enableViewsCheckBox, Room::kEnableViewsFieldNumber);
-  _resMapper->addMapping(_ui->clearViewportCheckBox, Room::kClearViewBackgroundFieldNumber);
-  _resMapper->toFirst();
+  _mapper->mapField(Room::kEnableViewsFieldNumber, _ui->enableViewsCheckBox);
+  _mapper->mapField(Room::kClearViewBackgroundFieldNumber, _ui->clearViewportCheckBox);
 
-  _viewMapper = new ImmediateDataWidgetMapper(this);
-  _viewMapper->addMapping(_ui->viewVisibleCheckBox, View::kVisibleFieldNumber);
+  //TODO: FIX GROUP
+  _mapper->mapField(View::kVisibleFieldNumber, _ui->viewVisibleCheckBox);
 
-  _viewMapper->addMapping(_ui->cameraXSpinBox, View::kXviewFieldNumber);
-  _viewMapper->addMapping(_ui->cameraYSpinBox, View::kYviewFieldNumber);
-  _viewMapper->addMapping(_ui->cameraWidthSpinBox, View::kWviewFieldNumber);
-  _viewMapper->addMapping(_ui->cameraHeightSpinBox, View::kHviewFieldNumber);
+  _mapper->mapField(View::kXviewFieldNumber, _ui->cameraXSpinBox);
+  _mapper->mapField(View::kYviewFieldNumber, _ui->cameraYSpinBox);
+  _mapper->mapField(View::kWviewFieldNumber, _ui->cameraWidthSpinBox);
+  _mapper->mapField(View::kHviewFieldNumber, _ui->cameraHeightSpinBox);
 
-  _viewMapper->addMapping(_ui->viewportXSpinBox, View::kXportFieldNumber);
-  _viewMapper->addMapping(_ui->viewportYSpinBox, View::kYportFieldNumber);
-  _viewMapper->addMapping(_ui->viewportWidthSpinBox, View::kWportFieldNumber);
-  _viewMapper->addMapping(_ui->viewportHeightSpinBox, View::kHportFieldNumber);
+  _mapper->mapField(View::kXportFieldNumber, _ui->viewportXSpinBox);
+  _mapper->mapField(View::kYportFieldNumber, _ui->viewportYSpinBox);
+  _mapper->mapField(View::kWportFieldNumber, _ui->viewportWidthSpinBox);
+  _mapper->mapField(View::kHportFieldNumber, _ui->viewportHeightSpinBox);
 
-  _viewMapper->addMapping(_ui->followingHBorderSpinBox, View::kHborderFieldNumber);
-  _viewMapper->addMapping(_ui->followingVBorderSpinBox, View::kVborderFieldNumber);
-  _viewMapper->addMapping(_ui->followingHSpeedSpinBox, View::kHspeedFieldNumber);
-  _viewMapper->addMapping(_ui->followingVSpeedSpinBox, View::kVspeedFieldNumber);
-  _viewMapper->toFirst();
+  _mapper->mapField(View::kHborderFieldNumber, _ui->followingHBorderSpinBox);
+  _mapper->mapField(View::kVborderFieldNumber, _ui->followingVBorderSpinBox);
+  _mapper->mapField(View::kHspeedFieldNumber, _ui->followingHSpeedSpinBox);
+  _mapper->mapField(View::kVspeedFieldNumber, _ui->followingVSpeedSpinBox);
+  //_mapper->popField();
+
+  _mapper->load();
 
   QMenuView* objMenu = new QMenuView(this);
   TreeSortFilterProxyModel* treeProxy = new TreeSortFilterProxyModel(this);

--- a/Editors/RoomEditor.cpp
+++ b/Editors/RoomEditor.cpp
@@ -25,7 +25,7 @@ RoomEditor::RoomEditor(MessageModel* model, QWidget* parent) : BaseEditor(model,
   _ui->roomPreviewBackground->SetAssetView(_ui->roomView);
 
   _mapper->mapName(_ui->roomName);
-  _mapper->pushResource();
+  _mapper->pushAsset();
 
   _mapper->mapField(Room::kSpeedFieldNumber, _ui->speedSpinBox);
   _mapper->mapField(Room::kWidthFieldNumber, _ui->widthSpinBox);

--- a/Editors/RoomEditor.h
+++ b/Editors/RoomEditor.h
@@ -35,7 +35,6 @@ class RoomEditor : public BaseEditor {
   Ui::RoomEditor* _ui;
   QLabel *cursorPositionLabel, *_assetNameLabel;
   MessageModel* _roomModel;
-  ImmediateDataWidgetMapper* _viewMapper;
 };
 
 #endif  // ROOMEDITOR_H

--- a/Editors/ScriptEditor.cpp
+++ b/Editors/ScriptEditor.cpp
@@ -18,8 +18,13 @@ ScriptEditor::ScriptEditor(MessageModel* model, QWidget* parent)
   connect(ui->actionSave, &QAction::triggered, this, &BaseEditor::OnSave);
 
   CodeWidget* codeWidget = _codeEditor->AddCodeWidget();
-  _resMapper->addMapping(codeWidget, Script::kCodeFieldNumber);
-  _resMapper->toFirst();
+
+  //TODO: _mapper->mapName(nameEdit);
+  _mapper->pushResource();
+
+  _mapper->mapField(Script::kCodeFieldNumber, codeWidget);
+
+  _mapper->load();
 
   _codeEditor->updateCursorPositionLabel();
   _codeEditor->updateLineCountLabel();

--- a/Editors/ScriptEditor.cpp
+++ b/Editors/ScriptEditor.cpp
@@ -20,7 +20,7 @@ ScriptEditor::ScriptEditor(MessageModel* model, QWidget* parent)
   CodeWidget* codeWidget = _codeEditor->AddCodeWidget();
 
   //TODO: _mapper->mapName(nameEdit);
-  _mapper->pushResource();
+  _mapper->pushAsset();
 
   _mapper->mapField(Script::kCodeFieldNumber, codeWidget);
 

--- a/Editors/ShaderEditor.cpp
+++ b/Editors/ShaderEditor.cpp
@@ -33,7 +33,7 @@ ShaderEditor::ShaderEditor(MessageModel* model, QWidget* parent)
   CodeWidget* fragWidget = _codeEditor->AddCodeWidget();
 
   //TODO: _mapper->mapName(nameEdit);
-  _mapper->pushResource();
+  _mapper->pushAsset();
 
   _mapper->mapField(Shader::kFragmentCodeFieldNumber, fragWidget);
   _mapper->mapField(Shader::kVertexCodeFieldNumber, vertexWidget);

--- a/Editors/ShaderEditor.cpp
+++ b/Editors/ShaderEditor.cpp
@@ -32,9 +32,13 @@ ShaderEditor::ShaderEditor(MessageModel* model, QWidget* parent)
   CodeWidget* vertexWidget = _codeEditor->AddCodeWidget();
   CodeWidget* fragWidget = _codeEditor->AddCodeWidget();
 
-  _resMapper->addMapping(fragWidget, Shader::kFragmentCodeFieldNumber);
-  _resMapper->addMapping(vertexWidget, Shader::kVertexCodeFieldNumber);
-  _resMapper->toFirst();
+  //TODO: _mapper->mapName(nameEdit);
+  _mapper->pushResource();
+
+  _mapper->mapField(Shader::kFragmentCodeFieldNumber, fragWidget);
+  _mapper->mapField(Shader::kVertexCodeFieldNumber, vertexWidget);
+
+  _mapper->load();
 
   connect(shaderType, QOverload<int>::of(&QComboBox::currentIndexChanged),
           [=](int index) { ui->stackedWidget->setCurrentIndex(index); });

--- a/Editors/SoundEditor.cpp
+++ b/Editors/SoundEditor.cpp
@@ -21,7 +21,7 @@ SoundEditor::SoundEditor(MessageModel* model, QWidget* parent)
   _ui->setupUi(this);
 
   _mapper->mapName(_ui->nameEdit);
-  _mapper->pushResource();
+  _mapper->pushAsset();
 
   _mapper->mapField(Sound::kVolumeFieldNumber, _ui->volumeSpinBox);
 

--- a/Editors/SoundEditor.cpp
+++ b/Editors/SoundEditor.cpp
@@ -20,8 +20,12 @@ SoundEditor::SoundEditor(MessageModel* model, QWidget* parent)
       _userPaused(false) {
   _ui->setupUi(this);
 
-  _nodeMapper->addMapping(_ui->nameEdit, TreeNode::kNameFieldNumber);
-  _resMapper->addMapping(_ui->volumeSpinBox, Sound::kVolumeFieldNumber);
+  _mapper->mapName(_ui->nameEdit);
+  _mapper->pushResource();
+
+  _mapper->mapField(Sound::kVolumeFieldNumber, _ui->volumeSpinBox);
+
+  _mapper->load();
 
   _ui->volumeSlider->setValue(static_cast<int>(_ui->volumeSpinBox->value() * 100));
 

--- a/Editors/SpriteEditor.cpp
+++ b/Editors/SpriteEditor.cpp
@@ -34,14 +34,22 @@ SpriteEditor::SpriteEditor(MessageModel* model, QWidget* parent)
   _ui->mainToolBar->addWidget(showOrigin);
   connect(showOrigin, &QCheckBox::stateChanged, _ui->subimagePreview, &SpriteView::SetShowOrigin);
 
-  _resMapper->addMapping(_ui->originXSpinBox, Sprite::kOriginXFieldNumber);
-  _resMapper->addMapping(_ui->originYSpinBox, Sprite::kOriginYFieldNumber);
-  _resMapper->addMapping(_ui->collisionShapeGroupBox, Sprite::kShapeFieldNumber, "currentIndex");
-  _resMapper->addMapping(_ui->bboxComboBox, Sprite::kBboxModeFieldNumber, "currentIndex");
-  _resMapper->addMapping(_ui->leftSpinBox, Sprite::kBboxLeftFieldNumber);
-  _resMapper->addMapping(_ui->rightSpinBox, Sprite::kBboxRightFieldNumber);
-  _resMapper->addMapping(_ui->topSpinBox, Sprite::kBboxTopFieldNumber);
-  _resMapper->addMapping(_ui->bottomSpinBox, Sprite::kBboxBottomFieldNumber);
+  //TODO: _mapper->mapName(_ui->nameEdit);
+  _mapper->pushResource();
+
+  _mapper->mapField(Sprite::kOriginXFieldNumber, _ui->originXSpinBox);
+  _mapper->mapField(Sprite::kOriginYFieldNumber, _ui->originYSpinBox);
+  _mapper->mapField(Sprite::kShapeFieldNumber, _ui->collisionShapeGroupBox, "currentIndex");
+  _mapper->mapField(Sprite::kBboxModeFieldNumber, _ui->bboxComboBox, "currentIndex");
+  _mapper->mapField(Sprite::kBboxLeftFieldNumber, _ui->leftSpinBox);
+  _mapper->mapField(Sprite::kBboxRightFieldNumber, _ui->rightSpinBox);
+  _mapper->mapField(Sprite::kBboxTopFieldNumber, _ui->topSpinBox);
+  _mapper->mapField(Sprite::kBboxBottomFieldNumber, _ui->bottomSpinBox);
+  //TODO: Finish the master detail mapper API
+  //_mapper->pushField(Sprite::kSubimagesFieldNumber);
+  //_mapper->mapField(0,_ui->subimagePreview);
+
+  _mapper->load();
 
   RebindSubModels();
 }

--- a/Editors/SpriteEditor.cpp
+++ b/Editors/SpriteEditor.cpp
@@ -35,7 +35,7 @@ SpriteEditor::SpriteEditor(MessageModel* model, QWidget* parent)
   connect(showOrigin, &QCheckBox::stateChanged, _ui->subimagePreview, &SpriteView::SetShowOrigin);
 
   //TODO: _mapper->mapName(_ui->nameEdit);
-  _mapper->pushResource();
+  _mapper->pushAsset();
 
   _mapper->mapField(Sprite::kOriginXFieldNumber, _ui->originXSpinBox);
   _mapper->mapField(Sprite::kOriginYFieldNumber, _ui->originYSpinBox);

--- a/Editors/TimelineEditor.cpp
+++ b/Editors/TimelineEditor.cpp
@@ -24,6 +24,7 @@ TimelineEditor::TimelineEditor(MessageModel* model, QWidget* parent)
   _mapper->pushAsset();
 
   _mapper->pushView(Timeline::kMomentsFieldNumber, _ui->momentsList);
+  _mapper->mapView(_ui->momentsList);
   _ui->momentsList->setModelColumn(Timeline::Moment::kStepFieldNumber);
 
   _mapper->load();
@@ -98,9 +99,6 @@ void TimelineEditor::RebindSubModels() {
   for (int moment = 0; moment < _momentsModel->rowCount(); ++moment) {
     BindMomentEditor(moment);
   }
-
-  _ui->momentsList->setModel(_momentsModel);
-  _ui->momentsList->setModelColumn(Timeline::Moment::kStepFieldNumber);
 
   if (_momentsModel->rowCount() == 0) _codeEditor->setDisabled(true);
 

--- a/Editors/TimelineEditor.cpp
+++ b/Editors/TimelineEditor.cpp
@@ -21,7 +21,7 @@ TimelineEditor::TimelineEditor(MessageModel* model, QWidget* parent)
   _ui->setupUi(momentWidget);
 
   _mapper->mapName(_ui->nameEdit);
-  _mapper->pushResource();
+  _mapper->pushAsset();
 
   _mapper->pushView(Timeline::kMomentsFieldNumber, _ui->momentsList);
   _ui->momentsList->setModelColumn(Timeline::Moment::kStepFieldNumber);

--- a/Editors/TimelineEditor.cpp
+++ b/Editors/TimelineEditor.cpp
@@ -23,6 +23,9 @@ TimelineEditor::TimelineEditor(MessageModel* model, QWidget* parent)
   _mapper->mapName(_ui->nameEdit);
   _mapper->pushResource();
 
+  _mapper->pushView(Timeline::kMomentsFieldNumber, _ui->momentsList);
+  _ui->momentsList->setModelColumn(Timeline::Moment::kStepFieldNumber);
+
   _mapper->load();
 
   connect(_ui->saveButton, &QAbstractButton::pressed, this, &BaseEditor::OnSave);

--- a/Editors/TimelineEditor.cpp
+++ b/Editors/TimelineEditor.cpp
@@ -20,7 +20,10 @@ TimelineEditor::TimelineEditor(MessageModel* model, QWidget* parent)
   QWidget* momentWidget = new QWidget(this);
   _ui->setupUi(momentWidget);
 
-  _nodeMapper->addMapping(_ui->nameEdit, TreeNode::kNameFieldNumber);
+  _mapper->mapName(_ui->nameEdit);
+  _mapper->pushResource();
+
+  _mapper->load();
 
   connect(_ui->saveButton, &QAbstractButton::pressed, this, &BaseEditor::OnSave);
 

--- a/Models/EditorMapper.cpp
+++ b/Models/EditorMapper.cpp
@@ -1,0 +1,63 @@
+#include "EditorMapper.h"
+
+#include "Editors/BaseEditor.h"
+#include "Components/Logger.h"
+
+#include "treenode.pb.h"
+
+EditorMapper::EditorMapper(MessageModel *model, BaseEditor *parent) : QObject(parent),
+  _rootModel(model) {
+  _rootMapper = new ModelMapper(model, parent);
+  _rootMapper->toFirst();
+}
+
+void EditorMapper::mapField(int fieldNumber, QWidget *widget, const QByteArray& property) {
+  auto mapper = _mappers.isEmpty() ? _rootMapper : _mappers.top();
+  mapper->addMapping(widget, fieldNumber, property);
+}
+
+void EditorMapper::mapName(QWidget *widget, const QByteArray& property) {
+  mapField(TreeNode::kNameFieldNumber, widget, property);
+}
+
+void EditorMapper::clear() {
+  _rootMapper->clearMapping();
+  foreach(auto group, _groups) {
+    group->clearMapping();
+  }
+}
+
+EditorMapper::MapGroup EditorMapper::pushField(int fieldNumber, int index) {
+  auto mapper = _mappers.isEmpty() ? _rootMapper : _mappers.top();
+  auto model = static_cast<MessageModel*>(mapper->GetModel());
+  auto submapper = new ModelMapper(model->GetSubModel<MessageModel*>(fieldNumber),
+                                   static_cast<BaseEditor*>(QObject::parent()));
+  submapper->setCurrentIndex(index);
+
+  _mappers.push(submapper);
+  _groups.append(submapper);
+
+  return submapper;
+}
+
+void EditorMapper::pushResource() {
+  //popRoot(); // << just in case
+  // ask the source for a message pointer
+  buffers::TreeNode* n = static_cast<buffers::TreeNode*>(_rootModel->GetBuffer());
+  auto type = n->type_case();
+  R_EXPECT_V(type != TreeNode::TYPE_NOT_SET)
+    << "Pushing resource field without a set type!";
+  // oneof enum values are equal to field numbers
+  pushField(type,0);
+}
+
+void EditorMapper::load(MapGroup group) {
+  if (group != nullptr) {
+    group->revert();
+    return;
+  }
+  _rootMapper->revert();
+  foreach(auto group, _groups) {
+    group->revert();
+  }
+}

--- a/Models/EditorMapper.cpp
+++ b/Models/EditorMapper.cpp
@@ -20,6 +20,11 @@ void EditorMapper::mapName(QWidget *widget, const QByteArray& property) {
   mapField(TreeNode::kNameFieldNumber, widget, property);
 }
 
+void EditorMapper::mapView(QAbstractItemView *view) {
+  auto mapper = _mappers.isEmpty() ? _rootMapper : _mappers.top();
+  view->setModel(mapper->GetModel());
+}
+
 EditorMapper::MapGroup EditorMapper::pushField(int fieldNumber, int index) {
   auto mapper = _mappers.isEmpty() ? _rootMapper : _mappers.top();
   auto model = static_cast<MessageModel*>(mapper->GetModel());
@@ -50,8 +55,6 @@ void EditorMapper::pushView(int fieldNumber, QAbstractItemView *view) {
   //TODO: autodetect this from type of submodel?
   //That or we should make all models horizontal with fields always in columns.
   group->setOrientation(Qt::Horizontal);
-  //TODO: mapView?
-  //view->setModel(model);
   connect(view->selectionModel(), &QItemSelectionModel::currentRowChanged,
           group, [group](const QModelIndex &current, const QModelIndex &){
     group->setCurrentIndex(current.row());

--- a/Models/EditorMapper.cpp
+++ b/Models/EditorMapper.cpp
@@ -23,7 +23,8 @@ void EditorMapper::mapName(QWidget *widget, const QByteArray& property) {
 EditorMapper::MapGroup EditorMapper::pushField(int fieldNumber, int index) {
   auto mapper = _mappers.isEmpty() ? _rootMapper : _mappers.top();
   auto model = static_cast<MessageModel*>(mapper->GetModel());
-  auto submapper = new ModelMapper(model->GetSubModel<MessageModel*>(fieldNumber),
+  auto submodel = model->GetSubModel<MessageModel*>(fieldNumber);
+  auto submapper = new ModelMapper(submodel,
                                    static_cast<BaseEditor*>(QObject::parent()));
   submapper->setCurrentIndex(index);
 
@@ -46,8 +47,11 @@ void EditorMapper::pushResource() {
 
 void EditorMapper::pushView(int fieldNumber, QAbstractItemView *view) {
   auto group = pushField(fieldNumber, view->currentIndex().row());
-  auto model = static_cast<MessageModel*>(group->GetModel());
-  view->setModel(model);
+  //TODO: autodetect this from type of submodel?
+  //That or we should make all models horizontal with fields always in columns.
+  group->setOrientation(Qt::Horizontal);
+  //TODO: mapView?
+  //view->setModel(model);
   connect(view->selectionModel(), &QItemSelectionModel::currentRowChanged,
           group, [group](const QModelIndex &current, const QModelIndex &){
     group->setCurrentIndex(current.row());

--- a/Models/EditorMapper.cpp
+++ b/Models/EditorMapper.cpp
@@ -34,7 +34,7 @@ EditorMapper::MapGroup EditorMapper::pushField(int fieldNumber, int index) {
   return submapper;
 }
 
-void EditorMapper::pushResource() {
+void EditorMapper::pushAsset() {
   popRoot(); // << just in case
   // ask the source for a message pointer
   buffers::TreeNode* n = static_cast<buffers::TreeNode*>(_rootModel->GetBuffer());

--- a/Models/EditorMapper.h
+++ b/Models/EditorMapper.h
@@ -1,0 +1,113 @@
+#ifndef EDITORMAPPER_H
+#define EDITORMAPPER_H
+
+#include "ModelMapper.h"
+
+#include <QObject>
+#include <QStack>
+#include <QHash>
+#include <QModelIndex>
+#include <QPersistentModelIndex>
+
+#include <google/protobuf/message.h>
+#include <google/protobuf/descriptor.h>
+
+using namespace google::protobuf;
+
+class MessageModel;
+class BaseEditor;
+
+/**
+ * @brief The EditorMapper class used to map widgets into the model.
+ * This class provides the data binding functionality allowing not
+ * only single indexes into the model to map multiple widgets, but for
+ * widgets to be grouped together by context. In other words, this
+ * class supports 1:M relationships between QObject properties,
+ * including widgets, and model indexes. The organization of the
+ * internal source model and protocol buffer is abstracted behind the
+ * compile-time generated constants and field numbers of resources.
+ */
+// NOTE: There is intentionally no API to remove individual mappings
+// in this class so that your tiny brain doesn't butcher what is
+// otherwise a very elegant execution of basic data structures.
+class EditorMapper : public QObject {
+  Q_OBJECT
+
+  MessageModel* _rootModel; // << the root model
+  ModelMapper* _rootMapper; // << mapper on the root
+  QStack<ModelMapper*> _mappers; // << current mappers in progress
+  QList<ModelMapper*> _groups; // << created mappers
+
+ public:
+  explicit EditorMapper(MessageModel *model, BaseEditor *parent);
+
+  // the fact this is a ModelMapper* is only an implementation detail
+  // that you should not rely on at all
+  using MapGroup = ModelMapper*;
+
+  /**
+   * @brief mapField Maps a proto field in the model to an object property.
+   * @param fieldNumber The compile-time generated field number constant.
+   * @param object The Qt object or widget we want to map.
+   * @param property The property name of the object we want to map. The
+   *                 default, an empty string, will instead look up the
+   *                 USER property on the object, which is the one QWidgets
+   *                 are associated with for editing. For example, the
+   *                 QLineEdit USER property is the "text" property.
+   */
+  void mapField(int fieldNumber, QWidget *widget, const QByteArray& property="");
+  /**
+   * @brief mapName Convenience for mapping the name field of the resource.
+   *
+   * This is an abstraction to keep the base editor and subclasses from relying
+   * on the structure of tree nodes and knowing about all other resource types
+   * which would slow down compilation.
+   *
+   * @param object The object to map the name to
+   * @param property The property name of the object to map. Same as
+   *                 mapField parameter.
+   */
+  void mapName(QWidget *widget, const QByteArray& property="");
+  /**
+   * @brief clear Removes all mappings and moves back to the root of the model.
+   */
+  void clear();
+  /**
+   * @brief pushField Moves current index into a repeated field.
+   *
+   * This can be used to map messages within a repeated field and easily
+   * remap the entire group later on. It's particular useful for master-detail
+   * oriented views like the room editor's background settings which change
+   * when the selected background changes.
+   *
+   * @param fieldNumber The compile-time constant of the repeated field number.
+   * @param index The index of the repeated field value, 0 by default.
+   * @return MapGroup An index which you can later use to remap the fields.
+   */
+  MapGroup pushField(int fieldNumber, int index = 0);
+  /**
+   * @brief pushResource Moves current index into the resource field.
+   *
+   * Like mapName this is also a convenience function that keeps editors
+   * loosely coupled from the structure of the tree node buffer. It's a
+   * consequence of the name being in the tree node but not the resource.
+   * This also resets the current index back to the root to find the
+   * currently set resource of the tree node. That's why there is no
+   * popResource, because you can just call this instead!
+   */
+  void pushResource();
+  /**
+   * @brief popField Moves current index back to the previous parent.
+   */
+  void popField();
+  /**
+   * @brief popRoot Moves back to the root of the model.
+   *
+   * Existing mappings are not cleared but future mappings will be made relative
+   * to the root as they initially were.
+   */
+  void popRoot();
+  void load(MapGroup group = nullptr);
+};
+
+#endif  // EDITORMAPPER_H

--- a/Models/EditorMapper.h
+++ b/Models/EditorMapper.h
@@ -8,6 +8,7 @@
 #include <QHash>
 #include <QModelIndex>
 #include <QPersistentModelIndex>
+#include <QAbstractItemView>
 
 #include <google/protobuf/message.h>
 #include <google/protobuf/descriptor.h>
@@ -96,6 +97,7 @@ class EditorMapper : public QObject {
    * popResource, because you can just call this instead!
    */
   void pushResource();
+  void pushView(int fieldNumber, QAbstractItemView *view);
   /**
    * @brief popField Moves current index back to the previous parent.
    */

--- a/Models/EditorMapper.h
+++ b/Models/EditorMapper.h
@@ -5,28 +5,17 @@
 
 #include <QObject>
 #include <QStack>
-#include <QHash>
-#include <QModelIndex>
-#include <QPersistentModelIndex>
 #include <QAbstractItemView>
-
-#include <google/protobuf/message.h>
-#include <google/protobuf/descriptor.h>
-
-using namespace google::protobuf;
 
 class MessageModel;
 class BaseEditor;
 
 /**
  * @brief The EditorMapper class used to map widgets into the model.
- * This class provides the data binding functionality allowing not
- * only single indexes into the model to map multiple widgets, but for
- * widgets to be grouped together by context. In other words, this
- * class supports 1:M relationships between QObject properties,
- * including widgets, and model indexes. The organization of the
- * internal source model and protocol buffer is abstracted behind the
- * compile-time generated constants and field numbers of resources.
+ * This class encapsulates the hierarchical data binding needed by
+ * the various editors. The organization of the internal source model
+ * and protocol buffer is abstracted behind the compile-time generated
+ * constants and field numbers of resources.
  */
 // NOTE: There is intentionally no API to remove individual mappings
 // in this class so that your tiny brain doesn't butcher what is
@@ -47,9 +36,9 @@ class EditorMapper : public QObject {
   using MapGroup = ModelMapper*;
 
   /**
-   * @brief mapField Maps a proto field in the model to an object property.
+   * @brief mapField Maps a proto field in the model to a widget property.
    * @param fieldNumber The compile-time generated field number constant.
-   * @param object The Qt object or widget we want to map.
+   * @param object The Qt widget we want to map.
    * @param property The property name of the object we want to map. The
    *                 default, an empty string, will instead look up the
    *                 USER property on the object, which is the one QWidgets
@@ -74,20 +63,20 @@ class EditorMapper : public QObject {
    */
   void clear();
   /**
-   * @brief pushField Moves current index into a repeated field.
+   * @brief pushField Moves current index into a field.
    *
-   * This can be used to map messages within a repeated field and easily
-   * remap the entire group later on. It's particular useful for master-detail
+   * This can be used to map messages within a repeated field and easily remap
+   * the entire group later on. It's particularly useful for master-detail
    * oriented views like the room editor's background settings which change
    * when the selected background changes.
    *
-   * @param fieldNumber The compile-time constant of the repeated field number.
+   * @param fieldNumber The compile-time constant of the field number.
    * @param index The index of the repeated field value, 0 by default.
    * @return MapGroup An index which you can later use to remap the fields.
    */
   MapGroup pushField(int fieldNumber, int index = 0);
   /**
-   * @brief pushResource Moves current index into the resource field.
+   * @brief pushAsset Moves current index into the resource field.
    *
    * Like mapName this is also a convenience function that keeps editors
    * loosely coupled from the structure of the tree node buffer. It's a
@@ -97,6 +86,16 @@ class EditorMapper : public QObject {
    * popResource, because you can just call this instead!
    */
   void pushAsset();
+  /**
+   * @brief pushView Moves current index into a field view.
+   *
+   * This can be used to create master-detail mappings in the editors.
+   * The view's selection change will automatically remap all of the
+   * fields that are mapped after this call.
+   *
+   * @param fieldNumber The compile-time constant of the field number.
+   * @param view The Qt view to map to the field.
+   */
   void pushView(int fieldNumber, QAbstractItemView *view);
   /**
    * @brief popField Moves current index back to the previous parent.
@@ -109,6 +108,11 @@ class EditorMapper : public QObject {
    * to the root as they initially were.
    */
   void popRoot();
+  /**
+   * @brief load Reverts all of the widgets in the group to the model values.
+   * @param group A specific group of mapped widgets to load. Can be null,
+   *              meaning load all mapped groups.
+   */
   void load(MapGroup group = nullptr);
 };
 

--- a/Models/EditorMapper.h
+++ b/Models/EditorMapper.h
@@ -59,6 +59,11 @@ class EditorMapper : public QObject {
    */
   void mapName(QWidget *widget, const QByteArray& property="");
   /**
+   * @brief mapView Changes the model of the view to the current mapper's.
+   * @param view The view to map the model of.
+   */
+  void mapView(QAbstractItemView *view);
+  /**
    * @brief clear Removes all mappings and moves back to the root of the model.
    */
   void clear();

--- a/Models/EditorMapper.h
+++ b/Models/EditorMapper.h
@@ -96,7 +96,7 @@ class EditorMapper : public QObject {
    * currently set resource of the tree node. That's why there is no
    * popResource, because you can just call this instead!
    */
-  void pushResource();
+  void pushAsset();
   void pushView(int fieldNumber, QAbstractItemView *view);
   /**
    * @brief popField Moves current index back to the previous parent.

--- a/Models/ModelMapper.cpp
+++ b/Models/ModelMapper.cpp
@@ -21,8 +21,17 @@ void ModelMapper::clearMapping() { _mapper->clearMapping(); }
 
 void ModelMapper::toFirst() { _mapper->toFirst(); }
 
+void ModelMapper::setOrientation(Qt::Orientation aOrientation) {
+  _mapper->setOrientation(aOrientation);
+}
+
 void ModelMapper::setCurrentIndex(int index) {
   _mapper->setCurrentIndex(index);
+}
+
+void ModelMapper::setModel(MessageModel *model) {
+  _mapper->setModel(model);
+  _model = model;
 }
 
 void ModelMapper::revert() {

--- a/Models/ModelMapper.cpp
+++ b/Models/ModelMapper.cpp
@@ -21,6 +21,14 @@ void ModelMapper::clearMapping() { _mapper->clearMapping(); }
 
 void ModelMapper::toFirst() { _mapper->toFirst(); }
 
+void ModelMapper::setCurrentIndex(int index) {
+  _mapper->setCurrentIndex(index);
+}
+
+void ModelMapper::revert() {
+  _mapper->revert();
+}
+
 // model
 
 void ModelMapper::ReplaceBuffer(google::protobuf::Message *buffer) { _model->ReplaceBuffer(buffer); }

--- a/Models/ModelMapper.h
+++ b/Models/ModelMapper.h
@@ -24,7 +24,9 @@ class ModelMapper : public QObject {
   bool IsDirty();
 
  public slots:
+  void setModel(MessageModel *model);
   void toFirst();
+  void setOrientation(Qt::Orientation aOrientation);
   void setCurrentIndex(int index); // toFirst(), toLast(), etc.
   void revert();
 

--- a/Models/ModelMapper.h
+++ b/Models/ModelMapper.h
@@ -15,7 +15,6 @@ class ModelMapper : public QObject {
   // mapper
   void addMapping(QWidget *widget, int section, QByteArray propName = "");
   void clearMapping();
-  void toFirst();
 
   // model
   MessageModel *GetModel();
@@ -23,6 +22,11 @@ class ModelMapper : public QObject {
   bool RestoreBackup();
   void SetDirty(bool dirty);
   bool IsDirty();
+
+ public slots:
+  void toFirst();
+  void setCurrentIndex(int index); // toFirst(), toLast(), etc.
+  void revert();
 
  protected:
   MessageModel *_model;

--- a/RadialGM.pro
+++ b/RadialGM.pro
@@ -71,6 +71,7 @@ SOURCES += \
     Dialogs/TimelineChangeMoment.cpp \
     Editors/ShaderEditor.cpp \
     Editors/SpriteEditor.cpp \
+    Models/EditorMapper.cpp \
     Models/MessageModel.cpp \
     Models/RepeatedImageModel.cpp \
     Models/RepeatedMessageModel.cpp \
@@ -126,6 +127,7 @@ HEADERS += \
     Editors/TimelineEditor.h \
     Editors/RoomEditor.h \
     Editors/SettingsEditor.h \
+    Models/EditorMapper.h \
     Models/MessageModel.h \
     Models/RepeatedImageModel.h \
     Models/RepeatedMessageModel.h \


### PR DESCRIPTION
This pull request introduces a new class which encapsulates the hierarchical data binding of the editors. It abstracts knowledge of how the message models are structured behind an interface that only requires knowledge of the protocol buffer's structure. Things like mapping of [master detail interfaces](https://en.wikipedia.org/wiki/Master%E2%80%93detail_interface), such as the Room View combobox, is automated by the interface (e.g, pushView). What this would allow us to do is change the model structure later on and not have to recode every editor. It would also allow us to flatten the existing models to solve #127 without having to recode all the editors because the mapper would be responsible for mapping the fields number into the flattened field index.

* All editors now have only a single `_mapper` member which is the new mapper class.
* All editors now use the `mapName`/`pushAsset`/`mapField` idioms of the new mapper.
* The timeline editor is an interesting case of master detail in that it's not using `pushView` interface yet. Fundies made code editor a stack of code widgets, which is kind of necessary for them to maintain separate undo stacks. I'm not sure what to do about that as I had never considered hitting undo in a detail widget of a master detail interface. One issue with fundies abstraction though is that CodeWidgetScintilla actually has that as part of its API and the documentation recommends that it be used in scenarios like this because it's more efficient as it will only maintain necessary things like separate undo stacks.
https://www.scintilla.org/ScintillaDoc.html#MultipleViews
* The room views combo box now works using the new `pushView` interface. The view property widgets will now update as you hover over the list items in the combo's popup list model.
* The room will crash on a new room because there's no views allocated to the message. That's something we clearly need to fix. You can only test views combo by opening an existing room/loading a game for now.
* There's kind of a small issue with `pushView` in that it requires the submodel to be of horizontal orientation. We could fix that by making all of our models horizontal, even the flat one for properties, so that fields are always in columns. I think that would actually make more sense anyway.
