### PR TITLE
Add static enigma-dev paths for linux to the paths RGM looks for enigma in

### DIFF
--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -36,7 +36,7 @@
 #undef GetMessage
 
 QList<QString> MainWindow::EnigmaSearchPaths = {QDir::currentPath(), "./enigma-dev", "../enigma-dev",
-                                                "../RadialGM/Submodules/enigma-dev"};
+                                                "../RadialGM/Submodules/enigma-dev", "/opt/enigma-dev/", "/usr/lib/enigma-dev"};
 QFileInfo MainWindow::EnigmaRoot = MainWindow::getEnigmaRoot();
 QList<buffers::SystemType> MainWindow::systemCache;
 MainWindow *MainWindow::_instance = nullptr;


### PR DESCRIPTION
Possibly an unorthodox change, but I usually see packaged applications that install into the system store their libraries in /usr/lib/<thing> and /opt/<thing> so I added those accordingly.