### PR TITLE
Repeated Submodel Flags

### DIFF
--- a/Models/RepeatedMessageModel.cpp
+++ b/Models/RepeatedMessageModel.cpp
@@ -59,3 +59,10 @@ QVariant RepeatedMessageModel::data(const QModelIndex &index, int role) const {
 
   return _subModels[index.row()]->data(_subModels[index.row()]->index(index.column()), role);
 }
+
+Qt::ItemFlags RepeatedMessageModel::flags(const QModelIndex &index) const {
+  R_EXPECT(index.row() >= 0 && index.row() < _subModels.size(), RepeatedModel::flags(index)) <<
+    "Supplied row was out of bounds:" << index.row();
+
+  return _subModels[index.row()]->flags(_subModels[index.row()]->index(index.column()));
+}

--- a/Models/RepeatedMessageModel.h
+++ b/Models/RepeatedMessageModel.h
@@ -30,6 +30,7 @@ class RepeatedMessageModel : public RepeatedModel<Message> {
   virtual bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::DisplayRole) override;
   virtual QVariant data(const QModelIndex &index, int role) const override;
   virtual int columnCount(const QModelIndex &parent = QModelIndex()) const override;
+  virtual Qt::ItemFlags flags(const QModelIndex &index) const override;
 
   // TODO: implement dropping a message
   //virtual QMimeData *mimeData(const QModelIndexList &indexes) const override;


### PR DESCRIPTION
I figured out why the view editing isn't working, the repeated message model isn't forwarding the flags request to the submodels. This seems to work the way I expect. I can now edit the x/y columns of the path editor points list. I am also able in #173 to edit the layer columns.