### PR TITLE
Extended Selection & Deletion of Path Points

### DIFF
--- a/Editors/PathEditor.cpp
+++ b/Editors/PathEditor.cpp
@@ -240,8 +240,10 @@ void PathEditor::on_deletePointButton_pressed() {
       .RemoveRows(_ui->pointsTableView->selectionModel()->selectedRows());
 
   if (_pointsModel->rowCount() > 0) {
-    QModelIndex newSelectIndex =
-        _pointsModel->index((deleteIndex == 0) ? 0 : deleteIndex - 1, Path::Point::kXFieldNumber);
+    auto rowCount = _ui->pointsTableView->model()->rowCount();
+    QModelIndex newSelectIndex = _pointsModel->index(
+          (deleteIndex >= rowCount) ? rowCount - 1 : deleteIndex,
+          Path::Point::kXFieldNumber);
     _ui->pointsTableView->setCurrentIndex(newSelectIndex);
   } else {
     _ui->deletePointButton->setDisabled(true);

--- a/Editors/PathEditor.cpp
+++ b/Editors/PathEditor.cpp
@@ -194,8 +194,6 @@ void PathEditor::MousePressed(Qt::MouseButton button) {
       QPoint pt = _ui->roomView->Point(i);
       if (pt == _ui->roomView->mousePos) {
         QModelIndex newSelectIndex = _pointsModel->index(i, Path::Point::kXFieldNumber);
-        _ui->pointsTableView->selectionModel()->select(newSelectIndex,
-                                                       QItemSelectionModel::QItemSelectionModel::ClearAndSelect);
         _ui->pointsTableView->setCurrentIndex(newSelectIndex);
         return;
       }
@@ -242,8 +240,6 @@ void PathEditor::on_deletePointButton_pressed() {
   if (_pointsModel->rowCount() > 0) {
     QModelIndex newSelectIndex =
         _pointsModel->index((deleteIndex == 0) ? 0 : deleteIndex - 1, Path::Point::kXFieldNumber);
-    _ui->pointsTableView->selectionModel()->select(newSelectIndex,
-                                                   QItemSelectionModel::QItemSelectionModel::ClearAndSelect);
     _ui->pointsTableView->setCurrentIndex(newSelectIndex);
   } else {
     _ui->deletePointButton->setDisabled(true);

--- a/Editors/PathEditor.cpp
+++ b/Editors/PathEditor.cpp
@@ -236,10 +236,8 @@ void PathEditor::on_insertPointButton_pressed() {
 
 void PathEditor::on_deletePointButton_pressed() {
   int deleteIndex = _ui->pointsTableView->selectionModel()->currentIndex().row();
-  {
-    RepeatedMessageModel::RowRemovalOperation remover(_pointsModel);
-    remover.RemoveRows(_ui->pointsTableView->selectionModel()->selectedRows());
-  }
+  RepeatedMessageModel::RowRemovalOperation(_pointsModel)
+      .RemoveRows(_ui->pointsTableView->selectionModel()->selectedRows());
 
   if (_pointsModel->rowCount() > 0) {
     QModelIndex newSelectIndex =

--- a/Editors/PathEditor.cpp
+++ b/Editors/PathEditor.cpp
@@ -194,9 +194,9 @@ void PathEditor::MousePressed(Qt::MouseButton button) {
       QPoint pt = _ui->roomView->Point(i);
       if (pt == _ui->roomView->mousePos) {
         QModelIndex newSelectIndex = _pointsModel->index(i, Path::Point::kXFieldNumber);
-        _ui->pointsTableView->setCurrentIndex(newSelectIndex);
         _ui->pointsTableView->selectionModel()->select(newSelectIndex,
                                                        QItemSelectionModel::QItemSelectionModel::ClearAndSelect);
+        _ui->pointsTableView->setCurrentIndex(newSelectIndex);
         return;
       }
     }

--- a/Editors/PathEditor.cpp
+++ b/Editors/PathEditor.cpp
@@ -214,10 +214,14 @@ void PathEditor::MouseReleased(Qt::MouseButton button) {
 
 void PathEditor::UpdateSelection(const QItemSelection& selected, const QItemSelection& /*deselected*/) {
   int selectIndex = -1;
+  // if new points were added to the selection, select them in the preview
   if (!selected.indexes().empty()) selectIndex = selected.indexes()[0].row();
   _ui->roomView->selectedPointIndex = selectIndex;
   _ui->pathPreviewBackground->update();
-  _ui->deletePointButton->setDisabled((selectIndex == -1));
+  // delete button should be enabled if the cumulative selection is not empty
+  // and contains at least one selected row with every column selected
+  bool hasSelectedPoint = !_ui->pointsTableView->selectionModel()->selectedRows().empty();
+  _ui->deletePointButton->setEnabled(hasSelectedPoint);
 }
 
 void PathEditor::on_addPointButton_pressed() {

--- a/Editors/PathEditor.cpp
+++ b/Editors/PathEditor.cpp
@@ -234,15 +234,15 @@ void PathEditor::on_deletePointButton_pressed() {
   int deleteIndex = _ui->pointsTableView->selectionModel()->currentIndex().row();
   {
     RepeatedMessageModel::RowRemovalOperation remover(_pointsModel);
-    remover.RemoveRow(deleteIndex);
+    remover.RemoveRows(_ui->pointsTableView->selectionModel()->selectedRows());
   }
 
   if (_pointsModel->rowCount() > 0) {
     QModelIndex newSelectIndex =
         _pointsModel->index((deleteIndex == 0) ? 0 : deleteIndex - 1, Path::Point::kXFieldNumber);
-    _ui->pointsTableView->setCurrentIndex(newSelectIndex);
     _ui->pointsTableView->selectionModel()->select(newSelectIndex,
                                                    QItemSelectionModel::QItemSelectionModel::ClearAndSelect);
+    _ui->pointsTableView->setCurrentIndex(newSelectIndex);
   } else {
     _ui->deletePointButton->setDisabled(true);
     _ui->pointsTableView->selectionModel()->clearSelection();

--- a/Editors/PathEditor.cpp
+++ b/Editors/PathEditor.cpp
@@ -234,6 +234,7 @@ void PathEditor::on_insertPointButton_pressed() {
 
 void PathEditor::on_deletePointButton_pressed() {
   int deleteIndex = _ui->pointsTableView->selectionModel()->currentIndex().row();
+  // this operation is temporary and will self destruct immediately removing the rows
   RepeatedMessageModel::RowRemovalOperation(_pointsModel)
       .RemoveRows(_ui->pointsTableView->selectionModel()->selectedRows());
 

--- a/Editors/PathEditor.cpp
+++ b/Editors/PathEditor.cpp
@@ -210,16 +210,17 @@ void PathEditor::MouseReleased(Qt::MouseButton button) {
   }
 }
 
-void PathEditor::UpdateSelection(const QItemSelection& selected, const QItemSelection& /*deselected*/) {
-  int selectIndex = -1;
-  // if new points were added to the selection, select them in the preview
-  if (!selected.indexes().empty()) selectIndex = selected.indexes()[0].row();
-  _ui->roomView->selectedPointIndex = selectIndex;
-  _ui->pathPreviewBackground->update();
+void PathEditor::UpdateSelection(const QItemSelection& /*selected*/, const QItemSelection& /*deselected*/) {
+  auto selectedPoints = _ui->pointsTableView->selectionModel()->selectedRows();
+  bool hasSelectedPoint = !selectedPoints.empty();
   // delete button should be enabled if the cumulative selection is not empty
   // and contains at least one selected row with every column selected
-  bool hasSelectedPoint = !_ui->pointsTableView->selectionModel()->selectedRows().empty();
   _ui->deletePointButton->setEnabled(hasSelectedPoint);
+  // keep most recently selected point selected in the preview
+  if (hasSelectedPoint)
+    _ui->roomView->selectedPointIndex = selectedPoints.last().row();
+  // update preview on point selection and deselection
+  _ui->pathPreviewBackground->update();
 }
 
 void PathEditor::on_addPointButton_pressed() {

--- a/Editors/PathEditor.ui
+++ b/Editors/PathEditor.ui
@@ -513,10 +513,10 @@
           <item>
            <widget class="QTableView" name="pointsTableView">
             <property name="selectionMode">
-             <enum>QAbstractItemView::SingleSelection</enum>
+             <enum>QAbstractItemView::ExtendedSelection</enum>
             </property>
             <property name="selectionBehavior">
-             <enum>QAbstractItemView::SelectItems</enum>
+             <enum>QAbstractItemView::SelectRows</enum>
             </property>
             <attribute name="horizontalHeaderStretchLastSection">
              <bool>true</bool>

--- a/Models/RepeatedModel.h
+++ b/Models/RepeatedModel.h
@@ -144,6 +144,10 @@ class RepeatedModel : public ProtoModel {
     void RemoveRows(int row, int count) {
       for (int i = row; i < row + count; ++i) _rows.insert(i);
     }
+    void RemoveRows(const QModelIndexList& indexes) {
+      foreach (auto index, indexes)
+        RemoveRow(index.row());
+    }
 
     ~RowRemovalOperation() {
       if (_rows.empty()) return;


### PR DESCRIPTION
* Overload `RowRemovalOperation::RemoveRows` to accept a `QModelIndexList` of all selected rows.
* Set [QAbstractItemView::ExtendedSelection](https://doc.qt.io/qt-5/qabstractitemview.html#SelectionMode-enum) on Path editor points list view so we can select to delete many points at once. This does not change the fact that there is a current index inside the selection which has the focus if an edit is requested.
* Set [QAbstractItemView::SelectRows](https://doc.qt.io/qt-5/qabstractitemview.html#SelectionBehavior-enum) on Path editors points list view so we are actually selecting the entire point, which is similar to GM/LGM and feels less awkward. There is still a current index inside the selected row which has the focus if an edit is requested in a specific column item (aka the field).
* Use the new `RowRemovalOperation` overload to bulk delete all the selected points in the path editor. I used [QItemSelectionModel::selectedRows](https://doc.qt.io/qt-5/qitemselectionmodel.html#selectedRows) so that we only delete points where every column (aka the entire row) is selected. This should always be the case since I've also changed the selection behavior to select rows instead of items.
* Remove selection after setting the current index, which already does a correct selection. As I've stated, the current index resides in the selection and belongs to the selection model.
* Add clarifying comments to the selection update slot about interaction with the above changes.
* The selected indexes passed to selection change slot may be empty and yet there is still a selection and so enabling of the delete button now needs to check the global selection model of the points table to determine if anything is selected. It should also check if there are selected rows and not just selected items.
* The selected point in the preview area is now the last, most recently selected point in the global, cumulative list selection.
* Deleting a point now keeps the same row selected, unless the last point is being deleted. This is how GM and the main Qt examples work with as well. Bounds checking is done against the row count so when the last point is deleted we do go to the previous row.

![Extended Path Point Selection](https://user-images.githubusercontent.com/3212801/91781782-30ecca80-ebc9-11ea-8178-edbcdbe5551e.png)

Understand that I am still not entirely sure the interaction of this with the current index. It seems that it is possible for the current index (which has the focus?) to reside outside of the selection if we deselect the current index. I am not sure how this interacts with [QTreeView::allColumnsShowFocus](https://doc.qt.io/qt-5/qtreeview.html#allColumnsShowFocus-prop) but I suspect it's related. Regardless, other than being weird and not sure of the expected behavior, it doesn't seem to cause any issues.

>In a view, there is always a current item and a selected item - two independent states. An item can be the current item and selected at the same time. The view is responsible for ensuring that there is always a current item as keyboard navigation, for example, requires a current item.
https://doc.qt.io/qt-5/model-view-programming.html#current-item-and-selected-items

![Current Index Outside Selection](https://user-images.githubusercontent.com/3212801/91781847-672a4a00-ebc9-11ea-8fe4-1580286bcec2.png)

