### PR TITLE
Sprite Show Menu

### DIFF
--- a/Editors/SpriteEditor.cpp
+++ b/Editors/SpriteEditor.cpp
@@ -20,19 +20,8 @@ SpriteEditor::SpriteEditor(MessageModel* model, QWidget* parent)
   connect(_ui->actionSave, &QAction::triggered, this, &BaseEditor::OnSave);
   _ui->scrollAreaWidget->SetAssetView(_ui->subimagePreview);
 
-  QLabel* bboxLabel = new QLabel(tr("Show BBox "));
-  QCheckBox* showBBox = new QCheckBox(this);
-  showBBox->setChecked(true);
-  _ui->mainToolBar->addWidget(bboxLabel);
-  _ui->mainToolBar->addWidget(showBBox);
-  connect(showBBox, &QCheckBox::stateChanged, _ui->subimagePreview, &SpriteView::SetShowBBox);
-
-  QLabel* originLabel = new QLabel(tr("Show Origin "));
-  QCheckBox* showOrigin = new QCheckBox(this);
-  showOrigin->setChecked(true);
-  _ui->mainToolBar->addWidget(originLabel);
-  _ui->mainToolBar->addWidget(showOrigin);
-  connect(showOrigin, &QCheckBox::stateChanged, _ui->subimagePreview, &SpriteView::SetShowOrigin);
+  connect(_ui->actionShowBBox, &QAction::toggled, _ui->subimagePreview, &SpriteView::SetShowBBox);
+  connect(_ui->actionShowOrigin, &QAction::toggled, _ui->subimagePreview, &SpriteView::SetShowOrigin);
 
   _nodeMapper->addMapping(_ui->nameEdit, TreeNode::kNameFieldNumber);
   _resMapper->addMapping(_ui->originXSpinBox, Sprite::kOriginXFieldNumber);

--- a/Editors/SpriteEditor.cpp
+++ b/Editors/SpriteEditor.cpp
@@ -13,6 +13,8 @@
 #include <QItemSelection>
 #include <QMessageBox>
 #include <QUuid>
+#include <QToolButton>
+#include <QMenu>
 
 SpriteEditor::SpriteEditor(MessageModel* model, QWidget* parent)
     : BaseEditor(model, parent), _ui(new Ui::SpriteEditor) {
@@ -20,6 +22,16 @@ SpriteEditor::SpriteEditor(MessageModel* model, QWidget* parent)
   connect(_ui->actionSave, &QAction::triggered, this, &BaseEditor::OnSave);
   _ui->scrollAreaWidget->SetAssetView(_ui->subimagePreview);
 
+  auto showButton = reinterpret_cast<QToolButton*>(_ui->mainToolBar->widgetForAction(_ui->actionShow));
+  showButton->setPopupMode(QToolButton::MenuButtonPopup);
+  QMenu *showMenu = new QMenu();
+  showMenu->addAction(_ui->actionShowBBox);
+  showMenu->addAction(_ui->actionShowOrigin);
+  _ui->actionShow->setMenu(showMenu);
+  connect(_ui->actionShow, &QAction::triggered, [=](){
+    _ui->actionShowBBox->setChecked(true);
+    _ui->actionShowOrigin->setChecked(true);
+  });
   connect(_ui->actionShowBBox, &QAction::toggled, _ui->subimagePreview, &SpriteView::SetShowBBox);
   connect(_ui->actionShowOrigin, &QAction::toggled, _ui->subimagePreview, &SpriteView::SetShowOrigin);
 

--- a/Editors/SpriteEditor.ui
+++ b/Editors/SpriteEditor.ui
@@ -55,8 +55,7 @@
      <addaction name="actionLoadSubimages"/>
      <addaction name="actionAddSubimages"/>
      <addaction name="separator"/>
-     <addaction name="actionShowBBox"/>
-     <addaction name="actionShowOrigin"/>
+     <addaction name="actionShow"/>
      <addaction name="separator"/>
      <addaction name="actionZoom"/>
      <addaction name="actionZoomIn"/>
@@ -689,6 +688,14 @@
    </property>
    <property name="toolTip">
     <string>Show Origin</string>
+   </property>
+  </action>
+  <action name="actionShow">
+   <property name="text">
+    <string>Show</string>
+   </property>
+   <property name="iconVisibleInMenu">
+    <bool>true</bool>
    </property>
   </action>
  </widget>

--- a/Editors/SpriteEditor.ui
+++ b/Editors/SpriteEditor.ui
@@ -55,6 +55,9 @@
      <addaction name="actionLoadSubimages"/>
      <addaction name="actionAddSubimages"/>
      <addaction name="separator"/>
+     <addaction name="actionShowBBox"/>
+     <addaction name="actionShowOrigin"/>
+     <addaction name="separator"/>
      <addaction name="actionZoom"/>
      <addaction name="actionZoomIn"/>
      <addaction name="actionZoomOut"/>
@@ -353,7 +356,7 @@
           <rect>
            <x>0</x>
            <y>0</y>
-           <width>627</width>
+           <width>635</width>
            <height>312</height>
           </rect>
          </property>
@@ -659,6 +662,34 @@
    </property>
    <property name="toolTip">
     <string>Zoom Out</string>
+   </property>
+  </action>
+  <action name="actionShowBBox">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="checked">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Show BBox</string>
+   </property>
+   <property name="toolTip">
+    <string>Show Bounding Box</string>
+   </property>
+  </action>
+  <action name="actionShowOrigin">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="checked">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Show Origin</string>
+   </property>
+   <property name="toolTip">
+    <string>Show Origin</string>
    </property>
   </action>
  </widget>

--- a/Editors/SpriteEditor.ui
+++ b/Editors/SpriteEditor.ui
@@ -61,7 +61,6 @@
      <addaction name="actionZoom"/>
      <addaction name="actionZoomIn"/>
      <addaction name="actionZoomOut"/>
-     <addaction name="separator"/>
     </widget>
    </item>
    <item>

--- a/Editors/SpriteEditor.ui
+++ b/Editors/SpriteEditor.ui
@@ -356,7 +356,7 @@
           <rect>
            <x>0</x>
            <y>0</y>
-           <width>635</width>
+           <width>627</width>
            <height>312</height>
           </rect>
          </property>


### PR DESCRIPTION
This is an alternative to #170 that combines both of the show buttons on the sprite form into a menu. It adds a split show button which when clicked toggles all the actions. I think this is less confusing to people because we did have a bug report in LGM one time about the sprite preview animation speed not being saved because people didn't understand it's not an actual property. I like this one because it's consistent with the show menu on the room form. However, since we are adding layer visibility, I don't know if we'll still need a special show menu in the room form. Also, the sprite form is one of our biggest and we need to try to conserve space.

| Pull | Master |
|------|--------|
|![Sprite Show Menu](https://user-images.githubusercontent.com/3212801/91638018-739c8000-e9da-11ea-94a1-d07a5b7c6af5.png)|![Sprite Show Checkboxes](https://user-images.githubusercontent.com/3212801/91636573-b86ee980-e9cf-11ea-9b66-2bdf680565fe.png)|