### PR TITLE
Sprite Collision Mask Tweak

### DIFF
--- a/Editors/SpriteEditor.cpp
+++ b/Editors/SpriteEditor.cpp
@@ -33,7 +33,7 @@ SpriteEditor::SpriteEditor(MessageModel* model, QWidget* parent)
   _nodeMapper->addMapping(_ui->nameEdit, TreeNode::kNameFieldNumber);
   _resMapper->addMapping(_ui->originXSpinBox, Sprite::kOriginXFieldNumber);
   _resMapper->addMapping(_ui->originYSpinBox, Sprite::kOriginYFieldNumber);
-  _resMapper->addMapping(_ui->collisionShapeGroupBox, Sprite::kShapeFieldNumber, "currentIndex");
+  _resMapper->addMapping(_ui->shapeComboBox, Sprite::kShapeFieldNumber, "currentIndex");
   _resMapper->addMapping(_ui->bboxComboBox, Sprite::kBboxModeFieldNumber, "currentIndex");
   _resMapper->addMapping(_ui->leftSpinBox, Sprite::kBboxLeftFieldNumber);
   _resMapper->addMapping(_ui->rightSpinBox, Sprite::kBboxRightFieldNumber);

--- a/Editors/SpriteEditor.ui
+++ b/Editors/SpriteEditor.ui
@@ -89,50 +89,6 @@
        <property name="bottomMargin">
         <number>4</number>
        </property>
-       <item row="2" column="0" colspan="2">
-        <widget class="QGroupBox" name="collisionShapeGroupBox">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="title">
-          <string>Collision Shape</string>
-         </property>
-         <layout class="QVBoxLayout" name="collisionShapeLayout">
-          <item>
-           <widget class="QComboBox" name="collisionShapeComboBox">
-            <item>
-             <property name="text">
-              <string>Precise</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Rectangle</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Disk</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Diamond</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Polygon</string>
-             </property>
-            </item>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
        <item row="0" column="0">
         <widget class="QLabel" name="nameLabel">
          <property name="text">
@@ -220,7 +176,7 @@
          </layout>
         </widget>
        </item>
-       <item row="3" column="0" colspan="2">
+       <item row="2" column="0" colspan="2">
         <widget class="QGroupBox" name="boundingboxGroup">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -229,16 +185,23 @@
           </sizepolicy>
          </property>
          <property name="title">
-          <string>Bounding Box</string>
+          <string>Collision Mask</string>
          </property>
          <property name="checkable">
           <bool>false</bool>
          </property>
-         <layout class="QVBoxLayout" name="bboxLayout">
+         <layout class="QFormLayout" name="formLayout">
           <property name="leftMargin">
            <number>9</number>
           </property>
-          <item>
+          <item row="0" column="0">
+           <widget class="QLabel" name="bboxLabel">
+            <property name="text">
+             <string>Mode</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
            <widget class="QComboBox" name="bboxComboBox">
             <item>
              <property name="text">
@@ -257,7 +220,71 @@
             </item>
            </widget>
           </item>
-          <item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="shapeLabel">
+            <property name="text">
+             <string>Type</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QComboBox" name="shapeComboBox">
+            <item>
+             <property name="text">
+              <string>Precise</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Rectangle</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Disk</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Diamond</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Polygon</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+          <item row="2" column="0" colspan="2">
+           <widget class="QLabel" name="alphaLabel">
+            <property name="text">
+             <string>Alpha Tolerance</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0" colspan="2">
+           <layout class="QHBoxLayout" name="alphaControlLayout">
+            <item>
+             <widget class="QSlider" name="alphaSlider">
+              <property name="maximum">
+               <number>255</number>
+              </property>
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QSpinBox" name="alphaSpinBox">
+              <property name="maximum">
+               <number>255</number>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item row="4" column="0" colspan="2">
            <layout class="QGridLayout" name="bboxDimensionsLayout">
             <property name="spacing">
              <number>0</number>


### PR DESCRIPTION
I am iterating on our earlier change of the sprite collision mask radio buttons to combo boxes. It seems [GMS2 has gone the same direction](https://docs2.yoyogames.com/source/_build/2_interface/1_editors/sprites.html) but additionally combined the shape and bbox mode under the same group, which I am proposing here. I fixed a typo with the mapping to the shape combo box which was mapping the group before. I also decided to add the missing alpha tolerance slider while I was in here which will later need added to the automatic bbox computation.

| GMS2 | Pull | Master |
|------|------|--------|
|![GMS2 Collision Mask Properties](https://user-images.githubusercontent.com/3212801/103386041-f63d6500-4aca-11eb-9c6f-bad54d20b169.png)|![Pull Request Collision Mask Properties](https://user-images.githubusercontent.com/3212801/103386069-1705ba80-4acb-11eb-9a4b-98edc50f5441.png)|![Master Collision Mask Properties](https://user-images.githubusercontent.com/3212801/103386097-33a1f280-4acb-11eb-80e3-07f9c2443739.png)|



