### PR TITLE
Path Editor Points List Row Heights

### DIFF
--- a/Editors/PathEditor.cpp
+++ b/Editors/PathEditor.cpp
@@ -77,6 +77,9 @@ PathEditor::PathEditor(MessageModel* model, QWidget* parent) : BaseEditor(model,
 
   _ui->statusBar->addWidget(_cursorPositionLabel);
 
+  // keep the vertical row heights only as big as necessary
+  _ui->pointsTableView->verticalHeader()->setSectionResizeMode(QHeaderView::ResizeToContents);
+  // evenly divide the width of the list view up for each column
   _ui->pointsTableView->installEventFilter(this);
 
   connect(xSnap, QOverload<int>::of(&QSpinBox::valueChanged), _ui->pathPreviewBackground,


### PR DESCRIPTION
This changes the vertical header resize mode so the rows are only as tall as they need to be to fit the display value. It looks neater and allows more points to be displayed. I could not get the speed column to show because it requires #127 to be solved. There are only 3 columns, and the first one is a junk column which we are hiding. I was not able to right align the cell display values like I wanted either and it requires a similar solution, because we will either need to handle `Qt::TextAlignmentRole` in the model, create a proxy model, or use a custom style delegate on the table.

| Pull                                                                                                                     | Master                                                                                                                     |
|--------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------|
| ![Pull Points List](https://user-images.githubusercontent.com/3212801/91343448-93e5f800-e7aa-11ea-9bcc-68437f20b30f.png) | ![Master Points List](https://user-images.githubusercontent.com/3212801/91343403-7fa1fb00-e7aa-11ea-81bf-bce9c2494821.png) |