### PR TITLE
Sprite Editor Layout Improvements

### DIFF
--- a/Editors/SpriteEditor.cpp
+++ b/Editors/SpriteEditor.cpp
@@ -34,6 +34,7 @@ SpriteEditor::SpriteEditor(MessageModel* model, QWidget* parent)
   _ui->mainToolBar->addWidget(showOrigin);
   connect(showOrigin, &QCheckBox::stateChanged, _ui->subimagePreview, &SpriteView::SetShowOrigin);
 
+  _nodeMapper->addMapping(_ui->nameEdit, TreeNode::kNameFieldNumber);
   _resMapper->addMapping(_ui->originXSpinBox, Sprite::kOriginXFieldNumber);
   _resMapper->addMapping(_ui->originYSpinBox, Sprite::kOriginYFieldNumber);
   _resMapper->addMapping(_ui->collisionShapeGroupBox, Sprite::kShapeFieldNumber, "currentIndex");

--- a/Editors/SpriteEditor.ui
+++ b/Editors/SpriteEditor.ui
@@ -169,9 +169,6 @@
             <property name="text">
              <string>&amp;X</string>
             </property>
-            <property name="alignment">
-             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-            </property>
             <property name="buddy">
              <cstring>originXSpinBox</cstring>
             </property>
@@ -201,9 +198,6 @@
            <widget class="QLabel" name="originYLabel">
             <property name="text">
              <string>&amp;Y</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
             </property>
             <property name="buddy">
              <cstring>originYSpinBox</cstring>
@@ -273,9 +267,6 @@
               <property name="text">
                <string>&amp;Bottom</string>
               </property>
-              <property name="alignment">
-               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-              </property>
               <property name="buddy">
                <cstring>bottomSpinBox</cstring>
               </property>
@@ -286,9 +277,6 @@
               <property name="text">
                <string>&amp;Left</string>
               </property>
-              <property name="alignment">
-               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-              </property>
               <property name="buddy">
                <cstring>leftSpinBox</cstring>
               </property>
@@ -298,9 +286,6 @@
              <widget class="QLabel" name="topLabel">
               <property name="text">
                <string>&amp;Top</string>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
               </property>
               <property name="buddy">
                <cstring>topSpinBox</cstring>
@@ -317,9 +302,6 @@
              <widget class="QLabel" name="rightLabel">
               <property name="text">
                <string>&amp;Right</string>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
               </property>
               <property name="buddy">
                <cstring>rightSpinBox</cstring>

--- a/Editors/SpriteEditor.ui
+++ b/Editors/SpriteEditor.ui
@@ -17,7 +17,7 @@
    <iconset resource="../images.qrc">
     <normaloff>:/resources/sprite.png</normaloff>:/resources/sprite.png</iconset>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_3">
+  <layout class="QVBoxLayout" name="mainLayout">
    <property name="spacing">
     <number>0</number>
    </property>
@@ -100,7 +100,7 @@
          <property name="title">
           <string>Collision Shape</string>
          </property>
-         <layout class="QVBoxLayout" name="verticalLayout_4">
+         <layout class="QVBoxLayout" name="collisionShapeLayout">
           <item>
            <widget class="QComboBox" name="collisionShapeComboBox">
             <item>
@@ -157,7 +157,7 @@
          <property name="title">
           <string>Origin</string>
          </property>
-         <layout class="QGridLayout" name="gridLayout_2" columnstretch="0,1,0,1">
+         <layout class="QGridLayout" name="originLayout" columnstretch="0,1,0,1">
           <item row="0" column="0">
            <widget class="QLabel" name="originXLabel">
             <property name="sizePolicy">
@@ -240,7 +240,7 @@
          <property name="checkable">
           <bool>false</bool>
          </property>
-         <layout class="QVBoxLayout" name="verticalLayout">
+         <layout class="QVBoxLayout" name="bboxLayout">
           <property name="leftMargin">
            <number>9</number>
           </property>

--- a/Editors/SpriteEditor.ui
+++ b/Editors/SpriteEditor.ui
@@ -260,7 +260,7 @@
           <item>
            <layout class="QGridLayout" name="bboxDimensionsLayout">
             <property name="spacing">
-             <number>4</number>
+             <number>0</number>
             </property>
             <item row="4" column="0">
              <widget class="QLabel" name="bottomLabel">

--- a/Editors/SpriteEditor.ui
+++ b/Editors/SpriteEditor.ui
@@ -101,21 +101,6 @@
           <string>Collision Shape</string>
          </property>
          <layout class="QVBoxLayout" name="verticalLayout_4">
