### PR TITLE
Background Editor Layout Improvements

### DIFF
--- a/Editors/BackgroundEditor.cpp
+++ b/Editors/BackgroundEditor.cpp
@@ -21,6 +21,7 @@ BackgroundEditor::BackgroundEditor(MessageModel* model, QWidget* parent)
 
   connect(_ui->actionSave, &QAction::triggered, this, &BaseEditor::OnSave);
 
+  _nodeMapper->addMapping(_ui->nameEdit, TreeNode::kNameFieldNumber);
   _resMapper->addMapping(_ui->smoothCheckBox, Background::kSmoothEdgesFieldNumber);
   _resMapper->addMapping(_ui->preloadCheckBox, Background::kPreloadFieldNumber);
   _resMapper->addMapping(_ui->tilesetGroupBox, Background::kUseAsTilesetFieldNumber);

--- a/Editors/BackgroundEditor.ui
+++ b/Editors/BackgroundEditor.ui
@@ -125,7 +125,7 @@
        <item>
         <widget class="QGroupBox" name="tilesetGroupBox">
          <property name="sizePolicy">
-          <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
+          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
            <horstretch>0</horstretch>
            <verstretch>0</verstretch>
           </sizepolicy>

--- a/Editors/BackgroundEditor.ui
+++ b/Editors/BackgroundEditor.ui
@@ -352,6 +352,16 @@
          </layout>
         </widget>
        </item>
+       <item>
+        <spacer name="propertiesBottomSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeType">
+          <enum>QSizePolicy::Expanding</enum>
+         </property>
+        </spacer>
+       </item>
       </layout>
      </item>
      <item>

--- a/Editors/BackgroundEditor.ui
+++ b/Editors/BackgroundEditor.ui
@@ -89,12 +89,15 @@
       <number>0</number>
      </property>
      <item>
-      <layout class="QVBoxLayout" name="propertiesLayout">
-       <property name="spacing">
-        <number>4</number>
-       </property>
+      <layout class="QFormLayout" name="propertiesLayout">
        <property name="sizeConstraint">
         <enum>QLayout::SetDefaultConstraint</enum>
+       </property>
+       <property name="horizontalSpacing">
+        <number>4</number>
+       </property>
+       <property name="verticalSpacing">
+        <number>4</number>
        </property>
        <property name="leftMargin">
         <number>4</number>
@@ -108,21 +111,21 @@
        <property name="bottomMargin">
         <number>4</number>
        </property>
-       <item>
+       <item row="0" column="0" colspan="2">
         <widget class="QCheckBox" name="smoothCheckBox">
          <property name="text">
           <string>&amp;Smooth edges</string>
          </property>
         </widget>
        </item>
-       <item>
+       <item row="1" column="0" colspan="2">
         <widget class="QCheckBox" name="preloadCheckBox">
          <property name="text">
           <string>Pre&amp;load texture</string>
          </property>
         </widget>
        </item>
-       <item>
+       <item row="2" column="0" colspan="2">
         <widget class="QGroupBox" name="tilesetGroupBox">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
@@ -351,16 +354,6 @@
           </item>
          </layout>
         </widget>
-       </item>
-       <item>
-        <spacer name="propertiesBottomSpacer">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeType">
-          <enum>QSizePolicy::Expanding</enum>
-         </property>
-        </spacer>
        </item>
       </layout>
      </item>

--- a/Editors/BackgroundEditor.ui
+++ b/Editors/BackgroundEditor.ui
@@ -111,21 +111,21 @@
        <property name="bottomMargin">
         <number>4</number>
        </property>
-       <item row="0" column="0" colspan="2">
+       <item row="1" column="0" colspan="2">
         <widget class="QCheckBox" name="smoothCheckBox">
          <property name="text">
           <string>&amp;Smooth edges</string>
          </property>
         </widget>
        </item>
-       <item row="1" column="0" colspan="2">
+       <item row="2" column="0" colspan="2">
         <widget class="QCheckBox" name="preloadCheckBox">
          <property name="text">
           <string>Pre&amp;load texture</string>
          </property>
         </widget>
        </item>
-       <item row="2" column="0" colspan="2">
+       <item row="3" column="0" colspan="2">
         <widget class="QGroupBox" name="tilesetGroupBox">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
@@ -354,6 +354,19 @@
           </item>
          </layout>
         </widget>
+       </item>
+       <item row="0" column="0">
+        <widget class="QLabel" name="nameLabel">
+         <property name="text">
+          <string>&amp;Name</string>
+         </property>
+         <property name="buddy">
+          <cstring>nameEdit</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="QLineEdit" name="nameEdit"/>
        </item>
       </layout>
      </item>


### PR DESCRIPTION
Bringing some of my layout improvements from #144 over to master as their own changes.

* Changes properties layout from vbox to form so it has two columns where that's needed like the name field.
* Adds the name label and a buddy field.
* Maps the name field to the tree node.
* Changes the tileset groupbox to fixed vertical size policy.

| Master                                                                                                                                             | Pull                                                                                                                                                     |
|----------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------|
| ![Master Background Editor Properties Layout](https://user-images.githubusercontent.com/3212801/90988710-f51b8a80-e562-11ea-8a38-dcb81669a01e.png) | ![Pull Request Background Editor Properties Layout](https://user-images.githubusercontent.com/3212801/90988682-ab32a480-e562-11ea-8460-656c50e5129b.png) |

What's odd is the layout looks different on master in the designer than it does at runtime. At runtime the editor above looks like there is a vertical spacer inside the tileset groupbox pushing them all to the top.
![Master Background Editor Designer Properties Layout](https://user-images.githubusercontent.com/3212801/90988808-bdf9a900-e563-11ea-9720-29fe5e9603af.png)

