### PR TITLE
Header Data Oopsie

### DIFF
--- a/Models/RepeatedModel.h
+++ b/Models/RepeatedModel.h
@@ -72,7 +72,7 @@ class RepeatedModel : public ProtoModel {
     auto data = ProtoModel::headerData(section, orientation, role);
     if (data.isValid()) return data;
     if (section <= 0 || role != Qt::DisplayRole || orientation != Qt::Orientation::Horizontal)
-      return QModelIndex();
+      return QVariant(); // << invalid
     return QString::fromStdString(_field->message_type()->field(section - 1)->name());
   }
 


### PR DESCRIPTION
I made a mistake in #153 when I decided to change the header data to explicitly return an invalid QModelIndex, rather than the invalid data from the base class. I meant to return an invalid QVariant, which is what our other data implementations and official Qt models do. This caused a regression where none of the headers in any of our views are currently showing.