### PR TITLE
Tileset Label Alignment

### DIFF
--- a/Editors/BackgroundEditor.ui
+++ b/Editors/BackgroundEditor.ui
@@ -150,7 +150,7 @@
            <enum>QFormLayout::ExpandingFieldsGrow</enum>
           </property>
           <property name="labelAlignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
           </property>
           <property name="horizontalSpacing">
            <number>4</number>


### PR DESCRIPTION
@JoshDreamland in #157 did not want me to right align the sprite bbox labels, so I am proposing to change the background frame's to be left aligned for consistency. I've done some more research and I think I can now articulate why Josh is correct in our specific case.

Yes it's true that the [Gestalt principles of grouping](https://en.wikipedia.org/wiki/Principles_of_grouping#Proximity) are why [right-aligned labels are easier to scan](https://uxmovement.com/forms/form-label-proximity-right-aligned-is-easier-to-scan/) when you are filling out a _sequential_ web form from top to bottom. However, left-aligned labels do work better where the user is scanning for just one field by name which they already know in advance. The latter is what we have in ENIGMA's case, as these fields are not really intended to be entered sequentially, or even changed from the default. The user typically comes into these editors looking to just change one or two of the fields for which they already know the name.

| Master (Right)                                                                                                                         | Pull (Left)                                                                                                                           |
|----------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------|
| ![Tileset Labels Right Alignment](https://user-images.githubusercontent.com/3212801/91100021-65451180-e632-11ea-9aaa-b6f0f2be1922.png) | ![Tileset Labels Left Alignment](https://user-images.githubusercontent.com/3212801/91099947-3b8bea80-e632-11ea-9034-9b53b4c67dd0.png) |