### PR TITLE
Asset Preview Event Filtering

### DIFF
--- a/Editors/PathEditor.cpp
+++ b/Editors/PathEditor.cpp
@@ -122,9 +122,6 @@ void PathEditor::RebindSubModels() {
   _roomLineEdit->setText(roomName);
 
   _ui->pathPreviewBackground->installEventFilter(this);
-  //connect(_ui->pathPreviewBackground, &AssetScrollAreaBackground::MouseMoved, this, &PathEditor::MouseMoved);
-  //connect(_ui->pathPreviewBackground, &AssetScrollAreaBackground::MousePressed, this, &PathEditor::MousePressed);
-  //connect(_ui->pathPreviewBackground, &AssetScrollAreaBackground::MouseReleased, this, &PathEditor::MouseReleased);
 
   connect(_ui->pointsTableView->selectionModel(), &QItemSelectionModel::selectionChanged, this,
           &PathEditor::UpdateSelection);

--- a/Editors/PathEditor.cpp
+++ b/Editors/PathEditor.cpp
@@ -143,7 +143,7 @@ bool PathEditor::eventFilter(QObject* obj, QEvent* event) {
     switch (event->type()) {
     case QEvent::MouseMove: {
       QMouseEvent* mouseEvent = static_cast<QMouseEvent*>(event);
-      QPoint roomPos = _ui->pathPreviewBackground->MapToRoom(mouseEvent->pos());
+      QPoint roomPos = _ui->pathPreviewBackground->MapToAsset(mouseEvent->pos());
       MouseMoved(roomPos.x(), roomPos.y());
       break;
     }

--- a/Editors/PathEditor.cpp
+++ b/Editors/PathEditor.cpp
@@ -121,9 +121,10 @@ void PathEditor::RebindSubModels() {
   }
   _roomLineEdit->setText(roomName);
 
-  connect(_ui->pathPreviewBackground, &AssetScrollAreaBackground::MouseMoved, this, &PathEditor::MouseMoved);
-  connect(_ui->pathPreviewBackground, &AssetScrollAreaBackground::MousePressed, this, &PathEditor::MousePressed);
-  connect(_ui->pathPreviewBackground, &AssetScrollAreaBackground::MouseReleased, this, &PathEditor::MouseReleased);
+  _ui->pathPreviewBackground->installEventFilter(this);
+  //connect(_ui->pathPreviewBackground, &AssetScrollAreaBackground::MouseMoved, this, &PathEditor::MouseMoved);
+  //connect(_ui->pathPreviewBackground, &AssetScrollAreaBackground::MousePressed, this, &PathEditor::MousePressed);
+  //connect(_ui->pathPreviewBackground, &AssetScrollAreaBackground::MouseReleased, this, &PathEditor::MouseReleased);
 
   connect(_ui->pointsTableView->selectionModel(), &QItemSelectionModel::selectionChanged, this,
           &PathEditor::UpdateSelection);
@@ -134,14 +135,32 @@ void PathEditor::RebindSubModels() {
 }
 
 bool PathEditor::eventFilter(QObject* obj, QEvent* event) {
-  if (_pointsModel != nullptr) {
-    // Resize columns to view size
-    if (obj == _ui->pointsTableView && event->type() == QEvent::Resize) {
-      QResizeEvent* resizeEvent = static_cast<QResizeEvent*>(event);
-      int cc = _pointsModel->columnCount() - 1;
-      for (int c = 1; c < cc; ++c) {  // column 1 is hidden
-        _ui->pointsTableView->setColumnWidth(c, (resizeEvent->size().width()) / cc);
-      }
+  // Resize columns to view size
+  if (obj == _ui->pointsTableView && event->type() == QEvent::Resize && _pointsModel != nullptr) {
+    QResizeEvent* resizeEvent = static_cast<QResizeEvent*>(event);
+    int cc = _pointsModel->columnCount() - 1;
+    for (int c = 1; c < cc; ++c) {  // column 1 is hidden
+      _ui->pointsTableView->setColumnWidth(c, (resizeEvent->size().width()) / cc);
+    }
+  } else if (obj == _ui->pathPreviewBackground) {
+    switch (event->type()) {
+    case QEvent::MouseMove: {
+      QMouseEvent* mouseEvent = static_cast<QMouseEvent*>(event);
+      QPoint roomPos = _ui->pathPreviewBackground->MapToRoom(mouseEvent->pos());
+      MouseMoved(roomPos.x(), roomPos.y());
+      break;
+    }
+    case QEvent::MouseButtonPress: {
+      QMouseEvent* mouseEvent = static_cast<QMouseEvent*>(event);
+      MousePressed(mouseEvent->button());
+      break;
+    }
+    case QEvent::MouseButtonRelease: {
+      QMouseEvent* mouseEvent = static_cast<QMouseEvent*>(event);
+      MouseReleased(mouseEvent->button());
+      break;
+    }
+    default: break;
     }
   }
   return QWidget::eventFilter(obj, event);

--- a/Editors/RoomEditor.cpp
+++ b/Editors/RoomEditor.cpp
@@ -159,7 +159,7 @@ bool RoomEditor::eventFilter(QObject* obj, QEvent* event) {
       cursorPositionLabel->setText(
             tr("X %0, Y %1")
             .arg(RoundNum(roomPos.x(),g.horSpacing))
-            .arg(RoundNum(roomPos.y(), g.vertSpacing)));
+            .arg(RoundNum(roomPos.y(),g.vertSpacing)));
       break;
     }
     default: break;

--- a/Editors/RoomEditor.cpp
+++ b/Editors/RoomEditor.cpp
@@ -154,7 +154,7 @@ bool RoomEditor::eventFilter(QObject* obj, QEvent* event) {
     switch (event->type()) {
     case QEvent::MouseMove: {
       QMouseEvent* mouseEvent = static_cast<QMouseEvent*>(event);
-      QPoint roomPos = _ui->roomPreviewBackground->MapToRoom(mouseEvent->pos());
+      QPoint roomPos = _ui->roomPreviewBackground->MapToAsset(mouseEvent->pos());
       const GridDimensions g = _ui->roomView->GetGrid();
       cursorPositionLabel->setText(
             tr("X %0, Y %1")

--- a/Editors/RoomEditor.cpp
+++ b/Editors/RoomEditor.cpp
@@ -70,10 +70,10 @@ RoomEditor::RoomEditor(MessageModel* model, QWidget* parent) : BaseEditor(model,
           [=](int index) { _viewMapper->setCurrentIndex(index); });
 
   cursorPositionLabel = new QLabel();
-  connect(_ui->roomPreviewBackground, &AssetScrollAreaBackground::MouseMoved, [=](int x, int y) {
-    const GridDimensions g = _ui->roomView->GetGrid();
-    cursorPositionLabel->setText(tr("X %0, Y %1").arg(RoundNum(x, g.horSpacing)).arg(RoundNum(y, g.vertSpacing)));
-  });
+  //connect(_ui->roomPreviewBackground, &AssetScrollAreaBackground::MouseMoved, [=](int x, int y) {
+   // const GridDimensions g = _ui->roomView->GetGrid();
+   // cursorPositionLabel->setText(tr("X %0, Y %1").arg(RoundNum(x, g.horSpacing)).arg(RoundNum(y, g.vertSpacing)));
+  //});
   _ui->statusBar->addWidget(cursorPositionLabel);
 
   _assetNameLabel = new QLabel("obj_xxx");

--- a/Editors/RoomEditor.cpp
+++ b/Editors/RoomEditor.cpp
@@ -70,10 +70,7 @@ RoomEditor::RoomEditor(MessageModel* model, QWidget* parent) : BaseEditor(model,
           [=](int index) { _viewMapper->setCurrentIndex(index); });
 
   cursorPositionLabel = new QLabel();
-  //connect(_ui->roomPreviewBackground, &AssetScrollAreaBackground::MouseMoved, [=](int x, int y) {
-   // const GridDimensions g = _ui->roomView->GetGrid();
-   // cursorPositionLabel->setText(tr("X %0, Y %1").arg(RoundNum(x, g.horSpacing)).arg(RoundNum(y, g.vertSpacing)));
-  //});
+  _ui->roomPreviewBackground->installEventFilter(this);
   _ui->statusBar->addWidget(cursorPositionLabel);
 
   _assetNameLabel = new QLabel("obj_xxx");
@@ -150,6 +147,25 @@ void RoomEditor::RebindSubModels() {
           });
 
   BaseEditor::RebindSubModels();
+}
+
+bool RoomEditor::eventFilter(QObject* obj, QEvent* event) {
+  if (obj == _ui->roomPreviewBackground) {
+    switch (event->type()) {
+    case QEvent::MouseMove: {
+      QMouseEvent* mouseEvent = static_cast<QMouseEvent*>(event);
+      QPoint roomPos = _ui->roomPreviewBackground->MapToRoom(mouseEvent->pos());
+      const GridDimensions g = _ui->roomView->GetGrid();
+      cursorPositionLabel->setText(
+            tr("X %0, Y %1")
+            .arg(RoundNum(roomPos.x(),g.horSpacing))
+            .arg(RoundNum(roomPos.y(), g.vertSpacing)));
+      break;
+    }
+    default: break;
+    }
+  }
+  return QWidget::eventFilter(obj, event);
 }
 
 void RoomEditor::SelectedObjectChanged(QAction* action) { _ui->currentObject->setText(action->text()); }

--- a/Editors/RoomEditor.h
+++ b/Editors/RoomEditor.h
@@ -19,6 +19,7 @@ class RoomEditor : public BaseEditor {
   explicit RoomEditor(MessageModel* model, QWidget* parent);
   ~RoomEditor() override;
 
+  bool eventFilter(QObject* obj, QEvent* event) override;
   void setZoom(qreal zoom);
 
  public slots:

--- a/Widgets/AssetScrollAreaBackground.cpp
+++ b/Widgets/AssetScrollAreaBackground.cpp
@@ -165,7 +165,7 @@ QPoint AssetScrollAreaBackground::GetCenterOffset() {
       (rect().height() < _assetView->rect().height()) ? 0 : rect().center().y() - _assetView->rect().center().y());
 }
 
-QPoint AssetScrollAreaBackground::MapToRoom(const QPoint &pos) const {
+QPoint AssetScrollAreaBackground::MapToAsset(const QPoint &pos) const {
   return (pos - _totalDrawOffset) / _currentZoom;
 }
 

--- a/Widgets/AssetScrollAreaBackground.cpp
+++ b/Widgets/AssetScrollAreaBackground.cpp
@@ -165,6 +165,10 @@ QPoint AssetScrollAreaBackground::GetCenterOffset() {
       (rect().height() < _assetView->rect().height()) ? 0 : rect().center().y() - _assetView->rect().center().y());
 }
 
+QPoint AssetScrollAreaBackground::MapToRoom(const QPoint &pos) const {
+  return (pos - _totalDrawOffset) / _currentZoom;
+}
+
 void AssetScrollAreaBackground::paintEvent(QPaintEvent* /* event */) {
   QPainter painter(this);
 
@@ -204,23 +208,6 @@ void AssetScrollAreaBackground::paintEvent(QPaintEvent* /* event */) {
 
 bool AssetScrollAreaBackground::eventFilter(QObject* obj, QEvent* event) {
   switch (event->type()) {
-    case QEvent::MouseMove: {
-      QMouseEvent* mouseEvent = static_cast<QMouseEvent*>(event);
-      QPoint roomPos = mouseEvent->pos() - _totalDrawOffset;
-      roomPos /= _currentZoom;
-      emit MouseMoved(roomPos.x(), roomPos.y());
-      break;
-    }
-    case QEvent::MouseButtonPress: {
-      QMouseEvent* mouseEvent = static_cast<QMouseEvent*>(event);
-      emit MousePressed(mouseEvent->button());
-      break;
-    }
-    case QEvent::MouseButtonRelease: {
-      QMouseEvent* mouseEvent = static_cast<QMouseEvent*>(event);
-      emit MouseReleased(mouseEvent->button());
-      break;
-    }
     case QEvent::KeyPress: {
       QKeyEvent* keyEvent = static_cast<QKeyEvent*>(event);
       _pressedKeys += keyEvent->key();

--- a/Widgets/AssetScrollAreaBackground.h
+++ b/Widgets/AssetScrollAreaBackground.h
@@ -32,8 +32,8 @@ class AssetScrollAreaBackground : public QWidget {
   bool GetGridVisible();
   QPoint GetCenterOffset();
   // maps a point on the asset scroll area background (e.g, from mouse event)
-  // into the room with scaling by the zoom and translation
-  QPoint MapToRoom(const QPoint &pos) const;
+  // into the asset with scaling by the zoom and translation
+  QPoint MapToAsset(const QPoint &pos) const;
 
  public slots:
   void SetZoom(qreal _currentZoom);

--- a/Widgets/AssetScrollAreaBackground.h
+++ b/Widgets/AssetScrollAreaBackground.h
@@ -31,6 +31,9 @@ class AssetScrollAreaBackground : public QWidget {
   void SetZoomRange(qreal scalingFactor, qreal min, qreal max);
   bool GetGridVisible();
   QPoint GetCenterOffset();
+  // maps a point on the asset scroll area background (e.g, from mouse event)
+  // into the room with scaling by the zoom and translation
+  QPoint MapToRoom(const QPoint &pos) const;
 
  public slots:
   void SetZoom(qreal _currentZoom);
@@ -40,11 +43,6 @@ class AssetScrollAreaBackground : public QWidget {
   void SetGridVisible(bool visible);
   void SetGridHSnap(int hSnap);
   void SetGridVSnap(int vSnap);
-
- signals:
-  void MouseMoved(int x, int y);
-  void MousePressed(Qt::MouseButton button);
-  void MouseReleased(Qt::MouseButton button);
 
  protected:
   // Standard Grid


### PR DESCRIPTION
While working on #173 to add room layers and instance placing, I noticed the asset scroll area background had custom signals. I realized that if I wanted to add additional handling of other events, I would need to add more signals, which I didn't like. The position wasn't even being provided for the pressed and released signals. It's also true that the signals method would not allow an event to be sunk like [event filters](https://doc.qt.io/qt-5/eventsandfilters.html#event-filters) allow. I decided to change the existing path and room editor stuff to use loosely coupled event filtering to make it easier to handle more events.

* Removes custom mouse signals emitted by the asset scroll area background.
* Installs path editor as an event filter on its asset scroll area background preview instead of connecting to old signals.
* Installs room editor as an event filter on its asset scroll area background preview instead of connecting to old signals.