### PR TITLE
Proto Model Header Data Overriding

### DIFF
--- a/Models/ProtoModel.cpp
+++ b/Models/ProtoModel.cpp
@@ -64,11 +64,9 @@ static QVariant getHeaderData(const QHash<int,QHash<Qt::ItemDataRole,QVariant>>&
 
 QVariant ProtoModel::headerData(int section, Qt::Orientation orientation, int role) const {
   if (orientation == Qt::Horizontal) {
-    auto data = getHeaderData(_horizontalHeaderData, section, role);
-    if (data.isValid()) return data;
+    return getHeaderData(_horizontalHeaderData, section, role);
   } else if (orientation == Qt::Vertical) {
-    auto data = getHeaderData(_verticalHeaderData, section, role);
-    if (data.isValid()) return data;
+    return getHeaderData(_verticalHeaderData, section, role);
   }
-  return QAbstractItemModel::headerData(section, orientation, role);
+  return QVariant();
 }

--- a/Models/RepeatedModel.h
+++ b/Models/RepeatedModel.h
@@ -69,8 +69,10 @@ class RepeatedModel : public ProtoModel {
   }
 
   virtual QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override {
+    auto data = ProtoModel::headerData(section, orientation, role);
+    if (data.isValid()) return data;
     if (section == 0 || role != Qt::DisplayRole || orientation != Qt::Orientation::Horizontal)
-      return ProtoModel::headerData(section, orientation, role);
+      return data;
     return QString::fromStdString(_field->message_type()->field(section - 1)->name());
   }
 


### PR DESCRIPTION
Small fix to f2f3ba70d7aa4b18635747dd47f93f109c8623d8 that makes the explicit header data override anything the base models return, such as the field names. This allows me to translate or hide the field names in the column headers. None of the models now return the base implementation which is just the section number converted to a string, because I check if the base ProtoModel class returned valid header data.

Now I can do the following.
![Room Layers Column Header Translation](https://user-images.githubusercontent.com/3212801/91647581-54c5da00-ea2a-11ea-97cc-6ea8d27844c3.png)
