### PR TITLE
Delete Confirmation Details

### DIFF
--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -575,12 +575,15 @@ void MainWindow::on_actionDelete_triggered() {
     selectedNames += (node == *selectedNodes.begin() ? "" : ", ") + QString::fromStdString(node->name());
   }
 
-  QMessageBox::StandardButton reply;
-  reply = QMessageBox::question(
-      this, tr("Delete Resources"),
-      tr("Do you want to delete the following resources from the project?\n%0").arg(selectedNames),
-      QMessageBox::Yes | QMessageBox::No);
-  if (reply != QMessageBox::Yes) return;
+  QMessageBox mb(
+    QMessageBox::Icon::Question,
+    tr("Delete Resources"),
+    tr("Do you want to delete the selected resources from the project?"),
+    QMessageBox::Yes | QMessageBox::No, this
+  );
+  mb.setDetailedText(selectedNames);
+  int ret = mb.exec();
+  if (ret != QMessageBox::Yes) return;
 
   // close subwindows
   for (auto node : selectedNodes) {


### PR DESCRIPTION
Just changing up the delete resources confirmation dialog a bit. I hide the list of resources in the details section. Even if we decide not to use the details section we should use [informative text](https://doc.qt.io/qt-5/qmessagebox.html#informativeText-prop) instead of string interpolation since the platform handles that for us.

| Master                                                                                                                          | Pull                                                                                                                             |
|---------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------|
| ![Delete Resources Master](https://user-images.githubusercontent.com/3212801/90578754-17dc2680-e192-11ea-8efc-aa5e01661fc1.png) | ![Delete Resources Details](https://user-images.githubusercontent.com/3212801/90578666-e7948800-e191-11ea-8008-440d72e8e691.png) |
