### PR TITLE
Fix Has Repeated Field Assertion

### DIFF
--- a/Models/MessageModel.cpp
+++ b/Models/MessageModel.cpp
@@ -132,7 +132,7 @@ QVariant MessageModel::dataInternal(const QModelIndex &index, int role) const {
   }
 
   // If the field has't been initialized return an invalid QVariant. (see QVariant.isValid())
-  if (NO_DEFAULT && !refl->HasField(*_protobuf, field)) return QVariant();
+  if (NO_DEFAULT && !field->is_repeated() && !refl->HasField(*_protobuf, field)) return QVariant();
 
   switch (field->cpp_type()) {
     case CppType::CPPTYPE_MESSAGE: R_EXPECT(false, QVariant()) << "The requested field " << index << " is a message";


### PR DESCRIPTION
Apparently it's an assertion in protobuf to call `HasField` on a repeated field. This isn't actually reproducible anywhere yet, I just ran onto it in #173 when putting the layers into a list view because they have a repeated field column that I will probably end up hiding. Maybe later we can actually handle repeated fields correctly, but for now it's definitely not correct to check `HasField` since it crashes.