### PR TITLE
Sprite Show CheckBox Labels

### DIFF
--- a/Editors/SpriteEditor.cpp
+++ b/Editors/SpriteEditor.cpp
@@ -22,10 +22,8 @@ SpriteEditor::SpriteEditor(MessageModel* model, QWidget* parent)
 
   QCheckBox* showBBox = new QCheckBox(tr("Show BBox"),this);
   showBBox->setChecked(true);
-  showBBox->setLayoutDirection(Qt::RightToLeft);
   QCheckBox* showOrigin = new QCheckBox(tr("Show Origin"),this);
   showOrigin->setChecked(true);
-  showOrigin->setLayoutDirection(Qt::RightToLeft);
 
   _ui->mainToolBar->addWidget(showBBox);
   _ui->mainToolBar->addWidget(showOrigin);

--- a/Editors/SpriteEditor.cpp
+++ b/Editors/SpriteEditor.cpp
@@ -20,18 +20,16 @@ SpriteEditor::SpriteEditor(MessageModel* model, QWidget* parent)
   connect(_ui->actionSave, &QAction::triggered, this, &BaseEditor::OnSave);
   _ui->scrollAreaWidget->SetAssetView(_ui->subimagePreview);
 
-  QLabel* bboxLabel = new QLabel(tr("Show BBox "));
-  QCheckBox* showBBox = new QCheckBox(this);
+  QCheckBox* showBBox = new QCheckBox(tr("Show BBox"),this);
   showBBox->setChecked(true);
-  _ui->mainToolBar->addWidget(bboxLabel);
-  _ui->mainToolBar->addWidget(showBBox);
-  connect(showBBox, &QCheckBox::stateChanged, _ui->subimagePreview, &SpriteView::SetShowBBox);
-
-  QLabel* originLabel = new QLabel(tr("Show Origin "));
-  QCheckBox* showOrigin = new QCheckBox(this);
+  showBBox->setLayoutDirection(Qt::RightToLeft);
+  QCheckBox* showOrigin = new QCheckBox(tr("Show Origin"),this);
   showOrigin->setChecked(true);
-  _ui->mainToolBar->addWidget(originLabel);
+  showOrigin->setLayoutDirection(Qt::RightToLeft);
+
+  _ui->mainToolBar->addWidget(showBBox);
   _ui->mainToolBar->addWidget(showOrigin);
+  connect(showBBox, &QCheckBox::stateChanged, _ui->subimagePreview, &SpriteView::SetShowBBox);
   connect(showOrigin, &QCheckBox::stateChanged, _ui->subimagePreview, &SpriteView::SetShowOrigin);
 
   _nodeMapper->addMapping(_ui->nameEdit, TreeNode::kNameFieldNumber);


### PR DESCRIPTION
This fixes the show checkboxes on the sprite form so you can click the label to toggle the checkbox. I removed the second label and added the text directly to the checkbox. Then I used `setLayoutDirection` to put the label to the left of the checkbox like fundies had it. This does not affect the text layout direction according to the documentation so it should not interfere with i18n here.
https://doc.qt.io/qt-5/qwidget.html#layoutDirection-prop