### PR TITLE
Fix Flag Warnings

### DIFF
--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -433,8 +433,8 @@ void MainWindow::on_actionExploreENIGMA_triggered() { QDesktopServices::openUrl(
 
 void MainWindow::on_actionAbout_triggered() {
   QMessageBox aboutBox(QMessageBox::Information, tr("About"),
-                       tr("ENIGMA is a free, open-source, and cross-platform game engine."), QMessageBox::Ok, this,
-                       nullptr);
+                       tr("ENIGMA is a free, open-source, and cross-platform game engine."),
+                       QMessageBox::Ok, this);
   QAbstractButton *aboutQtButton = aboutBox.addButton(tr("About Qt"), QMessageBox::HelpRole);
   aboutBox.exec();
 

--- a/Models/MessageModel.cpp
+++ b/Models/MessageModel.cpp
@@ -179,7 +179,7 @@ QModelIndex MessageModel::index(int row, int column, const QModelIndex & /*paren
 }
 
 Qt::ItemFlags MessageModel::flags(const QModelIndex &index) const {
-  if (!index.isValid()) return nullptr;
+  if (!index.isValid()) return Qt::NoItemFlags;
   auto flags = QAbstractItemModel::flags(index);
   // Row 0 isn't a valid field in messages. We use it as header data
   if (index.row() > 0) flags |= Qt::ItemIsEditable;

--- a/Models/ProtoModel.cpp
+++ b/Models/ProtoModel.cpp
@@ -34,7 +34,7 @@ bool ProtoModel::IsDirty() { return _dirty; }
 QModelIndex ProtoModel::parent(const QModelIndex & /*index*/) const { return QModelIndex(); }
 
 Qt::ItemFlags ProtoModel::flags(const QModelIndex &index) const {
-  if (!index.isValid()) return nullptr;
+  if (!index.isValid()) return Qt::NoItemFlags;
   auto flags = QAbstractItemModel::flags(index);
   flags |= Qt::ItemIsEditable;
   return flags;


### PR DESCRIPTION
First, the `Qt::ItemFlags` constructor for int was deprecated, so neither `0` nor `nullptr` were correct for invalid model indexes. The correct replacement is `Qt::NoItemFlags` that is assigned `0` in the enum. Second, apparently I made a mistake when I added the simple about dialog using `QMessageBox` in that I was passing `0` for the window flags parameter, then later changed it to `nullptr` because I confused it with the parent parameter. That's not good because it needed the `Qt::Dialog` flag it gets by default, so I just removed that argument from the call.
https://doc.qt.io/qt-5/qmessagebox.html#QMessageBox-1