### PR TITLE
Sprite Show Actions

### DIFF
--- a/Editors/SpriteEditor.cpp
+++ b/Editors/SpriteEditor.cpp
@@ -20,19 +20,8 @@ SpriteEditor::SpriteEditor(MessageModel* model, QWidget* parent)
   connect(_ui->actionSave, &QAction::triggered, this, &BaseEditor::OnSave);
   _ui->scrollAreaWidget->SetAssetView(_ui->subimagePreview);
 
-  QLabel* bboxLabel = new QLabel(tr("Show BBox "));
-  QCheckBox* showBBox = new QCheckBox(this);
-  showBBox->setChecked(true);
-  _ui->mainToolBar->addWidget(bboxLabel);
-  _ui->mainToolBar->addWidget(showBBox);
-  connect(showBBox, &QCheckBox::stateChanged, _ui->subimagePreview, &SpriteView::SetShowBBox);
-
-  QLabel* originLabel = new QLabel(tr("Show Origin "));
-  QCheckBox* showOrigin = new QCheckBox(this);
-  showOrigin->setChecked(true);
-  _ui->mainToolBar->addWidget(originLabel);
-  _ui->mainToolBar->addWidget(showOrigin);
-  connect(showOrigin, &QCheckBox::stateChanged, _ui->subimagePreview, &SpriteView::SetShowOrigin);
+  connect(_ui->actionShowBBox, &QAction::toggled, _ui->subimagePreview, &SpriteView::SetShowBBox);
+  connect(_ui->actionShowOrigin, &QAction::toggled, _ui->subimagePreview, &SpriteView::SetShowOrigin);
 
   _nodeMapper->addMapping(_ui->nameEdit, TreeNode::kNameFieldNumber);
   _resMapper->addMapping(_ui->originXSpinBox, Sprite::kOriginXFieldNumber);

--- a/Editors/SpriteEditor.ui
+++ b/Editors/SpriteEditor.ui
@@ -55,6 +55,9 @@
      <addaction name="actionLoadSubimages"/>
      <addaction name="actionAddSubimages"/>
      <addaction name="separator"/>
+     <addaction name="actionShowBBox"/>
+     <addaction name="actionShowOrigin"/>
+     <addaction name="separator"/>
      <addaction name="actionZoom"/>
      <addaction name="actionZoomIn"/>
      <addaction name="actionZoomOut"/>
@@ -353,7 +356,7 @@
           <rect>
            <x>0</x>
            <y>0</y>
-           <width>627</width>
+           <width>635</width>
            <height>312</height>
           </rect>
          </property>
@@ -659,6 +662,34 @@
    </property>
    <property name="toolTip">
     <string>Zoom Out</string>
+   </property>
+  </action>
+  <action name="actionShowBBox">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="checked">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Show BBox</string>
+   </property>
+   <property name="toolTip">
+    <string>Show Bounding Box</string>
+   </property>
+  </action>
+  <action name="actionShowOrigin">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="checked">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Show Origin</string>
+   </property>
+   <property name="toolTip">
+    <string>Show Origin</string>
    </property>
   </action>
  </widget>

--- a/Editors/SpriteEditor.ui
+++ b/Editors/SpriteEditor.ui
@@ -61,7 +61,6 @@
      <addaction name="actionZoom"/>
      <addaction name="actionZoomIn"/>
      <addaction name="actionZoomOut"/>
-     <addaction name="separator"/>
     </widget>
    </item>
    <item>

--- a/Editors/SpriteEditor.ui
+++ b/Editors/SpriteEditor.ui
@@ -356,7 +356,7 @@
           <rect>
            <x>0</x>
            <y>0</y>
-           <width>635</width>
+           <width>627</width>
            <height>312</height>
           </rect>
          </property>


### PR DESCRIPTION
I noticed the bbox and origin checkboxes on the sprite editor were backwards. I could have just fixed the label on the checkbox, but I thought I'd go for a more toolbar esque approach and turn them into checkable actions. They take up a bit less space this way too.

Another issue with having a separate label like master did is you can't click the label to toggle the checkbox. You can see this on the background form that clicking the label of a checkbox should toggle it. If you did want the label on the left of the checkbox, there is already a special property to do that.
https://doc.qt.io/qt-5/qwidget.html#layoutDirection-prop

| Pull | Master |
|------|--------|
|![Sprite Show Actions](https://user-images.githubusercontent.com/3212801/91636629-1e5b7100-e9d0-11ea-9d93-cdb010c8ed05.png)|![Sprite Show Checkboxes](https://user-images.githubusercontent.com/3212801/91636573-b86ee980-e9cf-11ea-9b66-2bdf680565fe.png)|