### PR TITLE
Included File Editor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,7 @@ set(RGM_SOURCES
     Editors/SpriteEditor.cpp
     Editors/BaseEditor.cpp
     Editors/RoomEditor.cpp
+    Editors/IncludeEditor.cpp
     Widgets/AssetView.cpp
     Widgets/CodeWidget.cpp
     Widgets/BackgroundView.cpp
@@ -130,6 +131,7 @@ set(RGM_HEADERS
     Editors/ScriptEditor.h
     Editors/CodeEditor.h
     Editors/ShaderEditor.h
+    Editors/IncludeEditor.h
     Widgets/AssetScrollArea.h
     Widgets/StackedCodeWidget.h
     Widgets/AssetScrollAreaBackground.h
@@ -160,6 +162,7 @@ set(RGM_UI
     Editors/FontEditor.ui
     Editors/TimelineEditor.ui
     Editors/ObjectEditor.ui
+    Editors/IncludeEditor.ui
 )
 
 set(RGM_RC

--- a/Editors/IncludeEditor.cpp
+++ b/Editors/IncludeEditor.cpp
@@ -1,0 +1,14 @@
+#include "IncludeEditor.h"
+#include "ui_IncludeEditor.h"
+
+IncludeEditor::IncludeEditor(QWidget *parent) :
+  QWidget(parent),
+  ui(new Ui::IncludeEditor)
+{
+  ui->setupUi(this);
+}
+
+IncludeEditor::~IncludeEditor()
+{
+  delete ui;
+}

--- a/Editors/IncludeEditor.h
+++ b/Editors/IncludeEditor.h
@@ -1,0 +1,22 @@
+#ifndef INCLUDEEDITOR_H
+#define INCLUDEEDITOR_H
+
+#include <QWidget>
+
+namespace Ui {
+class IncludeEditor;
+}
+
+class IncludeEditor : public QWidget
+{
+  Q_OBJECT
+
+public:
+  explicit IncludeEditor(QWidget *parent = nullptr);
+  ~IncludeEditor();
+
+private:
+  Ui::IncludeEditor *ui;
+};
+
+#endif // INCLUDEEDITOR_H

--- a/Editors/IncludeEditor.ui
+++ b/Editors/IncludeEditor.ui
@@ -1,0 +1,258 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>IncludeEditor</class>
+ <widget class="QWidget" name="IncludeEditor">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>262</width>
+    <height>387</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="windowTitle">
+   <string>Include</string>
+  </property>
+  <layout class="QFormLayout" name="mainLayout">
+   <property name="horizontalSpacing">
+    <number>4</number>
+   </property>
+   <property name="verticalSpacing">
+    <number>4</number>
+   </property>
+   <property name="leftMargin">
+    <number>4</number>
+   </property>
+   <property name="topMargin">
+    <number>4</number>
+   </property>
+   <property name="rightMargin">
+    <number>4</number>
+   </property>
+   <property name="bottomMargin">
+    <number>4</number>
+   </property>
+   <item row="0" column="0">
+    <widget class="QLabel" name="nameLabel">
+     <property name="text">
+      <string>&amp;Name</string>
+     </property>
+     <property name="buddy">
+      <cstring>nameEdit</cstring>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="QLineEdit" name="nameEdit"/>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="sizeLabel">
+     <property name="text">
+      <string>Size</string>
+     </property>
+     <property name="buddy">
+      <cstring>sizeEdit</cstring>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="QLineEdit" name="sizeEdit">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="text">
+      <string>0 bytes</string>
+     </property>
+     <property name="readOnly">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="fileLabel">
+     <property name="text">
+      <string>F&amp;ile Name</string>
+     </property>
+     <property name="buddy">
+      <cstring>fileEdit</cstring>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="QLineEdit" name="fileEdit"/>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="originalFileLabel">
+     <property name="text">
+      <string>Original File</string>
+     </property>
+     <property name="buddy">
+      <cstring>originalFileEdit</cstring>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1">
+    <widget class="QLineEdit" name="originalFileEdit">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="readOnly">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0" colspan="2">
+    <widget class="QCheckBox" name="storeCheckBox">
+     <property name="text">
+      <string>Store in the project editable</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="0" colspan="2">
+    <widget class="QCheckBox" name="removeEndCheckBox">
+     <property name="text">
+      <string>Remove file at end of game</string>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="0" colspan="2">
+    <widget class="QCheckBox" name="freeMemoryCheckBox">
+     <property name="text">
+      <string>Free memory after export</string>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="0" colspan="2">
+    <widget class="QCheckBox" name="overwriteExistingCheckBox">
+     <property name="text">
+      <string>Overwrite existing file</string>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="0" colspan="2">
+    <widget class="QGroupBox" name="exportActionGroupBox">
+     <property name="title">
+      <string>Export Action</string>
+     </property>
+     <layout class="QVBoxLayout" name="exportActionLayout">
+      <property name="spacing">
+       <number>4</number>
+      </property>
+      <property name="leftMargin">
+       <number>4</number>
+      </property>
+      <property name="topMargin">
+       <number>4</number>
+      </property>
+      <property name="rightMargin">
+       <number>4</number>
+      </property>
+      <property name="bottomMargin">
+       <number>4</number>
+      </property>
+      <item>
+       <widget class="QRadioButton" name="dontExportButton">
+        <property name="text">
+         <string>Don't export by default</string>
+        </property>
+        <attribute name="buttonGroup">
+         <string notr="true">buttonGroup</string>
+        </attribute>
+       </widget>
+      </item>
+      <item>
+       <widget class="QRadioButton" name="temporaryDirectoryButton">
+        <property name="text">
+         <string>Temporary directory</string>
+        </property>
+        <attribute name="buttonGroup">
+         <string notr="true">buttonGroup</string>
+        </attribute>
+       </widget>
+      </item>
+      <item>
+       <widget class="QRadioButton" name="sameFolderButton">
+        <property name="text">
+         <string>Same folder as executable</string>
+        </property>
+        <attribute name="buttonGroup">
+         <string notr="true">buttonGroup</string>
+        </attribute>
+       </widget>
+      </item>
+      <item>
+       <widget class="QRadioButton" name="customFolderButton">
+        <property name="text">
+         <string>Custom folder:</string>
+        </property>
+        <attribute name="buttonGroup">
+         <string notr="true">buttonGroup</string>
+        </attribute>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLineEdit" name="customFolderEdit">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="9" column="0" colspan="2">
+    <layout class="QHBoxLayout" name="confirmLayout">
+     <item>
+      <widget class="QPushButton" name="saveButton">
+       <property name="text">
+        <string>&amp;Save</string>
+       </property>
+       <property name="icon">
+        <iconset resource="../images.qrc">
+         <normaloff>:/actions/accept.png</normaloff>:/actions/accept.png</iconset>
+       </property>
+       <property name="default">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="loadDataButton">
+       <property name="text">
+        <string>&amp;Load Data</string>
+       </property>
+       <property name="icon">
+        <iconset resource="../images.qrc">
+         <normaloff>:/actions/open.png</normaloff>:/actions/open.png</iconset>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="saveDataButton">
+       <property name="text">
+        <string>S&amp;ave Data</string>
+       </property>
+       <property name="icon">
+        <iconset resource="../images.qrc">
+         <normaloff>:/actions/save.png</normaloff>:/actions/save.png</iconset>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources>
+  <include location="../images.qrc"/>
+ </resources>
+ <connections/>
+ <buttongroups>
+  <buttongroup name="buttonGroup"/>
+ </buttongroups>
+</ui>

--- a/Editors/IncludeEditor.ui
+++ b/Editors/IncludeEditor.ui
@@ -119,12 +119,18 @@
      <property name="text">
       <string>Remove file at end of game</string>
      </property>
+     <property name="checked">
+      <bool>true</bool>
+     </property>
     </widget>
    </item>
    <item row="6" column="0" colspan="2">
     <widget class="QCheckBox" name="freeMemoryCheckBox">
      <property name="text">
       <string>Free memory after export</string>
+     </property>
+     <property name="checked">
+      <bool>true</bool>
      </property>
     </widget>
    </item>
@@ -171,6 +177,9 @@
         <property name="text">
          <string>Temporary directory</string>
         </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
         <attribute name="buttonGroup">
          <string notr="true">buttonGroup</string>
         </attribute>
@@ -180,6 +189,9 @@
        <widget class="QRadioButton" name="sameFolderButton">
         <property name="text">
          <string>Same folder as executable</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
         </property>
         <attribute name="buttonGroup">
          <string notr="true">buttonGroup</string>

--- a/RadialGM.pro
+++ b/RadialGM.pro
@@ -69,6 +69,7 @@ LIBS += -L$$PWD/Submodules/enigma-dev/CommandLine/libEGM/ \
 
 SOURCES += \
     Dialogs/TimelineChangeMoment.cpp \
+    Editors/IncludeEditor.cpp \
     Editors/ShaderEditor.cpp \
     Editors/SpriteEditor.cpp \
     Models/MessageModel.cpp \
@@ -113,6 +114,7 @@ SOURCES += \
 
 HEADERS += \
     Dialogs/TimelineChangeMoment.h \
+    Editors/IncludeEditor.h \
     Editors/ShaderEditor.h \
     Editors/SpriteEditor.h \
     MainWindow.h \
@@ -163,6 +165,7 @@ HEADERS += \
 
 FORMS += \
     Dialogs/TimelineChangeMoment.ui \
+    Editors/IncludeEditor.ui \
     Editors/TimelineEditor.ui \
     MainWindow.ui \
     Dialogs/PreferencesDialog.ui \


### PR DESCRIPTION
This adds an editor for included files like the one I added to LateralGM which I based off of GameMaker 5's data file editor.

* We still need an include proto, so I haven't added any actual functionality and you can't open the editor yet.
* I decided to continue with the file name being separate, like GM5 and _unlike_ GMS, so we don't have file extensions in the tree.
* I've clearly kept several options that GMSv1.4 deprecated which I am not sure if are still useful.
* I've not included the target options that GMSv1.4 introduced because I don't know how we plan to handle that yet.

| RGM | LGM | GM5 | GMSv1.4 |
|-----|-----|-----|---------|
|![RGM Include Editor](https://user-images.githubusercontent.com/3212801/91336536-0ef5e100-e7a0-11ea-9103-f5a79c02f564.png)|![LGM Include Editor](https://user-images.githubusercontent.com/3212801/91336068-5def4680-e79f-11ea-99f2-7fa0d987ade9.png)|![GM5 Include Editor](https://user-images.githubusercontent.com/3212801/91336138-78c1bb00-e79f-11ea-9abb-34170388d09e.png)|![GMS Include Editor](https://user-images.githubusercontent.com/3212801/91336287-b1fa2b00-e79f-11ea-9d99-f13d8b059d81.png)|