### PR TITLE
Font Preview Initialize

### DIFF
--- a/Editors/FontEditor.cpp
+++ b/Editors/FontEditor.cpp
@@ -24,6 +24,8 @@ The quick brown fox jumps over the lazy dog.");
 
   // build the initial font out of the mapped properties
   _font = _ui->fontComboBox->currentFont();
+  // QFontComboBox does not have a default USER property
+  // so we have to use its QComboBox one to actually get font
   _font.setFamily(_ui->fontComboBox->currentText());
   _font.setPointSize(_ui->sizeSpinBox->value());
   _font.setBold(_ui->boldCheckBox->isChecked());

--- a/Editors/FontEditor.cpp
+++ b/Editors/FontEditor.cpp
@@ -7,10 +7,6 @@ FontEditor::FontEditor(MessageModel *model, QWidget *parent) : BaseEditor(model,
   _ui->setupUi(this);
   connect(_ui->saveButton, &QAbstractButton::pressed, this, &BaseEditor::OnSave);
 
-  _font = _ui->fontComboBox->currentFont();
-
-  _ui->fontPreviewText->setFont(_font);
-
   _ui->fontPreviewText->setText(
       "abcdefghijklmnopqrstuvwxyz\n\
 ABCDEFGHIJKLMNOPQRSTUVWXYZ\n\
@@ -25,6 +21,16 @@ The quick brown fox jumps over the lazy dog.");
   _resMapper->addMapping(_ui->italicCheckBox, Font::kItalicFieldNumber);
 
   RebindSubModels();
+
+  // build the initial font out of the mapped properties
+  _font = _ui->fontComboBox->currentFont();
+  _font.setFamily(_ui->fontComboBox->currentText());
+  _font.setPointSize(_ui->sizeSpinBox->value());
+  _font.setBold(_ui->boldCheckBox->isChecked());
+  _font.setItalic(_ui->italicCheckBox->isChecked());
+  // set the initial font on the preview area
+  _ui->fontPreviewText->setFont(_font);
+  _ui->rangePreviewText->setFont(_font);
 }
 
 FontEditor::~FontEditor() { delete _ui; }


### PR DESCRIPTION
We can't set the preview font on the preview text area _before_ we've mapped the property widgets to the model. We have to grab the values out of the model to build a QFont, which is easier to grab from the mapped and loaded widgets. We also need to set the initial font on the range preview too. The previews now have the correct font the first time the editor is opened.