-          <property name="spacing">
-           <number>4</number>
-          </property>
-          <property name="leftMargin">
-           <number>6</number>
-          </property>
-          <property name="topMargin">
-           <number>6</number>
-          </property>
-          <property name="rightMargin">
-           <number>6</number>
-          </property>
-          <property name="bottomMargin">
-           <number>6</number>
-          </property>
           <item>
            <widget class="QComboBox" name="collisionShapeComboBox">
             <item>
@@ -173,21 +158,6 @@
           <string>Origin</string>
          </property>
          <layout class="QGridLayout" name="gridLayout_2" columnstretch="0,1,0,1">
-          <property name="leftMargin">
-           <number>6</number>
-          </property>
-          <property name="topMargin">
-           <number>6</number>
-          </property>
-          <property name="rightMargin">
-           <number>6</number>
-          </property>
-          <property name="bottomMargin">
-           <number>6</number>
-          </property>
-          <property name="spacing">
-           <number>4</number>
-          </property>
           <item row="0" column="0">
            <widget class="QLabel" name="originXLabel">
             <property name="sizePolicy">
@@ -272,16 +242,7 @@
          </property>
          <layout class="QVBoxLayout" name="verticalLayout">
           <property name="leftMargin">
-           <number>6</number>
-          </property>
-          <property name="topMargin">
-           <number>6</number>
-          </property>
-          <property name="rightMargin">
-           <number>6</number>
-          </property>
-          <property name="bottomMargin">
-           <number>6</number>
+           <number>9</number>
           </property>
           <item>
            <widget class="QComboBox" name="bboxComboBox">

--- a/Editors/SpriteEditor.ui
+++ b/Editors/SpriteEditor.ui
@@ -70,12 +70,15 @@
       <number>4</number>
      </property>
      <item>
-      <layout class="QVBoxLayout" name="propertiesLayout">
-       <property name="spacing">
-        <number>4</number>
-       </property>
+      <layout class="QFormLayout" name="propertiesLayout">
        <property name="sizeConstraint">
         <enum>QLayout::SetDefaultConstraint</enum>
+       </property>
+       <property name="horizontalSpacing">
+        <number>4</number>
+       </property>
+       <property name="verticalSpacing">
+        <number>4</number>
        </property>
        <property name="leftMargin">
         <number>4</number>
@@ -86,74 +89,33 @@
        <property name="bottomMargin">
         <number>4</number>
        </property>
-       <item>
-        <widget class="QGroupBox" name="originGroupBox">
-         <property name="title">
-          <string>Origin</string>
-         </property>
-         <layout class="QGridLayout" name="gridLayout_2">
-          <item row="0" column="0">
-           <widget class="QLabel" name="originXLabel">
-            <property name="text">
-             <string>&amp;X</string>
-            </property>
-            <property name="buddy">
-             <cstring>originXSpinBox</cstring>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="1">
-           <widget class="QSpinBox" name="originXSpinBox">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="3">
-           <widget class="QSpinBox" name="originYSpinBox">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="2">
-           <widget class="QLabel" name="originYLabel">
-            <property name="text">
-             <string>&amp;Y</string>
-            </property>
-            <property name="buddy">
-             <cstring>originYSpinBox</cstring>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0" colspan="4">
-           <widget class="QPushButton" name="centerOriginButton">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>Center</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item>
+       <item row="2" column="0" colspan="2">
         <widget class="QGroupBox" name="collisionShapeGroupBox">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
          <property name="title">
           <string>Collision Shape</string>
          </property>
          <layout class="QVBoxLayout" name="verticalLayout_4">
+          <property name="spacing">
+           <number>4</number>
+          </property>
+          <property name="leftMargin">
+           <number>6</number>
+          </property>
+          <property name="topMargin">
+           <number>6</number>
+          </property>
+          <property name="rightMargin">
+           <number>6</number>
+          </property>
+          <property name="bottomMargin">
+           <number>6</number>
+          </property>
           <item>
            <widget class="QComboBox" name="collisionShapeComboBox">
             <item>
@@ -186,8 +148,122 @@
          </layout>
         </widget>
        </item>
-       <item>
+       <item row="0" column="0">
+        <widget class="QLabel" name="nameLabel">
+         <property name="text">
+          <string>&amp;Name</string>
+         </property>
+         <property name="buddy">
+          <cstring>nameEdit</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="QLineEdit" name="nameEdit"/>
+       </item>
+       <item row="1" column="0" colspan="2">
+        <widget class="QGroupBox" name="originGroupBox">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="title">
+          <string>Origin</string>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_2" columnstretch="0,1,0,1">
+          <property name="leftMargin">
+           <number>6</number>
+          </property>
+          <property name="topMargin">
+           <number>6</number>
+          </property>
+          <property name="rightMargin">
+           <number>6</number>
+          </property>
+          <property name="bottomMargin">
+           <number>6</number>
+          </property>
+          <property name="spacing">
+           <number>4</number>
+          </property>
+          <item row="0" column="0">
+           <widget class="QLabel" name="originXLabel">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>&amp;X</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+            <property name="buddy">
+             <cstring>originXSpinBox</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QSpinBox" name="originXSpinBox">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="3">
+           <widget class="QSpinBox" name="originYSpinBox">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="2">
+           <widget class="QLabel" name="originYLabel">
+            <property name="text">
+             <string>&amp;Y</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+            <property name="buddy">
+             <cstring>originYSpinBox</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0" colspan="4">
+           <widget class="QPushButton" name="centerOriginButton">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>Center</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item row="3" column="0" colspan="2">
         <widget class="QGroupBox" name="boundingboxGroup">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
          <property name="title">
           <string>Bounding Box</string>
          </property>
