### PR TITLE
Static Header Data

### DIFF
--- a/Editors/PathEditor.cpp
+++ b/Editors/PathEditor.cpp
@@ -10,6 +10,19 @@
 #include <QSpinBox>
 #include <QToolButton>
 
+void initialize_static_path_header_data() {
+  auto descriptor = Path::Point::GetDescriptor();
+  auto x_name = descriptor->FindFieldByNumber(Path::Point::kXFieldNumber)->full_name();
+  auto y_name = descriptor->FindFieldByNumber(Path::Point::kYFieldNumber)->full_name();
+  auto speed_name = descriptor->FindFieldByNumber(Path::Point::kSpeedFieldNumber)->full_name();
+  ProtoModel::SetHeaderData(x_name, Qt::Horizontal, PathEditor::tr("X"), Qt::DisplayRole);
+  ProtoModel::SetHeaderData(y_name, Qt::Horizontal, PathEditor::tr("Y"), Qt::DisplayRole);
+  ProtoModel::SetHeaderData(speed_name, Qt::Horizontal, PathEditor::tr("Speed"), Qt::DisplayRole);
+  ProtoModel::SetHeaderData(x_name, Qt::Horizontal, QIcon(":/actions/diamond-red.png"), Qt::DecorationRole);
+  ProtoModel::SetHeaderData(y_name, Qt::Horizontal, QIcon(":/actions/diamond-green.png"), Qt::DecorationRole);
+  ProtoModel::SetHeaderData(speed_name, Qt::Horizontal, QIcon(":/actions/motion.png"), Qt::DecorationRole);
+}
+
 PathEditor::PathEditor(MessageModel* model, QWidget* parent) : BaseEditor(model, parent), _ui(new Ui::PathEditor) {
   _ui->setupUi(this);
   connect(_ui->saveButton, &QAbstractButton::pressed, this, &BaseEditor::OnSave);
@@ -103,18 +116,6 @@ void PathEditor::RebindSubModels() {
 
   _ui->roomView->SetPathModel(_pathModel);
   _pointsModel = _pathModel->GetSubModel<RepeatedMessageModel*>(Path::kPointsFieldNumber);
-  _pointsModel->setHeaderData(Path::Point::kXFieldNumber, Qt::Horizontal,
-                              tr("X"), Qt::DisplayRole);
-  _pointsModel->setHeaderData(Path::Point::kYFieldNumber, Qt::Horizontal,
-                              tr("Y"), Qt::DisplayRole);
-  _pointsModel->setHeaderData(Path::Point::kSpeedFieldNumber, Qt::Horizontal,
-                              tr("Speed"), Qt::DisplayRole);
-  _pointsModel->setHeaderData(Path::Point::kXFieldNumber, Qt::Horizontal,
-                              QIcon(":/actions/diamond-red.png"), Qt::DecorationRole);
-  _pointsModel->setHeaderData(Path::Point::kYFieldNumber, Qt::Horizontal,
-                              QIcon(":/actions/diamond-green.png"), Qt::DecorationRole);
-  _pointsModel->setHeaderData(Path::Point::kSpeedFieldNumber, Qt::Horizontal,
-                              QIcon(":/actions/motion.png"), Qt::DecorationRole);
   _ui->pointsTableView->setModel(_pointsModel);
   _ui->pointsTableView->hideColumn(0);
 

--- a/Editors/PathEditor.h
+++ b/Editors/PathEditor.h
@@ -9,6 +9,8 @@
 #include <QLabel>
 #include <QLineEdit>
 
+void initialize_static_path_header_data();
+
 namespace Ui {
 class PathEditor;
 }

--- a/Models/ProtoModel.cpp
+++ b/Models/ProtoModel.cpp
@@ -6,6 +6,9 @@
 
 #include "Components/Logger.h"
 
+QHash<QString,QHash<Qt::ItemDataRole,QVariant>> ProtoModel::_horizontalProtoHeaderData;
+QHash<QString,QHash<Qt::ItemDataRole,QVariant>> ProtoModel::_verticalProtoHeaderData;
+
 ProtoModel::ProtoModel(QObject *parent, Message *protobuf) : ProtoModel(static_cast<ProtoModel *>(nullptr), protobuf) {
   QObject::setParent(parent);
 }
@@ -40,6 +43,18 @@ Qt::ItemFlags ProtoModel::flags(const QModelIndex &index) const {
   return flags;
 }
 
+bool ProtoModel::SetHeaderData(std::string full_name, Qt::Orientation orientation, const QVariant &value, int role) {
+  QString qfull_name = QString::fromStdString(full_name);
+  if (orientation == Qt::Horizontal) {
+    _horizontalProtoHeaderData[qfull_name][static_cast<Qt::ItemDataRole>(role)] = value;
+    return true;
+  } else if (orientation == Qt::Vertical) {
+    _verticalProtoHeaderData[qfull_name][static_cast<Qt::ItemDataRole>(role)] = value;
+    return true;
+  }
+  return false;
+}
+
 bool ProtoModel::setHeaderData(int section, Qt::Orientation orientation, const QVariant &value, int role) {
   if (orientation == Qt::Horizontal) {
     _horizontalHeaderData[section][static_cast<Qt::ItemDataRole>(role)] = value;
@@ -53,7 +68,8 @@ bool ProtoModel::setHeaderData(int section, Qt::Orientation orientation, const Q
   return QAbstractItemModel::setHeaderData(section, orientation, value, role);
 }
 
-static QVariant getHeaderData(const QHash<int,QHash<Qt::ItemDataRole,QVariant>>& map, int section, int role) {
+template <typename K>
+static QVariant getHeaderData(const QHash<K,QHash<Qt::ItemDataRole,QVariant>>& map, K section, int role) {
   auto sit = map.find(section);
   if (sit == map.end()) return QVariant();
   auto sectionMap = *sit;
@@ -63,10 +79,26 @@ static QVariant getHeaderData(const QHash<int,QHash<Qt::ItemDataRole,QVariant>>&
 }
 
 QVariant ProtoModel::headerData(int section, Qt::Orientation orientation, int role) const {
+  QVariant datas;
+  qDebug() << "FUCKING SHIT" << section;
   if (orientation == Qt::Horizontal) {
-    return getHeaderData(_horizontalHeaderData, section, role);
+    datas = getHeaderData(_horizontalHeaderData, section, role);
   } else if (orientation == Qt::Vertical) {
-    return getHeaderData(_verticalHeaderData, section, role);
+    datas = getHeaderData(_verticalHeaderData, section, role);
+  }
+  // non static header data overrides any static header data
+  if (datas.isValid()) return datas;
+  // find the fully qualified name of this section's field
+  const Descriptor *desc = this->GetDescriptor();
+  const FieldDescriptor *field = desc->FindFieldByNumber(section);
+  if (!field) return QVariant();
+  QString full_name = QString::fromStdString(field->full_name());
+  qDebug() << full_name << section;
+  // check if there's any static header data for the field at this section
+  if (orientation == Qt::Horizontal) {
+    return getHeaderData(_horizontalProtoHeaderData, full_name, role);
+  } else if (orientation == Qt::Vertical) {
+    return getHeaderData(_verticalProtoHeaderData, full_name, role);
   }
   return QVariant();
 }

--- a/Models/ProtoModel.cpp
+++ b/Models/ProtoModel.cpp
@@ -80,7 +80,7 @@ static QVariant getHeaderData(const QHash<K,QHash<Qt::ItemDataRole,QVariant>>& m
 
 QVariant ProtoModel::headerData(int section, Qt::Orientation orientation, int role) const {
   QVariant datas;
-  qDebug() << "FUCKING SHIT" << section;
+
   if (orientation == Qt::Horizontal) {
     datas = getHeaderData(_horizontalHeaderData, section, role);
   } else if (orientation == Qt::Vertical) {
@@ -88,17 +88,19 @@ QVariant ProtoModel::headerData(int section, Qt::Orientation orientation, int ro
   }
   // non static header data overrides any static header data
   if (datas.isValid()) return datas;
+
   // find the fully qualified name of this section's field
   const Descriptor *desc = this->GetDescriptor();
   const FieldDescriptor *field = desc->FindFieldByNumber(section);
   if (!field) return QVariant();
   QString full_name = QString::fromStdString(field->full_name());
-  qDebug() << full_name << section;
+
   // check if there's any static header data for the field at this section
   if (orientation == Qt::Horizontal) {
     return getHeaderData(_horizontalProtoHeaderData, full_name, role);
   } else if (orientation == Qt::Vertical) {
     return getHeaderData(_verticalProtoHeaderData, full_name, role);
   }
+
   return QVariant();
 }

--- a/Models/ProtoModel.h
+++ b/Models/ProtoModel.h
@@ -91,11 +91,16 @@ class ProtoModel : public QAbstractItemModel {
   virtual int columnCount(const QModelIndex &parent = QModelIndex()) const override = 0;
   virtual bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::DisplayRole) override = 0;
   virtual QVariant data(const QModelIndex &index, int role) const override = 0;
+  static bool SetHeaderData(std::string full_name, Qt::Orientation orientation, const QVariant &value,
+                            int role = Qt::EditRole);
   virtual bool setHeaderData(int section, Qt::Orientation orientation, const QVariant &value,
                              int role = Qt::EditRole) override;
   virtual QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
   virtual QModelIndex index(int row, int column = 0, const QModelIndex &parent = QModelIndex()) const override = 0;
   virtual Qt::ItemFlags flags(const QModelIndex &index) const override;
+  virtual const Descriptor* GetDescriptor() const {
+    return _protobuf->GetDescriptor();
+  }
 
  signals:
   // QAbstractItemModel has a datachanged signal but it doesn't store the old values
@@ -110,6 +115,8 @@ class ProtoModel : public QAbstractItemModel {
   bool _dirty;
   Message *_protobuf;
   ProtoModel *_parentModel;
+  static QHash<QString,QHash<Qt::ItemDataRole,QVariant>> _horizontalProtoHeaderData;
+  static QHash<QString,QHash<Qt::ItemDataRole,QVariant>> _verticalProtoHeaderData;
   QHash<int,QHash<Qt::ItemDataRole,QVariant>> _horizontalHeaderData;
   QHash<int,QHash<Qt::ItemDataRole,QVariant>> _verticalHeaderData;
 };

--- a/Models/RepeatedMessageModel.h
+++ b/Models/RepeatedMessageModel.h
@@ -31,6 +31,9 @@ class RepeatedMessageModel : public RepeatedModel<Message> {
   virtual QVariant data(const QModelIndex &index, int role) const override;
   virtual int columnCount(const QModelIndex &parent = QModelIndex()) const override;
   virtual Qt::ItemFlags flags(const QModelIndex &index) const override;
+  virtual const Descriptor* GetDescriptor() const override {
+    return _field->message_type();
+  }
 
   // TODO: implement dropping a message
   //virtual QMimeData *mimeData(const QModelIndexList &indexes) const override;

--- a/main.cpp
+++ b/main.cpp
@@ -1,6 +1,7 @@
 #include "main.h"
 #include "MainWindow.h"
 
+#include "Editors/PathEditor.h"
 #include "Dialogs/PreferencesKeys.h"
 
 #include <QApplication>
@@ -20,6 +21,8 @@ int main(int argc, char *argv[]) {
   a.setApplicationName("RadialGM");
   a.setWindowIcon(QIcon(":/icon.ico"));
   a.setAttribute(Qt::AA_DisableWindowContextHelpButton);
+
+  initialize_static_path_header_data();
 
   defaultStyle = a.style()->objectName();
 


### PR DESCRIPTION
This adds the static header data I mentioned in #167 and in #189 Josh suggested. It turned out to be more complicated than I thought due to initialization constraints, but it essentially worked out the way me and Josh expected. I am not sure if we actually want to go with it, but it does work. The path editor is still being translated and showing icons in header data.

![Static Path Editor Header Data](https://user-images.githubusercontent.com/3212801/92316067-f3b77c80-efbc-11ea-9478-d688073ea398.png)
