### PR TITLE
Path Point Fields Translation

### DIFF
--- a/Editors/PathEditor.cpp
+++ b/Editors/PathEditor.cpp
@@ -104,6 +104,12 @@ void PathEditor::RebindSubModels() {
   _ui->roomView->SetPathModel(_pathModel);
   _pointsModel = _pathModel->GetSubModel<RepeatedMessageModel*>(Path::kPointsFieldNumber);
   _pointsModel->setHeaderData(Path::Point::kXFieldNumber, Qt::Horizontal,
+                              tr("X"), Qt::DisplayRole);
+  _pointsModel->setHeaderData(Path::Point::kYFieldNumber, Qt::Horizontal,
+                              tr("Y"), Qt::DisplayRole);
+  _pointsModel->setHeaderData(Path::Point::kSpeedFieldNumber, Qt::Horizontal,
+                              tr("Speed"), Qt::DisplayRole);
+  _pointsModel->setHeaderData(Path::Point::kXFieldNumber, Qt::Horizontal,
                               QIcon(":/actions/diamond-red.png"), Qt::DecorationRole);
   _pointsModel->setHeaderData(Path::Point::kYFieldNumber, Qt::Horizontal,
                               QIcon(":/actions/diamond-green.png"), Qt::DecorationRole);


### PR DESCRIPTION
This uses the header data override of #175 to translate the path point list column headers.

|Master|Pull|
|----|----|
|![Path Point Columns Master](https://user-images.githubusercontent.com/3212801/92177575-c62cd080-ee0e-11ea-92c2-aeede1e12e8e.png)|![Path Point Columns Pull](https://user-images.githubusercontent.com/3212801/92177519-a7c6d500-ee0e-11ea-9a7a-c53e9d07368c.png)|