### PR TITLE
Fix Bool Field Editing

### DIFF
--- a/Models/MessageModel.cpp
+++ b/Models/MessageModel.cpp
@@ -96,7 +96,7 @@ bool MessageModel::setData(const QModelIndex &index, const QVariant &value, int 
 }
 
 QVariant MessageModel::Data(int row, int column) const {
-  return data(this->index(row, column, QModelIndex()), Qt::DisplayRole);
+  return data(this->index(row, column, QModelIndex()), Qt::EditRole);
 }
 
 template<bool NO_DEFAULT>
@@ -158,7 +158,7 @@ QVariant MessageModel::dataInternal(const QModelIndex &index, int role) const {
     case CppType::CPPTYPE_UINT64: return static_cast<unsigned long long>(refl->GetUInt64(*_protobuf, field));
     case CppType::CPPTYPE_DOUBLE: return refl->GetDouble(*_protobuf, field);
     case CppType::CPPTYPE_FLOAT: return refl->GetFloat(*_protobuf, field);
-    case CppType::CPPTYPE_BOOL: return QVariant();
+    case CppType::CPPTYPE_BOOL: return (role == Qt::EditRole) ? refl->GetBool(*_protobuf, field) : QVariant();
     case CppType::CPPTYPE_ENUM: return refl->GetEnumValue(*_protobuf, field);
     case CppType::CPPTYPE_STRING: return QString::fromStdString(refl->GetString(*_protobuf, field));
   }


### PR DESCRIPTION
Small issue with #182 is that the data widget mapper uses `Qt::EditRole` for bool fields. We have to support the role for those fields in the data method again. Also the preview areas are using our custom `ProtoModel::Data` method which was returning the `Qt::DisplayRole` for fields. I do not believe that was what we intended as the [Qt::DisplayRole](https://doc.qt.io/qt-5/qt.html#ItemDataRole-enum) is supposed to be the stringified data for display. Not only does the `Qt::EditRole` fix the path preview for smooth/closed it seems to be technically more correct since it returns appropriately typed data.

Although `Qt::EditRole` is also documented as technically returning a QString, everything seems to be fine as before. I tested around quite a bit and the path preview is back to normal and everything. Perhaps later if we do anymore specialization and end up hitting a wall, we could consider creating our own custom role for returning the typed data.