### PR TITLE
Abstract Map To Asset

### DIFF
--- a/Widgets/AssetScrollAreaBackground.cpp
+++ b/Widgets/AssetScrollAreaBackground.cpp
@@ -165,6 +165,10 @@ QPoint AssetScrollAreaBackground::GetCenterOffset() {
       (rect().height() < _assetView->rect().height()) ? 0 : rect().center().y() - _assetView->rect().center().y());
 }
 
+QPoint AssetScrollAreaBackground::MapToAsset(const QPoint &pos) const {
+  return (pos - _totalDrawOffset) / _currentZoom;
+}
+
 void AssetScrollAreaBackground::paintEvent(QPaintEvent* /* event */) {
   QPainter painter(this);
 
@@ -206,9 +210,8 @@ bool AssetScrollAreaBackground::eventFilter(QObject* obj, QEvent* event) {
   switch (event->type()) {
     case QEvent::MouseMove: {
       QMouseEvent* mouseEvent = static_cast<QMouseEvent*>(event);
-      QPoint roomPos = mouseEvent->pos() - _totalDrawOffset;
-      roomPos /= _currentZoom;
-      emit MouseMoved(roomPos.x(), roomPos.y());
+      QPoint assetPos = MapToAsset(mouseEvent->pos());
+      emit MouseMoved(assetPos.x(), assetPos.y());
       break;
     }
     case QEvent::MouseButtonPress: {

--- a/Widgets/AssetScrollAreaBackground.h
+++ b/Widgets/AssetScrollAreaBackground.h
@@ -31,6 +31,9 @@ class AssetScrollAreaBackground : public QWidget {
   void SetZoomRange(qreal scalingFactor, qreal min, qreal max);
   bool GetGridVisible();
   QPoint GetCenterOffset();
+  // maps a point on the asset scroll area background (e.g, from mouse event)
+  // into the asset with scaling by the zoom and translation
+  QPoint MapToAsset(const QPoint &pos) const;
 
  public slots:
   void SetZoom(qreal _currentZoom);


### PR DESCRIPTION
Simpler part of #184 that only has the mapping point to asset abstraction. There will likely be other places we will need to map a point into the asset area other than mouse events. Maybe later we should just cache a QTransform for the asset scroll area too and do it that way to avoid all of these manual transformation calculations.