### PR TITLE
Disable Plain Code Widget Word Wrapping

### DIFF
--- a/Widgets/CodeWidgetPlain.cpp
+++ b/Widgets/CodeWidgetPlain.cpp
@@ -15,6 +15,7 @@ CodeWidget::CodeWidget(QWidget* parent) : QWidget(parent), _font(QFont("Courier"
   QPlainTextEdit* plainTextEdit = new QPlainTextEdit(this);
   this->_textWidget = plainTextEdit;
   plainTextEdit->setFont(_font);
+  plainTextEdit->setWordWrapMode(QTextOption::NoWrap);
 
   connect(plainTextEdit, &QPlainTextEdit::textChanged, this, &CodeWidget::codeChanged);
   connect(plainTextEdit, &QPlainTextEdit::blockCountChanged, this, &CodeWidget::lineCountChanged);


### PR DESCRIPTION
I guess fundies doesn't like word wrapping and he's not using the Scintilla code widget, so I decided to turn off word wrapping (the default for QPlainTextEdit) in our plain code widget until #160 is completed and it can be based on the preference. This way at least our Scintilla and Plain code widgets are consistent with each other until such time. Although, due to yet another MSYS2 package issue I am not able to build our QScintilla based code widget now because I am missing the debug library.

For reference, QScintilla does no wrapping by default.
>The default is that lines are not wrapped.
https://www.riverbankcomputing.com/static/Docs/QScintilla/classQsciScintilla.html#ac04428d2f90c36458d68a673f107e40c

QPlainTextEdit does wrap by default.
>By default, this property is set to QTextOption::WrapAtWordBoundaryOrAnywhere.
https://doc.qt.io/qt-5/qplaintextedit.html#wordWrapMode-prop