### PR TITLE
Add TreeModel::MakeResourcePath and ResourceMoved.

### DIFF
--- a/Models/TreeModel.cpp
+++ b/Models/TreeModel.cpp
@@ -158,6 +158,18 @@ int TreeModel::rowCount(const QModelIndex &parent) const {
   return parentItem->child_size();
 }
 
+buffers::TreeNode *TreeModel::Parent(buffers::TreeNode *node) const {
+  auto p = parents.find(node);
+  return p == parents.end() ? nullptr : *p;
+}
+
+QString TreeModel::MakeResourcePath(buffers::TreeNode *resource) const {
+  QString res = QString::fromStdString(resource->name());
+  while ((resource = Parent(resource)))
+    res = QString::fromStdString(resource->name()) + "/" + res;
+  return res;
+}
+
 Qt::DropActions TreeModel::supportedDropActions() const { return Qt::MoveAction | Qt::CopyAction; }
 
 QStringList TreeModel::mimeTypes() const { return QStringList(treeNodeMime()); }
@@ -266,6 +278,8 @@ bool TreeModel::dropMimeData(const QMimeData *mimeData, Qt::DropAction action, i
       parents[node] = parentNode;
       endMoveRows();
       ++row;
+
+      emit ResourceMoved(node, oldParent);
     } else {
       if (node->folder()) continue;
       node = duplicateNode(*node);

--- a/Models/TreeModel.h
+++ b/Models/TreeModel.h
@@ -33,6 +33,13 @@ class TreeModel : public QAbstractItemModel {
   int rowCount(const QModelIndex &parent = QModelIndex()) const override;
   int columnCount(const QModelIndex &parent = QModelIndex()) const override;
 
+  // Retrieves the parent of the given node, or else returns nullptr.
+  // This is required because the TreeModel uses raw TreeNode protos as its data
+  // storage format, which cannot point to one another cyclically.
+  buffers::TreeNode *Parent(buffers::TreeNode *node) const;
+  // Builds the relative path of the given resource.
+  QString MakeResourcePath(buffers::TreeNode *resource) const;
+
   Qt::DropActions supportedDropActions() const override;
   QStringList mimeTypes() const override;
   QMimeData *mimeData(const QModelIndexList &indexes) const override;
@@ -46,7 +53,10 @@ class TreeModel : public QAbstractItemModel {
   void sortByName(const QModelIndex &index);
 
  signals:
+  // Called when the name of a single TreeNode changes.
   void ResourceRenamed(TypeCase type, const QString &oldName, const QString &newName);
+  // Called when a resource (or group of resources) is moved.
+  void ResourceMoved(TreeNode *node, TreeNode *old_parent);
 
  private:
   buffers::TreeNode *root;


### PR DESCRIPTION
These should enable moving resources on disk in response to moving that resource in the tree.

We may need to revisit the TreeModel to make it use a custom wrapper of the TreeNode proto. This would save us some headache keeping track of the tree structure, and also where the files live on disk, when they were last saved, etc.