### PR TITLE
Simpler Path Point Row Removal

### DIFF
--- a/Editors/PathEditor.cpp
+++ b/Editors/PathEditor.cpp
@@ -232,10 +232,7 @@ void PathEditor::on_insertPointButton_pressed() {
 
 void PathEditor::on_deletePointButton_pressed() {
   int deleteIndex = _ui->pointsTableView->selectionModel()->currentIndex().row();
-  {
-    RepeatedMessageModel::RowRemovalOperation remover(_pointsModel);
-    remover.RemoveRow(deleteIndex);
-  }
+  _pointsModel->removeRow(deleteIndex);
 
   if (_pointsModel->rowCount() > 0) {
     QModelIndex newSelectIndex =


### PR DESCRIPTION
Why use the row removal operation inline when you don't have to? I can see why the model would use it to implement remove rows but not why it's used outside the model. I can do the same thing the 4 locs are doing in a single loc and it works fine!