@@ -196,7 +272,16 @@
          </property>
          <layout class="QVBoxLayout" name="verticalLayout">
           <property name="leftMargin">
-           <number>9</number>
+           <number>6</number>
+          </property>
+          <property name="topMargin">
+           <number>6</number>
+          </property>
+          <property name="rightMargin">
+           <number>6</number>
+          </property>
+          <property name="bottomMargin">
+           <number>6</number>
           </property>
           <item>
            <widget class="QComboBox" name="bboxComboBox">
@@ -220,65 +305,76 @@
           <item>
            <layout class="QGridLayout" name="bboxDimensionsLayout">
             <property name="spacing">
-             <number>0</number>
+             <number>4</number>
             </property>
-            <item row="3" column="1">
-             <widget class="QSpinBox" name="topSpinBox"/>
-            </item>
             <item row="4" column="0">
              <widget class="QLabel" name="bottomLabel">
               <property name="text">
-               <string>Bottom</string>
+               <string>&amp;Bottom</string>
               </property>
-             </widget>
-            </item>
-            <item row="3" column="0">
-             <widget class="QLabel" name="topLabel">
-              <property name="text">
-               <string>Top</string>
+              <property name="alignment">
+               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+              </property>
+              <property name="buddy">
+               <cstring>bottomSpinBox</cstring>
               </property>
              </widget>
             </item>
             <item row="0" column="0">
              <widget class="QLabel" name="leftLabel">
               <property name="text">
-               <string>Left</string>
+               <string>&amp;Left</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+              </property>
+              <property name="buddy">
+               <cstring>leftSpinBox</cstring>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="0">
+             <widget class="QLabel" name="topLabel">
+              <property name="text">
+               <string>&amp;Top</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+              </property>
+              <property name="buddy">
+               <cstring>topSpinBox</cstring>
               </property>
              </widget>
             </item>
             <item row="0" column="1">
              <widget class="QSpinBox" name="leftSpinBox"/>
             </item>
-            <item row="4" column="1">
-             <widget class="QSpinBox" name="bottomSpinBox"/>
+            <item row="2" column="1">
+             <widget class="QSpinBox" name="topSpinBox"/>
             </item>
-            <item row="2" column="0">
+            <item row="1" column="0">
              <widget class="QLabel" name="rightLabel">
               <property name="text">
-               <string>Right</string>
+               <string>&amp;Right</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+              </property>
+              <property name="buddy">
+               <cstring>rightSpinBox</cstring>
               </property>
              </widget>
             </item>
-            <item row="2" column="1">
+            <item row="1" column="1">
              <widget class="QSpinBox" name="rightSpinBox"/>
+            </item>
+            <item row="4" column="1">
+             <widget class="QSpinBox" name="bottomSpinBox"/>
             </item>
            </layout>
           </item>
          </layout>
         </widget>
-       </item>
-       <item>
-        <spacer name="verticalSpacer">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
        </item>
       </layout>
      </item>


### PR DESCRIPTION
Same as #156 but for the sprite editor.

* Changes properties layout from vbox to form so it has two columns where that's needed like the name field.
* Adds the name label and a buddy field.
* Maps the name field to the tree node.
* Stretches the x/y origin line edits in the parent grid layout.
* Gives the root widget layout a proper "mainLayout" name.
* Gives the origin group layout a proper "originLayout" name.
* Gives the collision shape group layout a proper "collisionShapeLayout" name.
* Gives the BBox group layout a proper "bboxLayout" name.
* Gives all the labels in the BBox dimensions grid the correct buddy.
* Removes the bottom spacer in the properties layout that was used to push everything to the top since form layout does that automatically.

| Master                                                                                                                                             | Pull                                                                                                                                                     |
|----------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------|
| ![Master Sprite Editor Properties Layout](https://user-images.githubusercontent.com/3212801/90990945-619e8580-e573-11ea-9bf5-acc583e7cfd3.png) | ![Pull Request Sprite Editor Properties Layout](https://user-images.githubusercontent.com/3212801/91098594-bef80c80-e62f-11ea-91ba-2a7aa765cc4a.png) |
